### PR TITLE
[FreshRSS] Added unconventional mime type for RSS

### DIFF
--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -148,7 +148,7 @@ class SimplePie_Locator
 		{
 			$sniffer = $this->registry->create('Content_Type_Sniffer', array($file));
 			$sniffed = $sniffer->get_type();
-			if (in_array($sniffed, array('application/rss+xml', 'application/rdf+xml', 'text/rdf', 'application/atom+xml', 'text/xml', 'application/xml')))
+			if (in_array($sniffed, array('application/rss+xml', 'application/rdf+xml', 'text/rdf', 'application/atom+xml', 'text/xml', 'application/xml', 'application/x-rss+xml')))
 			{
 				return true;
 			}


### PR DESCRIPTION
Since `application/rss+xml` is not official http://www.iana.org/assignments/media-types/media-types.xhtml, then it is fair enough to use the `x-` prefix and accept `application/x-rss+xml`

Solves https://github.com/simplepie/simplepie/issues/373

https://github.com/FreshRSS/FreshRSS/commit/e4ea629f590192faf19a9cbdf33d400fdd6d5569
https://github.com/FreshRSS/FreshRSS/issues/706