### PR TITLE
Fix Strict errors shown by removing deprecated is_a()

### DIFF
--- a/SimplePie/Cache/File.php
+++ b/SimplePie/Cache/File.php
@@ -63,7 +63,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	{
 		if (file_exists($this->name) && is_writeable($this->name) || file_exists($this->location) && is_writeable($this->location))
 		{
-			if (is_a($data, 'SimplePie'))
+			if ($data instanceof SimplePie)
 			{
 				$data = $data->data;
 			}

--- a/SimplePie/Cache/Memcache.php
+++ b/SimplePie/Cache/Memcache.php
@@ -68,7 +68,7 @@ class SimplePie_Cache_Memcache implements SimplePie_Cache_Base
 
 	public function save($data)
 	{
-		if (is_a($data, 'SimplePie'))
+		if ($data instanceof SimplePie)
 		{
 			$data = $data->data;
 		}

--- a/SimplePie/Cache/MySQL.php
+++ b/SimplePie/Cache/MySQL.php
@@ -117,7 +117,7 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 			return false;
 		}
 
-		if (is_a($data, 'SimplePie'))
+		if ($data instanceof SimplePie)
 		{
 			$data = clone $data;
 

--- a/SimplePie/Core.php
+++ b/SimplePie/Core.php
@@ -841,7 +841,7 @@ class SimplePie_Core
 	 */
 	public function set_file(&$file)
 	{
-		if (is_a($file, 'SimplePie_File'))
+		if ($file instanceof SimplePie_File)
 		{
 			$this->feed_url = $file->url;
 			$this->file =& $file;
@@ -1558,7 +1558,7 @@ class SimplePie_Core
 				// If we don't already have the file (it'll only exist if we've opened it to check if the cache has been modified), open it.
 				if (!isset($file))
 				{
-					if (is_a($this->file, 'SimplePie_File') && $this->file->url === $this->feed_url)
+					if ($this->file instanceof SimplePie_File && $this->file->url === $this->feed_url)
 					{
 						$file =& $this->file;
 					}
@@ -2795,7 +2795,7 @@ class SimplePie_Core
 			$items = array();
 			foreach ($urls as $arg)
 			{
-				if (is_a($arg, 'SimplePie'))
+				if ($arg instanceof SimplePie)
 				{
 					$items = array_merge($items, $arg->get_items(0, $limit));
 				}


### PR DESCRIPTION
Function `is_a()` became deprecated with PHP 5.0.0 resulting in an `E_STRICT`
warning. Function is no longer deprecated with PHP 5.3.0, however, using any
version between 5.0.0 and 5.2.x and `E_DEPRECATED` enabled, `Strict standards`
notice is shown. This fix refactors all `is_a()` occurrences using `instanceof`
operator. For example,

  `if (is_a($this, 'SimplePie'))`

becomes

  `if ($this instanceof SimplePie)`
