### PR TITLE
Fix PHP8 crash due to insufficient isset test

### DIFF
--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -1803,7 +1803,7 @@ class SimplePie_Item
 							}
 							if (isset($content['attribs']['']['fileSize']))
 							{
-								$length = ceil($content['attribs']['']['fileSize']);
+								$length = intval($content['attribs']['']['fileSize']);
 							}
 							if (isset($content['attribs']['']['medium']))
 							{
@@ -2425,7 +2425,7 @@ class SimplePie_Item
 						}
 						if (isset($content['attribs']['']['fileSize']))
 						{
-							$length = ceil($content['attribs']['']['fileSize']);
+							$length = intval($content['attribs']['']['fileSize']);
 						}
 						if (isset($content['attribs']['']['medium']))
 						{
@@ -2790,7 +2790,7 @@ class SimplePie_Item
 					}
 					if (isset($link['attribs']['']['length']))
 					{
-						$length = ceil($link['attribs']['']['length']);
+						$length = intval($link['attribs']['']['length']);
 					}
 					if (isset($link['attribs']['']['title']))
 					{
@@ -2833,7 +2833,7 @@ class SimplePie_Item
 					}
 					if (isset($link['attribs']['']['length']))
 					{
-						$length = ceil($link['attribs']['']['length']);
+						$length = intval($link['attribs']['']['length']);
 					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
@@ -2868,7 +2868,7 @@ class SimplePie_Item
 					}
 					if (isset($enclosure[0]['attribs']['']['length']))
 					{
-						$length = ceil($enclosure[0]['attribs']['']['length']);
+						$length = intval($enclosure[0]['attribs']['']['length']);
 					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3401 (crash with PHP 8+)

`ceil()` crashes in PHP8+ in case of invalid input such as empty string.
`intval()` fixes the problem with almost identical behaviour than `ceil()` in PHP7- (except for floating point values)

#fix FreshRSS/FreshRSS#3401 (crash with PHP 8+)

Example with feed http://podcast.hr2.de/derTag/podcast.xml

```xml
<enclosure url="https://mp3podcasthr-a.akamaihd.net:443/mp3/podcast/derTag/derTag_20210129_87093232.mp3"
length="" type="audio/mpeg"/>
```

`isset("")` passes and then `ceil("")` crashes due to wrong type in PHP8+:

```
Uncaught TypeError: ceil(): Argument #1 ($num) must be of type
int|float, string given in ./SimplePie/SimplePie/Item.php:2871
```