### PR TITLE
fixes #146, text column for data in items table isn't appropiate, default column datatype size isn't enough

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -30,7 +30,7 @@ CREATE TABLE `cache_data` (
 CREATE TABLE `items` (
 	`feed_id` TEXT CHARACTER SET utf8 NOT NULL,
 	`id` TEXT CHARACTER SET utf8 NOT NULL,
-	`data` TEXT CHARACTER SET utf8 NOT NULL,
+	`data` MEDIUMBLOB CHARACTER SET utf8 NOT NULL,
 	`posted` INT UNSIGNED NOT NULL,
 	INDEX `feed_id` (
 		`feed_id`(125)

--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -136,7 +136,7 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 
 		if (!in_array($this->options['extras']['prefix'] . 'items', $db))
 		{
-			$query = $this->mysql->exec('CREATE TABLE `' . $this->options['extras']['prefix'] . 'items` (`feed_id` TEXT CHARACTER SET utf8 NOT NULL, `id` TEXT CHARACTER SET utf8 NOT NULL, `data` TEXT CHARACTER SET utf8 NOT NULL, `posted` INT UNSIGNED NOT NULL, INDEX `feed_id` (`feed_id`(125)))');
+			$query = $this->mysql->exec('CREATE TABLE `' . $this->options['extras']['prefix'] . 'items` (`feed_id` TEXT CHARACTER SET utf8 NOT NULL, `id` TEXT CHARACTER SET utf8 NOT NULL, `data` MEDIUMBLOB CHARACTER SET utf8 NOT NULL, `posted` INT UNSIGNED NOT NULL, INDEX `feed_id` (`feed_id`(125)))');
 			if ($query === false)
 			{
 				$this->mysql = null;


### PR DESCRIPTION
I'm reopening issue #146.

> > EricWVGG opened this issue 2 years ago:

On a few cached feeds, I'm getting the following error:

A PHP Error was encountered
Severity: Notice
Message: unserialize() [function.unserialize]: Error at offset 5558 of 65535 bytes
Filename: Cache/MySQL.php
Line Number: 296

I haven't found a pattern to this issue yet. It has happened on these feeds:
http://threeminds.organic.com/atom.xml
http://secretforts.blogspot.com/feeds/posts/default?alt=rss

The problem continues to exist when I wipe the cache tables, and run the feeds twice more.

> > rapid2k1 commented 6 days ago

I have been able to reproduce and fix this two problems.

From serialize command documentation:

"Note that this is a binary string which may include null bytes, and needs to be stored and handled as such. For example, serialize() output should generally be stored in a BLOB field in a database, rather than a CHAR or TEXT field."

Serialize output was stored in a TEXT column.

Also, the limit size of the TEXT column was reached (Message: unserialize() [function.unserialize]: Error at offset 5558 of 65535 bytes). Limit size is 65535 bytes, so serialize output was truncated, and unserialize couldn't recover it, throwing a warning.

I have changed the column type to MEDIUMBLOB, so a 16Mb rss item could be stored. This should be enough for everyone (tm) :)
