### PR TITLE
Added PHP 7.1 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 matrix: 
   allow_failures:
     - php: hhvm
     - php: 7.0
+    - php: 7.1
 branches:
   except:
     - one-dot-two


### PR DESCRIPTION
I'll see there is already commited patches for PHP 7.1, so why isn't it tested?