### PR TITLE
Fix #478

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -326,57 +326,57 @@ class SimplePie_Item
 	 */
 	public function get_description($description_only = false)
 	{
-		if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0])))
+		if (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($tag[0]['attribs'])), $this->get_base($tag[0])))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0])))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($tag[0]['attribs'])), $this->get_base($tag[0])))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0])))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($tag[0])))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0])))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tag[0])))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0])))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tag[0])))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
 		) {
 			return $return;
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
-			$return[0]['data'] &&
-			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML))
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_HTML))
 		) {
 			return $return;
 		}
@@ -1045,7 +1045,7 @@ class SimplePie_Item
 			}
 			if ($links = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'guid'))
 			{
-				if (!isset($links[0]['attribs']['']['isPermaLink']) || strtolower(trim($links[0]['attribs']['']['isPermaLink'])) === 'true')
+				if (!isset($links[0]['attribs']['']['isPermaLink']) || strtolower($links[0]['attribs']['']['isPermaLink']) === 'true')
 				{
 					$this->data['links']['alternate'][] = $this->sanitize($links[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($links[0]));
 				}
@@ -2182,10 +2182,10 @@ class SimplePie_Item
 							{
 								if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data']))
 								{
-									$temp = explode(',', $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT));
+									$temp = array_map('trim', explode(',', $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)));
 									foreach ($temp as $word)
 									{
-										$keywords[] = trim($word);
+										$keywords[] = $word;
 									}
 									unset($temp);
 								}
@@ -2198,10 +2198,10 @@ class SimplePie_Item
 							{
 								if (isset($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data']))
 								{
-									$temp = explode(',', $this->sanitize($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT));
+									$temp = array_map('trim', explode(',', $this->sanitize($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)));
 									foreach ($temp as $word)
 									{
-										$keywords[] = trim($word);
+										$keywords[] = $word;
 									}
 									unset($temp);
 								}
@@ -2675,10 +2675,10 @@ class SimplePie_Item
 						{
 							if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data']))
 							{
-								$temp = explode(',', $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT));
+								$temp = array_map('trim', explode(',', $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['keywords'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)));
 								foreach ($temp as $word)
 								{
-									$keywords[] = trim($word);
+									$keywords[] = $word;
 								}
 								unset($temp);
 							}
@@ -2942,7 +2942,7 @@ class SimplePie_Item
 		{
 			return (float) $return[0]['data'];
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_GEORSS, 'point')) && preg_match('/^((?:-)?[0-9]+(?:\.[0-9]+)) ((?:-)?[0-9]+(?:\.[0-9]+))$/', trim($return[0]['data']), $match))
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_GEORSS, 'point')) && preg_match('/^((?:-)?[0-9]+(?:\.[0-9]+)) ((?:-)?[0-9]+(?:\.[0-9]+))$/', $return[0]['data'], $match))
 		{
 			return (float) $match[1];
 		}
@@ -2974,7 +2974,7 @@ class SimplePie_Item
 		{
 			return (float) $return[0]['data'];
 		}
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_GEORSS, 'point')) && preg_match('/^((?:-)?[0-9]+(?:\.[0-9]+)) ((?:-)?[0-9]+(?:\.[0-9]+))$/', trim($return[0]['data']), $match))
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_GEORSS, 'point')) && preg_match('/^((?:-)?[0-9]+(?:\.[0-9]+)) ((?:-)?[0-9]+(?:\.[0-9]+))$/', $return[0]['data'], $match))
 		{
 			return (float) $match[2];
 		}

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -96,11 +96,11 @@ class SimplePie_Item
 	/**
 	 * array_map recursive
 	 *
-	 * @param $callback
-	 * @param $array
-	 * @return mixed
+	 * @param string $callback
+	 * @param array $array
+	 * @return array
 	 */
-	private function array_map_recursive($callback, &$array)
+	private function array_map_recursive($callback, array &$array)
 	{
 		foreach ($array as &$value) {
 			if (is_string($value)) {

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -331,42 +331,42 @@ class SimplePie_Item
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
@@ -395,12 +395,12 @@ class SimplePie_Item
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
         }
-		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
+        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -324,55 +324,64 @@ class SimplePie_Item
 	 * @param boolean $description_only Should we avoid falling back to the content?
 	 * @return string|null
 	 */
-    public function get_description($description_only = false)
-    {
-        if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
-        }
-        return $description_only ? null : $this->get_content(true);
-    }
+	public function get_description($description_only = false)
+	{
+		if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0])))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0])))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0])))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0])))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0])))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT))
+		) {
+			return $return;
+		}
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+			$return[0]['data'] &&
+			($return = $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML))
+		) {
+			return $return;
+		}
+		return $description_only ? null : $this->get_content(true);
+	}
 
 	/**
 	 * Get the content for the item
@@ -389,24 +398,27 @@ class SimplePie_Item
 	 * @return string|null
 	 */
     public function get_content($content_only = false)
-    {
-        if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        }
-        elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
-            $return[0]['data']
-        ) {
-            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-        }
-        return $content_only ? null : $this->get_description(true);
-    }
+	{
+		if (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($tag[0]['attribs'])), $this->get_base($tag[0])))
+		) {
+			return $return;
+		}
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($tag[0]['attribs'])), $this->get_base($tag[0])))
+		) {
+			return $return;
+		}
+		elseif (($tag = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
+			$tag[0]['data'] &&
+			($return = $this->sanitize($tag[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tag[0])))
+		) {
+			return $return;
+		}
+		return $content_only ? null : $this->get_description(true);
+	}
 
 	/**
 	 * Get the media:thumbnail of the item

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -90,7 +90,26 @@ class SimplePie_Item
 	public function __construct($feed, $data)
 	{
 		$this->feed = $feed;
-		$this->data = $data;
+		$this->data = $this->array_map_recursive('trim', $data);
+	}
+
+	/**
+	 * array_map recursive
+	 *
+	 * @param $callback
+	 * @param $array
+	 * @return mixed
+	 */
+	private function array_map_recursive($callback, &$array)
+	{
+		foreach ($array as &$value) {
+			if (is_string($value)) {
+				$value = $callback($value);
+			} elseif (is_array($value)) {
+				$this->array_map_recursive($callback, $value);
+			}
+		}
+		return $array;
 	}
 
 	/**
@@ -305,54 +324,47 @@ class SimplePie_Item
 	 * @param boolean $description_only Should we avoid falling back to the content?
 	 * @return string|null
 	 */
-	public function get_description($description_only = false)
-	{
-		if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary'))
-		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary'))
-		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
-		}
-
-		elseif (!$description_only)
-		{
-			return $this->get_content(true);
-		}
-		else
-		{
-			return null;
-		}
-	}
+    public function get_description($description_only = false)
+    {
+        if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
+        }
+        return $description_only ? null : $this->get_content(true);
+    }
 
 	/**
 	 * Get the content for the item
@@ -368,36 +380,30 @@ class SimplePie_Item
 	 * @param boolean $content_only Should we avoid falling back to the description?
 	 * @return string|null
 	 */
-	public function get_content($content_only = false)
-	{
-		if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content'))
-		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content'))
-		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded'))
-		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-		}
-		elseif (!$content_only)
-		{
-			return $this->get_description(true);
-		}
-		else
-		{
-			return null;
-		}
-	}
-	
+    public function get_content($content_only = false)
+    {
+        if (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
+            $return[0]['data']
+        ) {
+            return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+        }
+        return $content_only ? null : $this->get_description(true);
+    }
+
 	/**
 	 * Get the media:thumbnail of the item
 	 *
 	 * Uses `<media:thumbnail>`
 	 *
-	 * 
+	 *
 	 * @return array|null
 	 */
 	public function get_thumbnail()
@@ -414,7 +420,7 @@ class SimplePie_Item
 			}
 		}
 		return $this->data['thumbnail'];
-	}	
+	}
 
 	/**
 	 * Get a category for the item

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -330,35 +330,43 @@ class SimplePie_Item
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
@@ -386,11 +394,13 @@ class SimplePie_Item
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
-        } elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
+        }
+		elseif (($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
             $return[0]['data']
         ) {
             return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -404,7 +404,7 @@ class SimplePie_Sanitize
 				$data = $this->registry->call('Misc', 'change_encoding', array($data, 'UTF-8', $this->output_encoding));
 			}
 		}
-		return $data;
+		return trim($data);
 	}
 
 	protected function preprocess($html, $type)

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -52,7 +52,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @param string $template 
 	 */
-	protected function checkFromTemplate($template, $data, $expected)
+	protected function checkFromTemplate($template, $data)
 	{
 		if (!is_array($data))
 		{
@@ -103,7 +103,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<title>%s</title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -118,7 +118,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<dc:title>%s</dc:title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -133,7 +133,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<dc:title>%s</dc:title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -148,7 +148,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<a:title>%s</a:title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -163,7 +163,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<a:title>%s</a:title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -183,7 +183,7 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		</image>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
 	}
 
@@ -203,7 +203,24 @@ class ItemTest extends PHPUnit_Framework_TestCase
 		<title>%s</title>
 	</channel>
 </rss>';
-		$feed = $this->checkFromTemplate($data, $title, $expected);
+		$feed = $this->checkFromTemplate($data, $title);
 		$this->assertEquals($expected, $feed->get_title());
+	}
+
+	public function testItemWithEmptyContent()
+	{
+		$data =
+'<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	<channel>
+		<item>
+			<description>%s</description>
+			<content:encoded><![CDATA[ <script> ]]></content:encoded>
+		</item>
+	</channel>
+</rss>';
+		$content = 'item description';
+		$feed = $this->checkFromTemplate($data, $content);
+		$item = $feed->get_item();
+		$this->assertEquals($content, $item->get_content());
 	}
 }


### PR DESCRIPTION
- Trim sanitized data
- Trim item data
- `get_content`: Override empty `<content:encoded>` tags with `<description>`
- `get_description`: Override empty `<description>` tags with `<content:encoded>`

Fixes both issues mentioned in #478, as well as a few others not mentioned yet, all related to trim.

_Hope I didn't violate the coding standards too much :p_