### PR TITLE
PHP 8.0: handle removal of get_magic_quotes_gpc()

### DIFF
--- a/demo/test.php
+++ b/demo/test.php
@@ -6,7 +6,7 @@ include_once('../idn/idna_convert.class.php');
 $feed = new SimplePie();
 if (isset($_GET['feed']) && $_GET['feed'] !== '')
 {
-	if (get_magic_quotes_gpc())
+	if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc())
 	{
 		$_GET['feed'] = stripslashes($_GET['feed']);
 	}


### PR DESCRIPTION
The `get_magic_quotes_gpc()` function was deprecated in PHP 7.4 and removed in PHP 8.0.

Any function call to the `get_magic_quotes_gpc()` method now needs to be wrapped in a `function_exists()`.

