### PR TITLE
Simplepie version should be 1.2.1 instead of 1.2.1-dev

### DIFF
--- a/simplepie.inc
+++ b/simplepie.inc
@@ -52,7 +52,7 @@ define('SIMPLEPIE_NAME', 'SimplePie');
 /**
  * SimplePie Version
  */
-define('SIMPLEPIE_VERSION', '1.2.1-dev');
+define('SIMPLEPIE_VERSION', '1.2.1');
 
 /**
  * SimplePie Build


### PR DESCRIPTION
Most of the version numbers have been updated, except this one.
