### PR TITLE
export-ignore some files/folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/build export-ignore
+/compatibility_test export-ignore
+/demo export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+ROADMAP.md export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This adds a .gitattributes files, which sets some files/folders to be ignored when creating an archive.

This affects the zip from Github and the `dist` packages from Composer. It will reduce the filesize, because the tests folder is mainly pretty big.