### PR TITLE
Support requesting delta feeds (RFC3229+feed)

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1547,6 +1547,7 @@ class SimplePie
 						if (isset($this->data['headers']['etag']))
 						{
 							$headers['if-none-match'] = $this->data['headers']['etag'];
+							$headers['a-im'] = 'feed';
 						}
 
 						$file = $this->registry->create('File', array($this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));


### PR DESCRIPTION
When sending a `If-None-Match: $etag` header, tag along a `A-IM: feed`
header. Supporting servers should only return content that has been added
or changed since they sent the etag. content. Should have no affect on
servers who doesn’t support this. Saves bandwidth when supported.

Supported by ExpressionEngine, Textpattern, and Liferea. I’m working on adding support to more feed readers and hope to add it to WordPress soon.
