### PR TITLE
PHP8 catch ValueError for loadHTML()

### DIFF
--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -75,12 +75,19 @@ class SimplePie_Locator
 		$this->force_fsockopen = $force_fsockopen;
 		$this->curl_options = $curl_options;
 
-		if (class_exists('DOMDocument'))
+		if (class_exists('DOMDocument') && $this->file->body != '')
 		{
 			$this->dom = new DOMDocument();
 
 			set_error_handler(array('SimplePie_Misc', 'silence_errors'));
-			$this->dom->loadHTML($this->file->body);
+			try
+			{
+				$this->dom->loadHTML($this->file->body);
+			}
+			catch (Throwable $ex)
+			{
+				$this->dom = null;
+			}
 			restore_error_handler();
 		}
 		else


### PR DESCRIPTION
Fix
```
PHP Fatal error:  Uncaught ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty in /SimplePie/Locator.php:83
```

`set_error_handler` does not catch ValueError in PHP8.
The patch is compatible PHP5 and PHP7.

Fix downstream bug https://github.com/FreshRSS/FreshRSS/issues/3537
Downstream PR https://github.com/FreshRSS/FreshRSS/pull/3547