### PR TITLE
[FreshRSS] Sanitize closing HTML and BODY tags

### DIFF
--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -383,6 +383,7 @@ class SimplePie_Sanitize
 	protected function preprocess($html, $type)
 	{
 		$ret = '';
+		$html = preg_replace('%</?(?:html|body)[^>]*?'.'>%is', '', $html);
 		if ($type & ~SIMPLEPIE_CONSTRUCT_XHTML)
 		{
 			// Atom XHTML constructs are wrapped with a div by default


### PR DESCRIPTION
From September 2013.
SimplePie did not sanitize closing `</body>` and `</html>` tags.
https://github.com/FreshRSS/FreshRSS/issues/159
https://github.com/FreshRSS/FreshRSS/pull/160