### PR TITLE
Add toJson() function support

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -117,6 +117,16 @@ class SimplePie_Item
 	}
 
 	/**
+	 * Get a json string of the item
+	 *
+	 * @return string
+	 */
+	public function toJson()
+	{
+		return json_encode(array_shift($this->data['child']));
+	}
+	
+	/**
 	 * Remove items that link back to this before destroying this object
 	 */
 	public function __destruct()


### PR DESCRIPTION
In my case I have an API that calls some feed url then returns the results found, the front-end is VueJS base, so basically JSON is preferred as a response, why this function? because instead of doing too much on PHP side a `for loop` to build a complete list of items then convert it into JSON consumes time and memory, while it is so simple to do it in the Core class of `SimplePie_Item`.