### PR TITLE
PHP 7.4 compatibility patch.

### DIFF
--- a/library/SimplePie/Cache/File.php
+++ b/library/SimplePie/Cache/File.php
@@ -101,7 +101,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	 */
 	public function save($data)
 	{
-		if (file_exists($this->name) && is_writeable($this->name) || file_exists($this->location) && is_writeable($this->location))
+		if (file_exists($this->name) && is_writable($this->name) || file_exists($this->location) && is_writable($this->location))
 		{
 			if ($data instanceof SimplePie)
 			{


### PR DESCRIPTION
There is a strong likelihood of is_writeable being deprecated when PHP 7.4
is released in the future. To ensure compatibility with PHP 7.4,
is_writable should be used instead.

See: https://wiki.php.net/rfc/deprecations_php_7_4