### PR TITLE
PHP 5.2 is not supported anymore

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,14 +11,11 @@ compatibility and standards compliance][what_is].
 
 Requirements
 ------------
-* PHP 5.2.0 or newer
+* PHP 5.3+
 * libxml2 (certain 2.7.x releases are too buggy for words, and will crash)
 * Either the iconv or mbstring extension
 * cURL or fsockopen()
 * PCRE support
-
-If you're looking for PHP 4.x support, pull the "one-dot-two" branch, as that's
-the last version to support PHP 4.x.
 
 
 What comes in the package?

--- a/compatibility_test/sp_compatibility_test.php
+++ b/compatibility_test/sp_compatibility_test.php
@@ -14,7 +14,7 @@ else if (isset($_GET['background']))
 	exit;
 }
 
-$php_ok = (function_exists('version_compare') && version_compare(phpversion(), '5.2.0', '>='));
+$php_ok = (function_exists('version_compare') && version_compare(phpversion(), '5.3.0', '>='));
 $pcre_ok = extension_loaded('pcre');
 $curl_ok = function_exists('curl_exec');
 $zlib_ok = extension_loaded('zlib');
@@ -215,7 +215,7 @@ function fnLoadPngs() {
 				<tbody>
 					<tr class="<?php echo ($php_ok) ? 'enabled' : 'disabled'; ?>">
 						<td>PHP</td>
-						<td>5.2.0 or higher</td>
+						<td>5.3.0 or higher</td>
 						<td><?php echo phpversion(); ?></td>
 					</tr>
 					<tr class="<?php echo ($xml_ok) ? 'enabled, and sane' : 'disabled, or broken'; ?>">

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -659,9 +659,9 @@ class SimplePie
 	 */
 	public function __construct()
 	{
-		if (version_compare(PHP_VERSION, '5.2', '<'))
+		if (version_compare(PHP_VERSION, '5.3', '<'))
 		{
-			trigger_error('PHP 4.x, 5.0 and 5.1 are no longer supported. Please upgrade to PHP 5.2 or newer.');
+			trigger_error('Please upgrade to PHP 5.3 or newer.');
 			die();
 		}
 

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -130,14 +130,7 @@ class EncodingTest extends PHPUnit_Framework_TestCase
 	public function test_convert_UTF8_mbstring($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		if (version_compare(phpversion(), '5.3', '<'))
-		{
-			$this->assertEquals($expected, Mock_Misc::__callStatic('change_encoding_mbstring', array($input, $encoding, 'UTF-8')));
-		}
-		else
-		{
-			$this->assertEquals($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
-		}
+		$this->assertEquals($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
 	}
 
 	/**
@@ -150,13 +143,7 @@ class EncodingTest extends PHPUnit_Framework_TestCase
 	public function test_convert_UTF8_iconv($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		if (version_compare(phpversion(), '5.3', '<'))
-		{
-			$this->assertEquals($expected, Mock_Misc::__callStatic('change_encoding_iconv', array($input, $encoding, 'UTF-8')));
-		}
-		else {
-			$this->assertEquals($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
-		}
+		$this->assertEquals($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
 	}
 	/**#@-*/
 


### PR DESCRIPTION
Patches such as https://github.com/simplepie/simplepie/pull/388 and https://github.com/simplepie/simplepie/commit/a6e19f187d852ee59a3cdb176aa05b380d72555b killed PHP 5.2 without updating the documentation and version checks.
So the documentation and the code still allowed PHP 5.2, but SimplePie 1.4+ does not support it any more:

```
Warning: Unexpected character in input:  '\' (ASCII=92) state=1 in ./simplepie/library/SimplePie/ on line 460

Parse error: syntax error, unexpected T_STRING in ./simplepie/library/SimplePie/Parser.php on line 460
```

The Web site should be updated as well http://simplepie.org/wiki/setup/requirements