### PR TITLE
Force order by date

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -846,7 +846,7 @@ class SimplePie
 	 */
 	public function enable_order_by_date($enable = true)
 	{
-		$this->order_by_date = (bool) $enable;
+		$this->order_by_date = $enable;
 	}
 
 	/**
@@ -2906,7 +2906,7 @@ class SimplePie
 		if (!empty($this->data['items']))
 		{
 			// If we want to order it by date, check if all items have a date, and then sort it
-			if ($this->order_by_date && empty($this->multifeed_objects) || $this->order_by_date === 'force')
+			if (($this->order_by_date && empty($this->multifeed_objects)) || $this->order_by_date === 'force')
 			{
 				if (!isset($this->data['ordered_items']))
 				{

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -518,7 +518,8 @@ class SimplePie
 	public $cache_name_function = 'md5';
 
 	/**
-	 * @var bool Reorder feed by date descending
+     * @var mixed Reorder feed by date descending, if 'force' then
+     * do not abort sort if we find items without a date
 	 * @see SimplePie::enable_order_by_date()
 	 * @access private
 	 */
@@ -840,7 +841,8 @@ class SimplePie
 	/**
 	 * Set whether feed items should be sorted into reverse chronological order
 	 *
-	 * @param bool $enable Sort as reverse chronological order.
+	 * @param mixed $enable Sort as reverse chronological order.
+     * if 'force' then do not abort sort if we find items without dates
 	 */
 	public function enable_order_by_date($enable = true)
 	{
@@ -2904,22 +2906,21 @@ class SimplePie
 		if (!empty($this->data['items']))
 		{
 			// If we want to order it by date, check if all items have a date, and then sort it
-			//if ($this->order_by_date && empty($this->multifeed_objects))
-            if ($this->order_by_date)
+			if ($this->order_by_date && empty($this->multifeed_objects) || $this->order_by_date === 'force')
 			{
 				if (!isset($this->data['ordered_items']))
 				{
 					$do_sort = true;
-/* XXX
-					foreach ($this->data['items'] as $item)
-					{
-						if (!$item->get_date('U'))
-						{
-							$do_sort = false;
-							break;
-						}
-					}
-dw                 */
+                    if($this->order_by_date !== 'force') {
+					    foreach ($this->data['items'] as $item)
+					    {
+						    if (!$item->get_date('U'))
+						    {
+							    $do_sort = false;
+							    break;
+						    }
+					    }
+                    }
 					$item = null;
 					$this->data['ordered_items'] = $this->data['items'];
 					if ($do_sort)

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -2904,11 +2904,13 @@ class SimplePie
 		if (!empty($this->data['items']))
 		{
 			// If we want to order it by date, check if all items have a date, and then sort it
-			if ($this->order_by_date && empty($this->multifeed_objects))
+			//if ($this->order_by_date && empty($this->multifeed_objects))
+            if ($this->order_by_date)
 			{
 				if (!isset($this->data['ordered_items']))
 				{
 					$do_sort = true;
+/* XXX
 					foreach ($this->data['items'] as $item)
 					{
 						if (!$item->get_date('U'))
@@ -2917,6 +2919,7 @@ class SimplePie
 							break;
 						}
 					}
+dw                 */
 					$item = null;
 					$this->data['ordered_items'] = $this->data['items'];
 					if ($do_sort)


### PR DESCRIPTION
I use Simplepie to make an aggregate feed. If one day, one of the items from one of the feeds I use to make the aggregate has a bad date, then the order by date sorting is aborted and the order of my whole feed changes.

I would like simplepie to order by date anyway. To that end I added a 'force' option to enable_order_by_date that skips the missing date checks.

I like this because in this case only one item is out of order instead of every item.