### PR TITLE
URL Fragment should not be part of the request to the server

### DIFF
--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -71,7 +71,7 @@ class SimplePie_File
 		{
 			$idn = new idna_convert();
 			$parsed = SimplePie_Misc::parse_url($url);
-			$url = SimplePie_Misc::compress_parse_url($parsed['scheme'], $idn->encode($parsed['authority']), $parsed['path'], $parsed['query'], $parsed['fragment']);
+			$url = SimplePie_Misc::compress_parse_url($parsed['scheme'], $idn->encode($parsed['authority']), $parsed['path'], $parsed['query'], NULL);
 		}
 		$this->url = $url;
 		$this->permanent_url = $url;


### PR DESCRIPTION
`SimplePie_File` normalizes the URL to handle internationalized domains, but is forcing a URL fragment onto the end of URLs when there isn't one (`SimplePie_Misc::parse_url()` casts to an empty string). cURL is smart enough to not include URL fragments in the request, but only since cURL 7.20.0.

Sadly, some distros (e.g. CentOS 6) still ship with an archaic 7.19.7. Combined with `CURLOPT_FAILONERROR` on such clients, the result is a SimplePie failure:

```
RSS Parser Error: cURL error 22: The requested URL returned error: 400 Bad Request
```

The real blame lies in those older versions of cURL. But since the URL fragment [shouldn't be included in the server request anyway](https://www.greenbytes.de/tech/webdav/rfc7230.html#rfc.section.5.1.p.2), this PR makes sure it doesn't get added, and restores functionality in environments with outdated curl libs.

also fixes: https://github.com/simplepie/simplepie/issues/545

see also: [Why modern curl versions cut off the #anchor part of the URL? @ Stack Overflow](https://stackoverflow.com/questions/46281537/why-modern-curl-versions-cut-off-the-anchor-part-of-the-url)