### PR TITLE
Use the cache_duration variable for all types of cache

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -516,7 +516,7 @@ class SimplePie
 	 * @see SimplePie::set_cache_duration()
 	 * @access private
 	 */
-	public $cache_duration = 3600;
+	public static $cache_duration = 3600;
 
 	/**
 	 * @var int Auto-discovery cache duration (in seconds)
@@ -874,7 +874,7 @@ class SimplePie
 	 */
 	public function set_cache_duration($seconds = 3600)
 	{
-		$this->cache_duration = (int) $seconds;
+		self::$cache_duration = (int) $seconds;
 	}
 
 	/**
@@ -1517,7 +1517,7 @@ class SimplePie
 					}
 				}
 				// Check if the cache has been updated
-				elseif ($cache->mtime() + $this->cache_duration < time())
+				elseif ($cache->mtime() + self::$cache_duration < time())
 				{
 					// Want to know if we tried to send last-modified and/or etag headers
 					// when requesting this file. (Note that it's up to the file to

--- a/library/SimplePie/Cache/Memcache.php
+++ b/library/SimplePie/Cache/Memcache.php
@@ -98,6 +98,7 @@ class SimplePie_Cache_Memcache implements SimplePie_Cache_Base
 		$this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
 
 		$this->name = $this->options['extras']['prefix'] . md5("$name:$type");
+		$this->options['extras']['timeout'] = SimplePie::$cache_duration;
 
 		$this->cache = new Memcache();
 		$this->cache->addServer($this->options['host'], (int) $this->options['port']);

--- a/library/SimplePie/Cache/Memcached.php
+++ b/library/SimplePie/Cache/Memcached.php
@@ -94,6 +94,7 @@ class SimplePie_Cache_Memcached implements SimplePie_Cache_Base
         $this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
 
         $this->name = $this->options['extras']['prefix'] . md5("$name:$type");
+        $this->options['extras']['timeout'] = SimplePie::$cache_duration;
 
         $this->cache = new Memcached();
         $this->cache->addServer($this->options['host'], (int)$this->options['port']);

--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -99,6 +99,7 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 		);
 		
 		$this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
+		$this->options['extras']['cache_purge_time'] = SimplePie::$cache_duration;
 
 		// Path is prefixed with a "/"
 		$this->options['dbname'] = substr($this->options['path'], 1);

--- a/library/SimplePie/Cache/Redis.php
+++ b/library/SimplePie/Cache/Redis.php
@@ -77,6 +77,7 @@ class SimplePie_Cache_Redis implements SimplePie_Cache_Base {
         }
 
         $this->name = $this->options['prefix'] . $name;
+        $this->options['expire'] =  SimplePie::$cache_duration;        
     }
 
     /**


### PR DESCRIPTION
I made SimplePie::$cache_duration a static variable.
Then I modified the
different cache classes to access it and use it as the custom value.