### PR TITLE
Fixed a typo in Date.php (wrong number for September)

### DIFF
--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -173,7 +173,7 @@ class SimplePie_Parse_Date
 		'aug' => 8,
 		'august' => 8,
 		'sep' => 9,
-		'september' => 8,
+		'september' => 9,
 		'oct' => 10,
 		'october' => 10,
 		'nov' => 11,


### PR DESCRIPTION
OIne of the variants for September was assigned the month number 8 instead of 9