### PR TITLE
fix Trying to access array offset on value of type null

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -958,7 +958,7 @@ class SimplePie_Item
 	public function get_link($key = 0, $rel = 'alternate')
 	{
 		$links = $this->get_links($rel);
-		if ($links[$key] !== null)
+		if ($links && $links[$key] !== null)
 		{
 			return $links[$key];
 		}


### PR DESCRIPTION
With 7.4.0RC3

```
There were 8 errors:

1) OldTest::testOld with data set #682 (SimplePie_First_Item_Permalink_Test_Atom_03_Enclosure Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

2) OldTest::testOld with data set #684 (SimplePie_First_Item_Permalink_Test_Atom_10_Enclosure Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

3) OldTest::testOld with data set #688 (SimplePie_First_Item_Permalink_Test_Bug_10_Test_2 Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

4) OldTest::testOld with data set #689 (SimplePie_First_Item_Permalink_Test_Bug_10_Test_3 Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

5) OldTest::testOld with data set #690 (SimplePie_First_Item_Permalink_Test_Bug_156_Test_0 Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

6) OldTest::testOld with data set #702 (SimplePie_First_Item_Permalink_Test_RSS_091_Userland_Atom_03_Link_Enclosure Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

7) OldTest::testOld with data set #704 (SimplePie_First_Item_Permalink_Test_RSS_091_Userland_Atom_10_Link_Enclosure Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

8) OldTest::testOld with data set #712 (SimplePie_First_Item_Permalink_Test_RSS_20_Enclosure Object (...))
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:961
/dev/shm/BUILDROOT/php-simplepie-1.5.2-1.fc29.remi.x86_64/usr/share/php/php-simplepie/SimplePie/Item.php:936
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/functions.php:328
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests/compat_test_harness.php:40
/dev/shm/BUILD/simplepie-173663382a9346acd53df60c7ffb20689c9cf1f6/tests/oldtests.php:82

ERRORS!
Tests: 1313, Assertions: 1413, Errors: 8.

```