### PR TITLE
Composer: mf2/mf2 suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4 || ~5"
 	},
+	"suggest": {
+		"mf2/mf2": "Microformat module that allows for parsing HTML for microformats"
+	},
 	"autoload": {
 		"psr-0": {
 			"SimplePie": "library"


### PR DESCRIPTION
> Microformat module that allows for parsing HTML documents for microformats.
Source; http://simplepie.org/wiki/sp2/goals?rev=1222735877

We're using it in [`Parser.php`](https://github.com/simplepie/simplepie/blob/master/library/SimplePie/Parser.php#L79), so we should at least suggest it for installation.

Most Simplepie users probably isn't aware of this at all, and personally I didn't notice it until I randomly saw an conversion where it was mentioned, a few months ago.
I'm not exactly sure what it really does, or when it's recommended/needed, so please update the suggestion text if anyone has a better text to fill in.