### PR TITLE
Fixes an issue where the IRI could be generated with a trailing ?#

### DIFF
--- a/library/SimplePie/IRI.php
+++ b/library/SimplePie/IRI.php
@@ -1170,11 +1170,11 @@ class SimplePie_IRI
 		{
 			$iri .= $this->normalization[$this->scheme]['ipath'];
 		}
-		if ($this->iquery !== null)
+		if (!empty($this->iquery))
 		{
 			$iri .= '?' . $this->iquery;
 		}
-		if ($this->ifragment !== null)
+		if (!empty($this->ifragment))
 		{
 			$iri .= '#' . $this->ifragment;
 		}


### PR DESCRIPTION
Which results in resource not found errors on some feeds.

Fix for issue #366.