### PR TITLE
Composer: Added missing php module requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,19 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6.0"
+		"php": ">=5.6.0",
+		"ext-pcre": "*",
+		"ext-xml": "*",
+		"ext-xmlreader": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~5.4.3 || ~6.5"
 	},
 	"suggest": {
+		"ext-curl": "",
+		"ext-iconv": "",
+		"ext-intl": "",
+		"ext-mbstring": "",
 		"mf2/mf2": "Microformat module that allows for parsing HTML for microformats"
 	},
 	"autoload": {


### PR DESCRIPTION
Required:
- `PCRE`, `XML` and `XMLReader` - Simplepie will start complaining if missing...

Optional:
- `cURL` - If not, `fsockopen` will be used for downloads
- `iconv`, `intl` and `mbstring` - Character encoding support