### PR TITLE
Error message when XML or PCRE extensions missing

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1294,6 +1294,7 @@ class SimplePie
 		// Check absolute bare minimum requirements.
 		if (!extension_loaded('xml') || !extension_loaded('pcre'))
 		{
+			$this->error = 'XML or PCRE extensions not loaded!';
 			return false;
 		}
 		// Then check the xml extension is sane (i.e., libxml 2.7.x issue on PHP < 5.2.9 and libxml 2.7.0 to 2.7.2 on any version) if we don't have xmlreader.


### PR DESCRIPTION
The XML extension is not loaded by default on PHP7.
It is therefore relevant to have the reason of failure in the error message instead of returning an empty error message.
https://github.com/FreshRSS/FreshRSS/pull/1230
https://github.com/FreshRSS/FreshRSS/issues/1227#issuecomment-242978687