### PR TITLE
New field on SimplePie_Core to control items sorting

### DIFF
--- a/SimplePie/Core.php
+++ b/SimplePie/Core.php
@@ -551,6 +551,13 @@ class SimplePie_Core
 	 */
 	public $autodiscovery = SIMPLEPIE_LOCATOR_ALL;
 
+    /**
+     * Set false to avoid automatic sorting of items by entry update timestamp.
+     * @var bool
+	 * @access private
+     */
+    public $do_sort = true;
+
 	/**
 	 * @var string Class used for caching feeds
 	 * @see SimplePie::set_cache_class()
@@ -2721,7 +2728,7 @@ class SimplePie_Core
 			{
 				if (!isset($this->data['ordered_items']))
 				{
-					$do_sort = true;
+					$do_sort = $this->do_sort;
 					foreach ($this->data['items'] as $item)
 					{
 						if (!$item->get_date('U'))
@@ -2788,7 +2795,7 @@ class SimplePie_Core
 				}
 			}
 
-			$do_sort = true;
+			$do_sort = $this->do_sort;
 			foreach ($items as $item)
 			{
 				if (!$item->get_date('U'))


### PR DESCRIPTION
The Atom spec tells nothing about sorting of entries, so I guess sorting of entries by their update timestamp should not be enforced on the feed.

I made it default to sorting, to avoid breaking backwards compat.
