### PR TITLE
Distinct cache for force_feed

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1711,7 +1711,7 @@ class SimplePie
 					{
 						trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
 					}
-					$url = $this->feed_url . ($this->force_feed ? '#force_feed' : '');
+					$url = $this->feed_url . '#force_feed';
 					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $url), 'spc'));
 				}
 			}

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1711,8 +1711,7 @@ class SimplePie
 					{
 						trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
 					}
-					$url = $this->feed_url . '#force_feed';
-					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $url), 'spc'));
+					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $file->url), 'spc'));
 				}
 			}
 			$this->feed_url = $file->url;

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1373,7 +1373,8 @@ class SimplePie
 			// Decide whether to enable caching
 			if ($this->cache && $parsed_feed_url['scheme'] !== '')
 			{
-				$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $this->feed_url), 'spc'));
+				$url = $this->feed_url . ($this->force_feed ? '#force_feed' : '');
+				$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $url), 'spc'));
 			}
 
 			// Fetch the data via SimplePie_File into $this->raw_data
@@ -1710,7 +1711,8 @@ class SimplePie
 					{
 						trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
 					}
-					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $file->url), 'spc'));
+					$url = $this->feed_url . ($this->force_feed ? '#force_feed' : '');
+					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $url), 'spc'));
 				}
 			}
 			$this->feed_url = $file->url;


### PR DESCRIPTION
Ensure that feeds retrieved with the force_feed option do not share the
same cache than feeds retrieved without this option.
Otherwise, in a context with multiple clients, clients without the
force_feed option would have a behaviour (working or not) depending
entirely on what other clients with force_feed are doing. In other
words, it procudes a side-effect difficult to predict, which should be
avoided.