### PR TITLE
Compatibility test + error msg clarifications

### DIFF
--- a/compatibility_test/sp_compatibility_test.php
+++ b/compatibility_test/sp_compatibility_test.php
@@ -20,6 +20,7 @@ $curl_ok = function_exists('curl_exec');
 $zlib_ok = extension_loaded('zlib');
 $mbstring_ok = extension_loaded('mbstring');
 $iconv_ok = extension_loaded('iconv');
+$intl_ok = version_compare(phpversion(), '5.5.0', '>=') && extension_loaded('intl');
 if (extension_loaded('xmlreader'))
 {
 	$xml_ok = true;
@@ -81,11 +82,14 @@ echo sprintf($testRow,str_pad(($mbstring_ok ? 'Passed' : 'Failed'), 7),str_pad('
 echo sprintf($testRow,str_pad(($iconv_ok ? 'Passed' : 'Failed'), 7),str_pad('iconv',20),str_pad('Enabled', 20),str_pad(( $iconv_ok ? 'Enabled' : 'Disabled' ), 20));
 
 
+echo sprintf($testRow,str_pad(($intl_ok ? 'Passed' : 'Failed'), 7),str_pad('intl',20),str_pad('Enabled', 20),str_pad(( $intl_ok ? 'Enabled' : 'Disabled' ), 20));
+
+
 echo "\n\n";
 
 echo "What does this mean? \n\n";
 
-if ($php_ok && $xml_ok && $pcre_ok && $mbstring_ok && $iconv_ok && $curl_ok && $zlib_ok):
+if ($php_ok && $xml_ok && $pcre_ok && $mbstring_ok && $iconv_ok && $intl_ok && $curl_ok && $zlib_ok):
 	echo "You have everything you need to run SimplePie properly!  Congratulations!\n\n";
 else:
 	if ($php_ok):
@@ -107,14 +111,30 @@ else:
                 echo "Zlib: The Zlib extension is not available.  SimplePie will ignore any GZIP-encoding, and instead handle feeds as uncompressed text.\n";
             endif;
 
-            if ($mbstring_ok && $iconv_ok):
-                echo "mbstring and iconv: You have both mbstring and iconv installed!  This will allow SimplePie to handle the greatest number of languages. \nCheck the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
-            elseif ($mbstring_ok):
-                echo "mbstring: mbstring is installed, but iconv is not.  Check the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
-            elseif ($iconv_ok):
-                echo "iconv: iconv is installed, but mbstring is not.  Check the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
+            if ($mbstring_ok && $iconv_ok && $intl_ok):
+                echo "mbstring, iconv and intl: You have both mbstring, iconv and intl installed and enabled!  This will allow SimplePie to handle the greatest number of languages. \nCheck the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
+            elseif (($mbstring_ok && $iconv_ok) ||
+                ($mbstring_ok && $intl_ok) ||
+                ($iconv_ok && $intl_ok)
+            ):
+                if ($mbstring_ok):
+                    echo "mbstring: mbstring is installed and enabled.\n";
+                else:
+                    echo "mbstring: mbstring extension is not available.\n";
+                endif;
+                if ($iconv_ok):
+                    echo "iconv: iconv is installed and enabled.\n";
+                else:
+                    echo "iconv: iconv extension is not available.\n";
+                endif;
+                if ($intl_ok):
+                    echo "intl: intl is installed and enabled.\n";
+                else:
+                    echo "intl: intl extension is not supported/available (PHP 5.5+).\n";
+                endif;
+                echo "Check the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
             else:
-                echo "mbstring and iconv: You do not have either of the extensions installed. This will significantly impair your ability to read non-English feeds, as well as even some English ones.  Check the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
+                echo "mbstring, iconv and intl: You do not have either of the extensions installed and enabled, (intl supported as of PHP 5.5+). This will significantly impair your ability to read non-English feeds, as well as even some English ones.  Check the http://simplepie.org/wiki/faq/supported_character_encodings chart to see what's supported on your webhost.\n";
             endif;
 
         else:

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1379,7 +1379,7 @@ class SimplePie
 		
 		// Empty response check
 		if(empty($this->raw_data)){
-			$this->error = "A feed could not be found at $this->feed_url. Empty body.";
+			$this->error = "A feed could not be found at `$this->feed_url`. Empty body.";
 			$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
 			return false;
 		}
@@ -1446,7 +1446,7 @@ class SimplePie
 					$this->data = $parser->get_data();
 					if (!($this->get_type() & ~SIMPLEPIE_TYPE_NONE))
 					{
-						$this->error = "A feed could not be found at $this->feed_url. This does not appear to be a valid RSS or Atom feed.";
+						$this->error = "A feed could not be found at `$this->feed_url`. This does not appear to be a valid RSS or Atom feed.";
 						$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
 						return false;
 					}
@@ -1476,18 +1476,18 @@ class SimplePie
 		else
 		{
 			$this->error = 'The data could not be converted to UTF-8.';
-			if (!extension_loaded('mbstring') && !extension_loaded('iconv') && !extension_loaded('intl')) {
-				$this->error .= ' You MUST have either the iconv, intl or mbstring extension installed and enabled.';
+			if (!extension_loaded('mbstring') && !extension_loaded('iconv') && !class_exists('\UConverter')) {
+				$this->error .= ' You MUST have either the iconv, mbstring or intl (PHP 5.5+) extension installed and enabled.';
 			} else {
 				$missingExtensions = array();
 				if (!extension_loaded('iconv')) {
 					$missingExtensions[] = 'iconv';
 				}
-				if (!extension_loaded('intl')) {
-					$missingExtensions[] = 'intl';
-				}
 				if (!extension_loaded('mbstring')) {
 					$missingExtensions[] = 'mbstring';
+				}
+				if (!class_exists('\UConverter')) {
+					$missingExtensions[] = 'intl (PHP 5.5+)';
 				}
 				$this->error .= ' Try installing/enabling the ' . implode(' or ', $missingExtensions) . ' extension.';
 			}

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -165,8 +165,9 @@ class EncodingTest extends PHPUnit_Framework_TestCase
 	public function test_convert_UTF8_uconverter($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		if (version_compare(phpversion(), '5.5', '>='))
-		{
+		if (version_compare(phpversion(), '5.5', '>=') &&
+			extension_loaded('intl')
+		) {
 			$this->assertEquals($expected, Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
 		}
 	}

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -47,26 +47,6 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 
 class EncodingTest extends PHPUnit_Framework_TestCase
 {
-	/**
-	 * Test if we have mbstring
-	 *
-	 * Used for depends
-	 */
-	public function test_has_mbstring()
-	{
-		$this->assertTrue(function_exists('mb_convert_encoding'));
-	}
-
-	/**
-	 * Test if we have iconv (crazy if we don't)
-	 *
-	 * Used for depends
-	 */
-	public function test_has_iconv()
-	{
-		$this->assertTrue(function_exists('iconv'));
-	}
-
 	/**#@+
 	 * UTF-8 methods
 	 */
@@ -134,26 +114,28 @@ class EncodingTest extends PHPUnit_Framework_TestCase
 	 * Convert * to UTF-8 using mbstring
 	 *
 	 * Special cases only
-	 * @depends test_has_mbstring
 	 * @dataProvider toUTF8_mbstring
 	 */
 	public function test_convert_UTF8_mbstring($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEquals($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+		if (extension_loaded('mbstring')) {
+			$this->assertEquals($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+		}
 	}
 
 	/**
 	 * Convert * to UTF-8 using iconv
 	 *
 	 * Special cases only
-	 * @depends test_has_iconv
 	 * @dataProvider toUTF8_iconv
 	 */
 	public function test_convert_UTF8_iconv($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEquals($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
+		if (extension_loaded('iconv')) {
+			$this->assertEquals($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Added intl to the sp_compatibility_test
- Updated error messages, to clarify that intl support requires php 5.5+
- Test won't fail if intl isn't available

Update:
- Removed tests that caused failure if either mbstring or iconv wasn't available

For the record, the tests will still fail if none of the required extensions is available. That test hasn't changed.

Consider this as an update to PR #485: `Support for Uconverter`.