### PR TITLE
[FreshRSS] decode special chars for MAYBE_HTML

### DIFF
--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -229,6 +229,7 @@ class SimplePie_Sanitize
 		{
 			if ($type & SIMPLEPIE_CONSTRUCT_MAYBE_HTML)
 			{
+				$data = htmlspecialchars_decode($data, ENT_QUOTES); 
 				if (preg_match('/(&(#(x[0-9a-fA-F]+|[0-9]+)|[a-zA-Z0-9]+)|<\/[A-Za-z][^\x09\x0A\x0B\x0C\x0D\x20\x2F\x3E]*' . SIMPLEPIE_PCRE_HTML_ATTRIBUTE . '>)/', $data))
 				{
 					$type |= SIMPLEPIE_CONSTRUCT_HTML;


### PR DESCRIPTION
Suggestion for bug https://github.com/simplepie/simplepie/issues/350

It is quite common for feeds (e.g. Facebook as reported above) to have some MAYBE_HTML section HTML-encoded, which is currently not handled by SimplePie
```xml
<title><![CDATA[ L&#039;alpha 11 est arriv&#xe9;e...]]></title>
```

This is the approach currently used (with success) in FreshRSS:
https://github.com/FreshRSS/FreshRSS/issues/754
https://github.com/FreshRSS/FreshRSS/pull/813