### PR TITLE
Force HTTPS for selected domains

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1153,6 +1153,7 @@ class SimplePie
 			$this->strip_attributes(false);
 			$this->add_attributes(false);
 			$this->set_image_handler(false);
+			$this->set_https_domains(array());
 		}
 	}
 
@@ -1253,6 +1254,19 @@ class SimplePie
 	public function set_url_replacements($element_attribute = null)
 	{
 		$this->sanitize->set_url_replacements($element_attribute);
+	}
+
+	/**
+	 * Set the list of domains for which to force HTTPS.
+	 * @see SimplePie_Sanitize::set_https_domains()
+	 * @param array List of HTTPS domains. Example array('biz', 'example.com', 'example.org', 'www.example.net').
+	 */
+	public function set_https_domains($domains = array())
+	{
+		if (is_array($domains))
+		{
+			$this->sanitize->set_https_domains($domains);
+		}
 	}
 
 	/**

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -2862,6 +2862,7 @@ class SimplePie_Item
 					$width = null;
 
 					$url = $this->sanitize($enclosure[0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($enclosure[0]));
+					$url = $this->feed->sanitize->https_url($url);
 					if (isset($enclosure[0]['attribs']['']['type']))
 					{
 						$type = $this->sanitize($enclosure[0]['attribs']['']['type'], SIMPLEPIE_CONSTRUCT_TEXT);

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -511,9 +511,9 @@ class SimplePie_Sanitize
 					if ($element->hasAttribute($attribute))
 					{
 						$value = $this->registry->call('Misc', 'absolutize_url', array($element->getAttribute($attribute), $this->base));
-						$value = $this->https_url($value);
-						if ($value)
+						if ($value !== false)
 						{
+							$value = $this->https_url($value);
 							$element->setAttribute($attribute, $value);
 						}
 					}

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -72,6 +72,14 @@ class SimplePie_Sanitize
 	var $force_fsockopen = false;
 	var $replace_url_attributes = null;
 
+	/**
+	 * List of domains for which to force HTTPS.
+	 * @see SimplePie_Sanitize::set_https_domains()
+	 * Array is a tree split at DNS levels. Example:
+	 * array('biz' => true, 'com' => array('example' => true), 'net' => array('example') => array('www' => true))
+	 */
+	var $https_domains = array();
+
 	public function __construct()
 	{
 		// Set defaults
@@ -239,6 +247,68 @@ class SimplePie_Sanitize
 			);
 		}
 		$this->replace_url_attributes = (array) $element_attribute;
+	}
+
+	/**
+	 * Set the list of domains for which to force HTTPS.
+	 * @see SimplePie_Misc::https_url()
+	 * Example array('biz', 'example.com', 'example.org', 'www.example.net');
+	 */
+	public function set_https_domains($domains)
+	{
+		$this->https_domains = array();
+		foreach ($domains as $domain)
+		{
+			$domain = trim($domain, ". \t\n\r\0\x0B");
+			$segments = array_reverse(explode('.', $domain));
+			$node =& $this->https_domains;
+			foreach ($segments as $segment)
+			{//Build a tree
+				if ($node === true)
+				{
+					break;
+				}
+				if (!isset($node[$segment]))
+				{
+					$node[$segment] = array();
+				}
+				$node =& $node[$segment];
+			}
+			$node = true;
+		}
+	}
+
+	/**
+	 * Check if the domain is in the list of forced HTTPS.
+	 */
+	protected function is_https_domain($domain)
+	{
+		$domain = trim($domain, '. ');
+		$segments = array_reverse(explode('.', $domain));
+		$node =& $this->https_domains;
+		foreach ($segments as $segment)
+		{//Explore the tree
+			if (isset($node[$segment]))
+			{
+				$node =& $node[$segment];
+			}
+			else
+			{
+				break;
+			}
+		}
+		return $node === true;
+	}
+
+	/**
+	 * Force HTTPS for selected Web sites.
+	 */
+	public function https_url($url)
+	{
+		return (strtolower(substr($url, 0, 7)) === 'http://') &&
+			$this->is_https_domain(parse_url($url, PHP_URL_HOST)) ?
+			substr_replace($url, 's', 4, 0) :	//Add the 's' to HTTPS
+			$url;
 	}
 
 	public function sanitize($data, $type, $base = '')
@@ -441,7 +511,8 @@ class SimplePie_Sanitize
 					if ($element->hasAttribute($attribute))
 					{
 						$value = $this->registry->call('Misc', 'absolutize_url', array($element->getAttribute($attribute), $this->base));
-						if ($value !== false)
+						$value = $this->https_url($value);
+						if ($value)
 						{
 							$element->setAttribute($attribute, $value);
 						}


### PR DESCRIPTION
Some feeds have embedded references using e.g. `//youtube.com/` or `http://youtube.com/` which are increasingly failing as HTTPS is required.

This PR allows setting a list of domains for which to force HTTPS with a new function `SimplePie::set_https_domains([])`

Downstream PR: https://github.com/FreshRSS/FreshRSS/pull/1087
https://github.com/FreshRSS/FreshRSS/pull/1098