### PR TITLE
Fix for Issue #327 - Purges MySql cache contents older than a configu

### DIFF
--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -159,11 +159,16 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 			return false;
 		}
 
-		$count = $this->mysql->query('DELETE i, cd FROM `' . $this->options['extras']['prefix'] . 'sp_cache_data` cd, ' .
+		$query = $this->mysql->prepare('DELETE i, cd FROM `' . $this->options['extras']['prefix'] . 'sp_cache_data` cd, ' .
 			'`' . $this->options['extras']['prefix'] . 'items` i ' .
-			'WHERE cd.id = i.feed_id ' .
-			'AND cd.mtime < (unix_timestamp() - ' . $this->options['extras']['cache_purge_time'] . ')'
-			);
+			'WHERE `cd.id` = `i.feed_id` ' .
+			'AND `cd.mtime` < (unix_timestamp() - :purge_time)');
+		$query->bindValue(':purge_time', $this->options['extras']['cache_purge_time']);
+
+		if (!$query->execute())
+		{
+			return false;
+		}
 
 		if ($data instanceof SimplePie)
 		{

--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -94,6 +94,7 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 			'path' => '',
 			'extras' => array(
 				'prefix' => '',
+				'cache_purge_time' => 2592000
 			),
 		);
 		
@@ -157,6 +158,12 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 		{
 			return false;
 		}
+
+		$count = $this->mysql->query('DELETE i, cd FROM `' . $this->options['extras']['prefix'] . 'sp_cache_data` cd, ' .
+			'`' . $this->options['extras']['prefix'] . 'items` i ' .
+			'WHERE cd.id = i.feed_id ' .
+			'AND cd.mtime < (unix_timestamp() - ' . $this->options['extras']['cache_purge_time'] . ')'
+			);
 
 		if ($data instanceof SimplePie)
 		{


### PR DESCRIPTION

I have added a new option to the MySql cache backend. Configured through set_cache_location():
cache_purge_time=seconds. It defaults to 2592000 (30 days). Everything older (not updated for 30 days) will be deleted before each call to save(), that is, when storing/updating content from the cache.

$feed->set_cache_location('mysql://user:pass@localhost:3306/table?prefix=sp_&cache_purge_time=2592000');

The following sql code will be run before any update.

~~~
DELETE i, cd 
FROM `sp_cache_data` cd, `sp_items` i
WHERE cd.id = i.feed_id AND cd.mtime < (unix_timestamp() - cache_purge_time
~~~
