### PR TITLE
Remove PHP Notices

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -2733,7 +2733,9 @@ class SimplePie_Item
 						{
 							foreach ($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['thumbnail'] as $thumbnail)
 							{
-								$thumbnails[] = $this->sanitize($thumbnail['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+								if (isset($thumbnail['attribs']['']['url'])) {
+									$thumbnails[] = $this->sanitize($thumbnail['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+								}
 							}
 							if (is_array($thumbnails))
 							{

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -2658,7 +2658,9 @@ class SimplePie_Item
 						// PLAYER
 						if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player']))
 						{
-							$player = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+							if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'])) {
+								$player = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+							}
 						}
 						else
 						{

--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -720,7 +720,7 @@ class SimplePie_Parse_Date
 		{
 			$output .= substr($string, $position, $pos - $position);
 			$position = $pos + 1;
-			if ($string[$pos - 1] !== '\\')
+			if ($pos === 0 || $string[$pos - 1] !== '\\')
 			{
 				$depth++;
 				while ($depth && $position < $length)


### PR DESCRIPTION
Example:

    $feed = new SimplePie();
    $feed->set_feed_url('http://feeds.feedburner.com/surfline-rss-surf-news');
    $feed->init();
    foreach ($feed->get_items() as $item) {
        $item->get_gmdate();
    }

Result:

    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723
    PHP Notice:  Uninitialized string offset: -1 in /simplepie/library/SimplePie/Parse/Date.php on line 723

This is due to invalid pub data in RSS.
Format is `(MM/dd)`.

Another example:

    $feed = new SimplePie();
    $feed->set_feed_url('http://www.express.pk/feed/');
    $feed->init();
    foreach ($feed->get_items() as $item) {
        $item->get_enclosures();
    }

Result:

    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736
    PHP Notice:  Undefined index: url in /simplepie/library/SimplePie/Item.php on line 2736

Another example:

    $feed = new SimplePie();
    $feed->set_feed_url('http://data.msnbc.msn.com/feeds/franchise/foodmain?output=mrss');
    $feed->init();
    foreach ($feed->get_items() as $item) {
        $item->get_enclosures();
    }

Result:

    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
    PHP Notice:  Undefined index: in /simplepie/library/SimplePie/Item.php on line 2661
