### PR TITLE
Allow force-get supplied item ID

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -206,9 +206,10 @@ class SimplePie_Item
 	 *
 	 * @since Beta 2
 	 * @param boolean $hash Should we force using a hash instead of the supplied ID?
-	 * @return string
+	 * @param string|false $fn User-supplied function to generate an hash
+	 * @return string|null
 	 */
-	public function get_id($hash = false, $fn = '')
+	public function get_id($hash = false, $fn = 'md5')
 	{
 		if (!$hash)
 		{
@@ -237,7 +238,15 @@ class SimplePie_Item
 				return $this->sanitize($this->data['attribs'][SIMPLEPIE_NAMESPACE_RDF]['about'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
 		}
-		if ($fn === '' || !is_callable($fn)) $fn = 'md5';
+		if ($fn === false)
+		{
+			return null;
+		}
+		elseif (!is_callable($fn))
+		{
+			trigger_error('User-supplied function $fn must be callable', E_USER_WARNING);
+			$fn = 'md5';
+		}
 		return call_user_func($fn,
 		       $this->get_permalink().$this->get_title().$this->get_content());
 	}


### PR DESCRIPTION
Allow forcing `$item->get_id()` to return supplied ID, instead of generating one. If no ID is supplied, it will return `null`.

**The issue:**
If an item gets updated (eg. a news article), and a item ID isn't supplied, a new unique ID will __always__ be generated, causing duplicates, even if it has the same permalink or even title...

**Bonus changes/fixes:**
- Previously, if an invalid or not callable function name was supplied, it was replaced by `md5` without warning, now it produces an `E_USER_WARNING` first...
- The `$fn` parameter, was missing from the PHPdoc block, now fixed.