### PR TITLE
silent Warning cast with PHP 5.3.3 (RHEL-6)

### DIFF
--- a/library/SimplePie/Registry.php
+++ b/library/SimplePie/Registry.php
@@ -113,7 +113,7 @@ class SimplePie_Registry
 	 */
 	public function register($type, $class, $legacy = false)
 	{
-		if (!is_subclass_of($class, $this->default[$type]))
+		if (!@is_subclass_of($class, $this->default[$type]))
 		{
 			return false;
 		}


### PR DESCRIPTION
When running test suite on RHEL-6, with stock PHP 5.3.3, it fails with

     1) CacheTest::testDirectOverrideLegacy
     Failed asserting that exception of type "PHPUnit_Framework_Error_Warning" matches expected exception "Exception_Success".

     2) CacheTest::testDirectOverrideNew
     Failed asserting that exception of type "PHPUnit_Framework_Error_Warning" matches expected exception "Exception_Success".

After analysis, this is due to PHP warning in register method

     PHP Warning: Unknown class passed as parameter in ....SimplePie/Registry.php on line 116

This trivial fix simply silent this warning.