### PR TITLE
Fix for PHP 7.1

### DIFF
--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -690,7 +690,7 @@ class SimplePie_Parse_Date
 			}
 
 			// Convert the number of seconds to an integer, taking decimals into account
-			$second = round($match[6] + $match[7] / pow(10, strlen($match[7])));
+			$second = round((int)$match[6] + (int)$match[7] / pow(10, strlen($match[7])));
 
 			return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
 		}


### PR DESCRIPTION
Without: 

```
There were 60 errors:

1) OldTest::testOld with data set #60 (SimplePie_Date_Test_RFC3339_2 Object (...))
A non-numeric value encountered

/dev/shm/BUILDROOT/php-simplepie-1.4.2-1.fc23.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Parse/Date.php:693
/dev/shm/BUILDROOT/php-simplepie-1.4.2-1.fc23.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Parse/Date.php:602
/dev/shm/BUILDROOT/php-simplepie-1.4.2-1.fc23.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Misc.php:1763
/dev/shm/BUILD/simplepie-9b775e88ba1128fa14c69ff94ab954d86067de2a/tests/oldtests/functions.php:124
/dev/shm/BUILD/simplepie-9b775e88ba1128fa14c69ff94ab954d86067de2a/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-9b775e88ba1128fa14c69ff94ab954d86067de2a/tests/oldtests.php:82
```

With, same result than PHP 7.0 (Failure on IRITest.php)