### PR TITLE
Replace pow() call with `**` operator (micro performance optimization)

### DIFF
--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -724,7 +724,7 @@ class SimplePie_Parse_Date
 			}
 
 			// Convert the number of seconds to an integer, taking decimals into account
-			$second = round((int)$match[6] + (int)$match[7] / pow(10, strlen($match[7])));
+			$second = round((int)$match[6] + (int)$match[7] / (10 ** strlen($match[7])));
 
 			return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
 		}


### PR DESCRIPTION
Since PHP 5.6, we can use the `**` operator to achieve the same result. However, because `**` is a language operator, it is about 4 time faster compared to the `pow()` function call. 

This is purely a micro performance optimization, but an optimization without the a BC break or side effects. May I suggest that we replace the `pow()` as in the commits?

I would also like to mention simplepie/simplepie#620, and it would be great if this could be included in the new release as well, so we can get this into WordPress downstream as well. 

Thank you.