### PR TITLE
Use current HHVM 3.15.2 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
+sudo: false
 language: php
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-matrix: 
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Travis CI update
   allow_failures:
     - php: hhvm
     - php: 7.0


### PR DESCRIPTION
The current Travis CI setup is testing against hhvm 3.6.6 since Travis CI container uses precise which is locked at hhvm 3.6.6 as the last hhvm build for that version. Using the non-container Trusty build allows testing current hhvm 3.15.2 (or newer depending on release schedule)