### PR TITLE
[FreshRSS] Explicit UTF-8

### DIFF
--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -124,7 +124,7 @@ class SimplePie_Misc
 						{
 							$attribs[$j][2] = $attribs[$j][1];
 						}
-						$return[$i]['attribs'][strtolower($attribs[$j][1])]['data'] = SimplePie_Misc::entities_decode(end($attribs[$j]));
+						$return[$i]['attribs'][strtolower($attribs[$j][1])]['data'] = SimplePie_Misc::entities_decode(end($attribs[$j]), 'UTF-8');
 					}
 				}
 			}
@@ -138,7 +138,7 @@ class SimplePie_Misc
 		foreach ($element['attribs'] as $key => $value)
 		{
 			$key = strtolower($key);
-			$full .= " $key=\"" . htmlspecialchars($value['data']) . '"';
+			$full .= " $key=\"" . htmlspecialchars($value['data'], ENT_COMPAT, 'UTF-8') . '"';
 		}
 		if ($element['self_closing'])
 		{


### PR DESCRIPTION
Use explicit UTF-8 in functions in which the default encoding may change depending on PHP's version or setup.
`htmlspecialchars` was used in the whole SimplePie code with the explicit parameters `(ENT_COMPAT, 'UTF-8')` except in one instance.

https://github.com/FreshRSS/FreshRSS/commit/6981a24b9c41c577d9c47e7e53c094fbecbb6b38