### PR TITLE
Update build/compile.php to fix error

### DIFF
--- a/build/compile.php
+++ b/build/compile.php
@@ -51,8 +51,10 @@ $compiled .= remove_header($contents) . "\n";
 $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(SP_PATH . '/library/SimplePie'));
 foreach($files as $file_path => $info)
 {
-	$contents = file_get_contents($file_path);
-	$compiled .= remove_header($contents) . "\n";
+	if (!is_dir($file_path)) {
+		$contents = file_get_contents($file_path);
+		$compiled .= remove_header($contents) . "\n";
+	}
 }
 
 // Strip excess whitespace


### PR DESCRIPTION
On Windows, the compiling fails.  
Because the argument of `file_get_contents()` is directory.  
If you confirm that the argument is NOT directory, the compiling succeeds.

```cmd
C:\simplepie>php build\compile.php

Warning: file_get_contents(C:\simplepie/library/SimplePie\.): failed to open stream: Permission denied in C:\simplepie\build\compile.php on line 54
```