### PR TITLE
PHP 8.0: prevent ValueError for invalid encoding

### DIFF
--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -364,11 +364,12 @@ class SimplePie_Misc
 		}
 
 		// Check that the encoding is supported
-		if (@mb_convert_encoding("\x80", 'UTF-16BE', $input) === "\x00\x80")
+		if (!in_array($input, mb_list_encodings()))
 		{
 			return false;
 		}
-		if (!in_array($input, mb_list_encodings()))
+
+		if (@mb_convert_encoding("\x80", 'UTF-16BE', $input) === "\x00\x80")
 		{
 			return false;
 		}


### PR DESCRIPTION
Check the encoding against the list of supported encodings before ever calling `mb_convert_encoding()`.

This prevents a fatal `ValueError` on PHP 8.0 when passing an invalid encoding and maintains the documented behaviour of returning `false` on an invalid encoding.