### PR TITLE
[FreshRSS] Better error message for inaccessible feeds

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1520,13 +1520,15 @@ class SimplePie
 
 			if (!$locate->is_feed($file))
 			{
+				$copyStatusCode = $file->status_code;
+				$copyContentType = $file->headers['content-type'];
 				// We need to unset this so that if SimplePie::set_file() has been called that object is untouched
 				unset($file);
 				try
 				{
 					if (!($file = $locate->find($this->autodiscovery, $this->all_discovered_feeds)))
 					{
-						$this->error = "A feed could not be found at $this->feed_url. A feed with an invalid mime type may fall victim to this error, or " . SIMPLEPIE_NAME . " was unable to auto-discover it.. Use force_feed() if you are certain this URL is a real feed.";
+						$this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`";
 						$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
 						return false;
 					}


### PR DESCRIPTION
An inaccessible feed can be due to several problems. For identifying the problem, it is an important information to provide the HTTP status code and the HTTP content type of the server response, which SimplePie did not do.

Should solve https://github.com/simplepie/simplepie/issues/102

https://github.com/FreshRSS/FreshRSS/commit/56ac35095a6923661453916c472e117643cdea84
https://github.com/FreshRSS/FreshRSS/issues/456