### PR TITLE
Remove HTTP credentials in HTTP Referer

### DIFF
--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -106,7 +106,7 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_FAILONERROR, 1);
 				curl_setopt($fp, CURLOPT_TIMEOUT, $timeout);
 				curl_setopt($fp, CURLOPT_CONNECTTIMEOUT, $timeout);
-				curl_setopt($fp, CURLOPT_REFERER, $url);
+				curl_setopt($fp, CURLOPT_REFERER, SimplePie_Misc::url_remove_credentials($url));
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
 				foreach ($curl_options as $curl_param => $curl_value) {

--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -2260,4 +2260,14 @@ function embed_wmedia(width, height, link) {
 	{
 		// No-op
 	}
+
+	/**
+	 * Sanitize a URL by removing HTTP credentials.
+	 * @param string $url the URL to sanitize.
+	 * @return string the same URL without HTTP credentials.
+	 */
+	public static function url_remove_credentials($url)
+	{
+		return preg_replace('#^(https?://)[^/:@]+:[^/:@]+@#i', '$1', $url);
+	}
 }


### PR DESCRIPTION
The HTTP Referer might appear in various logs and should not contain HTTP credentials
`https://user:password@example.net/`

New function `SimplePie_Misc::url_remove_credentials($url)` to strip credentials from a URL, before such a use.

Piece of this downstream PR: https://github.com/FreshRSS/FreshRSS/pull/815

(I use this function in several other circumstances, which will be the topic of distinct PRs)