### PR TITLE
Add travis tests for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 matrix: 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 matrix: 
   allow_failures:
     - php: hhvm
+    - php: 7.0
 branches:
   except:
     - one-dot-two


### PR DESCRIPTION
4 failed tests in PHP 7.0
26 in hhvm

PHP 7.0 support is within range!