### PR TITLE
Refactored UTF-8 conversion error message

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1467,7 +1467,14 @@ class SimplePie
 		}
 		else
 		{
-			$this->error = 'The data could not be converted to UTF-8. You MUST have either the iconv or mbstring extension installed. Upgrading to PHP 5.x (which includes iconv) is highly recommended.';
+			$this->error = 'The data could not be converted to UTF-8.';
+			if (!extension_loaded('mbstring') && !extension_loaded('iconv')) {
+				$this->error .= ' You MUST have either the iconv or mbstring extension installed.';
+			} elseif (!extension_loaded('mbstring')) {
+				$this->error .= ' Try installing the mbstring extension.';
+			} elseif (!extension_loaded('iconv')) {
+				$this->error .= ' Try installing the iconv extension.';
+			}
 		}
 
 		$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));


### PR DESCRIPTION
Refactored "The data could not be converted to UTF-8. (...)" error message
- No longer complains about (not) missing extensions
- Removed solicitation about upgrading to PHP 5.x, - Simplepie already requires PHP 5.3, so this is just nuts!

See also comment at #466 (at the bottom of the first post)