### PR TITLE
Return effective feed URL when asking for non-permanent subscribe_url

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1712,8 +1712,8 @@ class SimplePie
 					}
 					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $file->url), 'spc'));
 				}
-				$this->feed_url = $file->url;
 			}
+			$this->feed_url = $file->url;
 			$locate = null;
 		}
 
@@ -1911,7 +1911,8 @@ class SimplePie
 	 *
 	 * When the 'permanent' mode is disabled (default),
 	 * may or may not be different from the URL passed to {@see set_feed_url()},
-	 * depending on whether auto-discovery was used.
+	 * depending on whether auto-discovery was used, and whether there were
+	 * any redirects along the way.
 	 *
 	 * @since Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
 	 * @todo Support <itunes:new-feed-url>

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -41,30 +41,18 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-require_once dirname(__FILE__) . '/bootstrap.php';
-
-require_once dirname(__FILE__) . '/EncodingTest.php';
-require_once dirname(__FILE__) . '/IRITest.php';
-require_once dirname(__FILE__) . '/LocatorTest.php';
-require_once dirname(__FILE__) . '/ItemTest.php';
-require_once dirname(__FILE__) . '/oldtests.php';
- 
-class AllTests
+class SubscribeUrlTest extends PHPUnit\Framework\TestCase
 {
-	public static function suite()
+	public function testDirectOverrideLegacy()
 	{
-		$suite = new PHPUnit_Framework_TestSuite();
-		$suite->setName('SimplePie');
+		$feed = new SimplePie();
+		$feed->get_registry()->register('File', MockSimplePie_RedirectingFile::class);
+		$feed->enable_cache(false);
+		$feed->set_feed_url('http://example.com/feed/');
 
-		$suite->addTestSuite('CacheTest');
-		$suite->addTestSuite('EncodingTest');
-		$suite->addTestSuite('IRITest');
-		$suite->addTestSuite('LocatorTest');
-		$suite->addTestSuite('HTTPParserTest');
-		$suite->addTestSuite('ItemTest');
-		$suite->addTestSuite('OldTest');
-		$suite->addTestSuite('SubscribeUrlTest');
- 
-		return $suite;
+		$feed->init();
+
+		$this->assertEquals('https://example.com/feed/2019-10-07', $feed->subscribe_url());
+		$this->assertEquals('https://example.com/feed/', $feed->subscribe_url(true));
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,11 +10,26 @@ class MockSimplePie_File extends SimplePie_File
 	public function __construct($url)
 	{
 		$this->url = $url;
+		$this->permanent_url = $url;
 		$this->headers = array(
 			'content-type' => 'application/atom+xml'
 		);
 		$this->method = SIMPLEPIE_FILE_SOURCE_REMOTE;
 		$this->body = '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />';
 		$this->status_code = 200;
+	}
+}
+
+/**
+ * Acts as a fake feed request that simulates first a permanent redirect from http:// URLs to https://,
+ * and then appends a date non-permanently.
+ */
+class MockSimplePie_RedirectingFile extends MockSimplePie_File
+{
+	public function __construct($url)
+	{
+		parent::__construct($url);
+		$this->permanent_url = str_replace('http://', 'https://', $url); // simulate 301
+		$this->url = $this->permanent_url . '2019-10-07'; // simulate 302
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ class MockSimplePie_File extends SimplePie_File
 			'content-type' => 'application/atom+xml'
 		);
 		$this->method = SIMPLEPIE_FILE_SOURCE_REMOTE;
-		$this->body = '<?xml version="1.0" encoding="utf-8"?><feed />';
+		$this->body = '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />';
 		$this->status_code = 200;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ class MockSimplePie_File extends SimplePie_File
 			'content-type' => 'application/atom+xml'
 		);
 		$this->method = SIMPLEPIE_FILE_SOURCE_REMOTE;
-		$this->body = '<?xml charset="utf-8"?><feed />';
+		$this->body = '<?xml version="1.0" encoding="utf-8"?><feed />';
 		$this->status_code = 200;
 	}
 }


### PR DESCRIPTION
`subscribe_url` method supports two modes: permanent and non-permanent. And while the URL for the first one is obtained from the `File` after it has been fetched, discounting auto-discovery, the latter one remains the same from the time `set_feed_url` was called.

Because even the permanent mode concerns itself with redirection (although limited to a potential 301 as a first link in the chain), I would expect the non-permanent one to care doubly so.

This patch enables just that – after the feed is fetched, url property is updated, regardless of auto-discovery being done.

Fixes: #2