### PR TITLE
Updating favicon url in `get_favicon` function

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -3155,7 +3155,7 @@ class SimplePie
 
 		if (($url = $this->get_link()) !== null)
 		{
-			return 'http://g.etfv.co/' . urlencode($url);
+			return 'https://www.google.com/s2/favicons?domain=' . urlencode($url);
 		}
 
 		return false;


### PR DESCRIPTION
Updating outdated url http://g.etfv.co/ with google's url to fetch favicon. This will return the correct favicon.