### PR TITLE
Fix a PHP 7 deprecation message

### DIFF
--- a/idn/idna_convert.class.php
+++ b/idn/idna_convert.class.php
@@ -91,7 +91,7 @@ class idna_convert
     var $_strict_mode    =  false;  // Behave strict or not
 
     // The constructor
-    function idna_convert($options = false)
+    function __construct($options = false)
     {
         $this->slast = $this->_sbase + $this->_lcount * $this->_vcount * $this->_tcount;
         if (function_exists('file_get_contents')) {


### PR DESCRIPTION
As noted on PHP’s [Constructors and Destructors page](http://php.net/manual/en/language.oop5.decon.php), 

> Old style constructors are DEPRECATED in PHP 7.0, and will be removed in a future version. You should always use __construct() in new code.

PHP has supported __construct() since version 5 and SimplePie requires 5.3, so no reason not to change this now, and avoid deprecation errors when running PHP 7.