### PR TITLE
Use saveHTML(node) (was: Sanitize: superfluous entities)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,9 @@ compatibility and standards compliance][what_is].
 
 Requirements
 ------------
-* PHP 5.3+
+* PHP 5.3.0+ (5.3.6+ recommended since SimplePie 1.4.3+)
+	* Support for PHP 5.2 stopped in branch `one-dot-three`
+	* Support for PHP 4 stopped in branch `one-dot-two`
 * libxml2 (certain 2.7.x releases are too buggy for words, and will crash)
 * Either the iconv or mbstring extension
 * cURL or fsockopen()

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -273,10 +273,6 @@ class SimplePie_Sanitize
 				$document = new DOMDocument();
 				$document->encoding = 'UTF-8';
 
-				// See https://github.com/simplepie/simplepie/issues/334
-				$unique_tag = '#'.uniqid().'#';
-				$data = trim($unique_tag . $data . $unique_tag);
-
 				$data = $this->preprocess($data, $type);
 
 				set_error_handler(array('SimplePie_Misc', 'silence_errors'));
@@ -366,11 +362,17 @@ class SimplePie_Sanitize
 					}
 				}
 
+				// Get content node
+				$div = $document->getElementsByTagName('body')->item(0)->firstChild;
 				// Finally, convert to a HTML string
-				$data = trim($document->saveHTML());
-				$result = explode($unique_tag, $data);
-				// The tags may not be found again if there was invalid markup.
-				$data = count($result) === 3 ? $result[1] : '';
+				if (version_compare(PHP_VERSION, '5.3.6', '>='))
+				{
+					$data = trim($document->saveHTML($div));
+				}
+				else
+				{
+					$data = trim($document->saveXML($div));
+				}
 
 				if ($this->remove_div)
 				{


### PR DESCRIPTION
Re-use https://github.com/simplepie/simplepie/pull/388 instead of https://github.com/simplepie/simplepie/pull/378
Requires PHP 5.3.6, but fall-back with saveXML() for PHP 5.0.
https://github.com/simplepie/simplepie/issues/334
https://github.com/jagermesh/simplepie/commit/d91ae5e718a446652efd08cb42a622c93226d215