### PR TITLE
PHP 7.4 compatibility fix / implode argument order

### DIFF
--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -575,8 +575,8 @@ class SimplePie_Parse_Date
 	 */
 	public function __construct()
 	{
-		$this->day_pcre = '(' . implode(array_keys($this->day), '|') . ')';
-		$this->month_pcre = '(' . implode(array_keys($this->month), '|') . ')';
+		$this->day_pcre = '(' . implode('|', array_keys($this->day)) . ')';
+		$this->month_pcre = '(' . implode('|', array_keys($this->month)) . ')';
 
 		static $cache;
 		if (!isset($cache[get_class($this)]))


### PR DESCRIPTION
`implode()` takes two parameters, `$glue` and `$pieces`.
For historical reasons, `implode()` accepted these parameters in either order, though it was recommended to use the documented argument order of `implode( $glue, $pieces )`.

PHP 7.4 is slated to deprecate the tolerance for passing the parameters for `implode()` in reverse order.
PHP 8.0 is expected to remove the tolerance for this completely.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
* https://php.net/manual/en/function.implode.php