### PR TITLE
Parsing bug with leading whitespace

### DIFF
--- a/simplepie.inc
+++ b/simplepie.inc
@@ -7869,6 +7869,8 @@ class SimplePie_File
 				$this->success = false;
 			}
 		}
+		// leading whitespace will cause SimplePie to error.
+		$this->body = trim($this->body);
 	}
 }
 


### PR DESCRIPTION
Changed SimplePie to trim whitespace around the XML document.  Leading whitespace was causing SimplePie to error.  This is the feed that caused me to find this bug: http://feeds.feedburner.com/TheArgyleSocialBlog
