### PR TITLE
PHP 8.0: required parameters are no longer allowed after optional parameters

### DIFF
--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -94,7 +94,7 @@ class SimplePie_Locator
 		$this->registry = $registry;
 	}
 
-	public function find($type = SIMPLEPIE_LOCATOR_ALL, &$working)
+	public function find($type = SIMPLEPIE_LOCATOR_ALL, &$working = null)
 	{
 		if ($this->is_feed($this->file))
 		{


### PR DESCRIPTION
By giving the `&$working` parameter a default value, this issue is circumvented without breaking bckward-compatibility.
