### PR TITLE
Fix typo in MIME type in Content_Type_Sniffer

### DIFF
--- a/library/SimplePie/Content/Type/Sniffer.php
+++ b/library/SimplePie/Content/Type/Sniffer.php
@@ -150,7 +150,7 @@ class SimplePie_Content_Type_Sniffer
 		}
 		elseif (preg_match('/[\x00-\x08\x0E-\x1A\x1C-\x1F]/', $this->file->body))
 		{
-			return 'application/octect-stream';
+			return 'application/octet-stream';
 		}
 
 		return 'text/plain';


### PR DESCRIPTION
This surprised me. I may be misunderstanding something, but I believe `application/octet-stream` is the right MIME type for this function, seeing [there's no](https://www.iana.org/assignments/media-types/media-types.xhtml) `octect-stream`. 