### PR TITLE
Update File.php

### DIFF
--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -282,7 +282,7 @@ class SimplePie_File
 		else
 		{
 			$this->method = SIMPLEPIE_FILE_SOURCE_LOCAL | SIMPLEPIE_FILE_SOURCE_FILE_GET_CONTENTS;
-			if (!$this->body = file_get_contents($url))
+			if (empty($url) || !($this->body = file_get_contents($url)))
 			{
 				$this->error = 'file_get_contents could not read the file';
 				$this->success = false;


### PR DESCRIPTION
There is PHP error "Filename cannot be empty" when someone tries to instantiate SimplePie_File object with bad URI (e.g. URI without schema "www.vg.no/rss/create.php?categories=21,20&keywords=&limit=10")
