### PR TITLE
Remove old PHP directive conditionals

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -706,7 +706,7 @@ class SimplePie
 	 */
 	public function __destruct()
 	{
-		if ((version_compare(PHP_VERSION, '5.6', '<') || !gc_enabled()) && !ini_get('zend.ze1_compatibility_mode'))
+		if (!gc_enabled())
 		{
 			if (!empty($this->data['items']))
 			{

--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -109,7 +109,7 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_REFERER, $url);
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
-				if (!ini_get('open_basedir') && !ini_get('safe_mode') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
+				if (!ini_get('open_basedir') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
 				{
 					curl_setopt($fp, CURLOPT_FOLLOWLOCATION, 1);
 					curl_setopt($fp, CURLOPT_MAXREDIRS, $redirects);

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -121,7 +121,7 @@ class SimplePie_Item
 	 */
 	public function __destruct()
 	{
-		if ((version_compare(PHP_VERSION, '5.6', '<') || !gc_enabled()) && !ini_get('zend.ze1_compatibility_mode'))
+		if (!gc_enabled())
 		{
 			unset($this->feed);
 		}


### PR DESCRIPTION
Since the minimum PHP version was raised to 5.6, there are two PHP directive checks that can be safely removed from conditional statements:

- [`zend.ze1_compatibility_mode`](https://www.php.net/manual/en/ini.core.php#ini.zend.ze1-compatibility-mode)
- [`safe_mode`](https://www.php.net/manual/en/ini.sect.safe-mode.php#ini.safe-mode)

Both of these directives were deprecated in PHP 5.3 and removed completely in 5.4, so the conditionals will always return `true`. I have also removed the `version_compare()` checks in the same `if` statements as they were checking for PHP < 5.6 (which is no longer supported).

- [X] Removed checks for removed PHP directives.
- [X] Removed version checks for PHP < 5.6 in the same control structures.

Removing these will prevent false positives when running code analysis tools such as PHP_CodeSniffer where rulesets flag instances of deprecated and removed directives (such as in the [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ruleset).