### PR TITLE
PHPUnit dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
 	"require": {
 		"php": ">=5.3.0"
 	},
+	"require-dev": {
+		"phpunit/phpunit": "~4 || ~5"
+	},
 	"autoload": {
 		"psr-0": {
 			"SimplePie": "library"


### PR DESCRIPTION
Added PHPUnit as dev-dependency
- Version 4 required for PHP 5.3 support
- Version 6 is never going to work (when released) because of simplepies usage of deprecated class constructors, so we have to stop at 5.x