### PR TITLE
Parsing bug with leading whitespace

### DIFF
--- a/SimplePie/File.php
+++ b/SimplePie/File.php
@@ -274,5 +274,7 @@ class SimplePie_File
 				$this->success = false;
 			}
 		}
+		// leading whitespace will cause SimplePie to error.
+		$this->body = trim($this->body);
 	}
 }


### PR DESCRIPTION
Changed SimplePie to trim whitespace around the XML document.  Leading whitespace was causing SimplePie to error.  This is the feed that caused me to find this bug: http://feeds.feedburner.com/TheArgyleSocialBlog
