### PR TITLE
-fix bug in IRI get_iri

### DIFF
--- a/library/SimplePie/IRI.php
+++ b/library/SimplePie/IRI.php
@@ -1170,11 +1170,11 @@ class SimplePie_IRI
 		{
 			$iri .= $this->normalization[$this->scheme]['ipath'];
 		}
-		if ($this->iquery !== null)
+		if ($this->iquery !== null&&$this->iquery!=="")
 		{
 			$iri .= '?' . $this->iquery;
 		}
-		if ($this->ifragment !== null)
+		if ($this->ifragment !== null&&$this->ifragment!=="")
 		{
 			$iri .= '#' . $this->ifragment;
 		}


### PR DESCRIPTION
 for the url 
http://news.softpedia.com/newsRSS/Linux-7.xml
 it returned the wrong url
http://news.softpedia.com/newsRSS/Linux-7.xml?#
 , it added the extra "?#" at the end
