### PR TITLE
Change to resume support of BusinessWire.com

### DIFF
--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -153,7 +153,8 @@ class SimplePie_Locator
 			$sniffed = $sniffer->get_type();
 			$mime_types = array('application/rss+xml', 'application/rdf+xml',
 			                    'text/rdf', 'application/atom+xml', 'text/xml',
-			                    'application/xml', 'application/x-rss+xml');
+			                    'application/xml', 'application/x-rss+xml',
+					    'application/x-rss+xml, text/xml');
 			if ($check_html)
 			{
 				$mime_types[] = 'text/html';

--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -154,7 +154,7 @@ class SimplePie_Locator
 			$mime_types = array('application/rss+xml', 'application/rdf+xml',
 			                    'text/rdf', 'application/atom+xml', 'text/xml',
 			                    'application/xml', 'application/x-rss+xml',
-					    'application/x-rss+xml, text/xml');
+					    'application/rss+xml, text/xml');
 			if ($check_html)
 			{
 				$mime_types[] = 'text/html';


### PR DESCRIPTION
Our processing of BusinessWire feeds broke around 2019/02/27.

For example:
http://feeds.businesswire.com/BW/Electronic_Design_Automation-rss

This change enabled me to resume processing BusinessWire.