### PR TITLE
Remove duplicate case

### DIFF
--- a/library/SimplePie/Decode/HTML/Entities.php
+++ b/library/SimplePie/Decode/HTML/Entities.php
@@ -169,7 +169,6 @@ class SimplePie_Decode_HTML_Entities
 			case "\x09":
 			case "\x0A":
 			case "\x0B":
-			case "\x0B":
 			case "\x0C":
 			case "\x20":
 			case "\x3C":


### PR DESCRIPTION
`\x0B` appears twice as case values.