### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"php": ">=5.3.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4 || ~5"
+		"phpunit/phpunit": "~4.8.35 || ~5.4.3 || ~6.5"
 	},
 	"suggest": {
 		"mf2/mf2": "Microformat module that allows for parsing HTML for microformats"

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -72,7 +72,7 @@ class Mock_CacheNew extends SimplePie_Cache
 	}
 }
 
-class CacheTest extends PHPUnit_Framework_TestCase
+class CacheTest extends PHPUnit\Framework\TestCase
 {
 	/**
 	 * @expectedException Exception_Success

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -45,7 +45,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
-class EncodingTest extends PHPUnit_Framework_TestCase
+class EncodingTest extends PHPUnit\Framework\TestCase
 {
 	/**#@+
 	 * UTF-8 methods

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -45,7 +45,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
-class HTTPParserTest extends PHPUnit_Framework_TestCase
+class HTTPParserTest extends PHPUnit\Framework\TestCase
 {
 	public static function chunkedProvider()
 	{

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -42,7 +42,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
  
-class IRITest extends PHPUnit_Framework_TestCase
+class IRITest extends PHPUnit\Framework\TestCase
 {
 	public static function rfc3986_tests()
 	{

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -45,7 +45,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
-class ItemTest extends PHPUnit_Framework_TestCase
+class ItemTest extends PHPUnit\Framework\TestCase
 {
 	/**
 	 * Run a test using a sprintf template and data

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -45,7 +45,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
-class LocatorTest extends PHPUnit_Framework_TestCase
+class LocatorTest extends PHPUnit\Framework\TestCase
 {
 	public static function feedmimetypes()
 	{

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -44,7 +44,7 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
-class SanitizeTest extends PHPUnit_Framework_TestCase
+class SanitizeTest extends PHPUnit\Framework\TestCase
 {
 	public function testSanitize()
 	{

--- a/tests/oldtests.php
+++ b/tests/oldtests.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__) . '/oldtests/compat_test_harness.php';
 require_once dirname(__FILE__) . '/oldtests/functions.php';
 
-class OldTest extends PHPUnit_Framework_TestCase
+class OldTest extends PHPUnit\Framework\TestCase
 {
     public function getTests()
     {


### PR DESCRIPTION
I've added `PHPUnit 6` support. I just need to bump `PHPUnit 4` to [`4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4835---2017-02-06) and `PHPUnit 5` to [`5.4.3`](https://github.com/sebastianbergmann/phpunit/blob/5.4/ChangeLog-5.4.md#543---2016-06-09) to support the new `PHPUnit\Framework\TestCase` :man_technologist: 

The failing tests are because we are not installing anything on `Travis CI`, neither update or use `vendor/bin/phpunit`. Can I fix it in another PR?