### PR TITLE
PHP 8.1: fix "passing null to non-nullable" deprecation notice

### DIFF
--- a/library/SimplePie/Enclosure.php
+++ b/library/SimplePie/Enclosure.php
@@ -1152,7 +1152,12 @@ class SimplePie_Enclosure
 		// If we encounter an unsupported mime-type, check the file extension and guess intelligently.
 		if (!in_array($type, array_merge($types_flash, $types_fmedia, $types_quicktime, $types_wmedia, $types_mp3)))
 		{
-			switch (strtolower($this->get_extension()))
+			$extension = $this->get_extension();
+			if ($extension === null) {
+				return null;
+			}
+
+			switch (strtolower($extension))
 			{
 				// Audio mime-types
 				case 'aac':


### PR DESCRIPTION
As of PHP 8.1, passing `null` to non-nullable arguments of PHP native functions is deprecated.
Ref: https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

The `SimplePie_Enclosure::get_extension()` returns the file extension as a string or `null`.

In the `SimplePie_Enclosure::get_real_type()` method, the return value of a call to the `get_extension()` method was directly passed on to the PHP native `strtolower()` function, leading to the PHP 8.1 `strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice.

This small change fixes this issue without BC break.

This is covered by 36 of the existing tests in the `OldTest` class.