### PR TITLE
Improvement to #512:  https://github.com/simplepie/simplepie/pull/512

### DIFF
--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -512,6 +512,9 @@ class SimplePie_HTTP_Parser
 		if (false !== stripos($data, "HTTP/1.0 200 Connection established\r\n\r\n")) {
 			$data = str_ireplace("HTTP/1.0 200 Connection established\r\n\r\n", '', $data);
 		}
+		if (false !== stripos($data, "HTTP/1.1 200 Connection established\r\n\r\n")) {
+			$data = str_ireplace("HTTP/1.1 200 Connection established\r\n\r\n", '', $data);
+		}
 		return $data;
 	}
 }

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -97,4 +97,20 @@ class HTTPParserTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(array('content-type' => 'text/plain'), $parser->headers);
 		$this->assertEquals($expected, $parser->body);
 	}
+
+	/**
+	 * @dataProvider chunkedProvider
+	 */
+	public function testChunkedProxy11($data, $expected)
+	{
+		$data = "HTTP/1.1 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
+		$data = SimplePie_HTTP_Parser::prepareHeaders($data);
+		$parser = new SimplePie_HTTP_Parser($data);
+		$this->assertTrue($parser->parse());
+		$this->assertEquals(1.1, $parser->http_version);
+		$this->assertEquals(200, $parser->status_code);
+		$this->assertEquals('OK', $parser->reason);
+		$this->assertEquals(array('content-type' => 'text/plain'), $parser->headers);
+		$this->assertEquals($expected, $parser->body);
+	}
 }


### PR DESCRIPTION
While worked with SQuid proxies, I found myself in the similar situation. The only difference is that I've gotten from proxy reponse with HTTP 1.1, not HTTP 1.0.

The pull request managed this situation as well. I just extended tests and code of the function SimplePie_HTTP_Parser::prepareHeaders in the simplest way, to not fall into overengineering.