### PR TITLE
[FreshRSS] Allow protocol-relative URLs

### DIFF
--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -79,6 +79,10 @@ class SimplePie_Misc
 
 	public static function absolutize_url($relative, $base)
 	{
+		if (substr($relative, 0, 2) === '//')
+		{//Allow protocol-relative URLs "//www.example.net" which will pick HTTP or HTTPS automatically
+			return $relative;
+		}
 		$iri = SimplePie_IRI::absolutize(new SimplePie_IRI($base), $relative);
 		if ($iri === false)
 		{


### PR DESCRIPTION
Quick fix to disable absolutize_url for protocol-relative URLs such as
"//www.example.net" which will pick HTTP or HTTPS automatically

https://github.com/FreshRSS/FreshRSS/commit/be3b07a374c42a7d424b6ae12fd33c70c00c91ff