### PR TITLE
Changed merge_items to be a static method.

### DIFF
--- a/SimplePie/Core.php
+++ b/SimplePie/Core.php
@@ -2788,7 +2788,7 @@ class SimplePie_Core
 	/**
 	 * @static
 	 */
-	public function merge_items($urls, $start = 0, $end = 0, $limit = 0)
+	public static function merge_items($urls, $start = 0, $end = 0, $limit = 0)
 	{
 		if (is_array($urls) && sizeof($urls) > 0)
 		{


### PR DESCRIPTION
Unit tests showed no additional failures after running, merge_items is only ever called as a static method in the codebase and I saw it in the issues list, so I thought I'd change it.
