### PR TITLE
Tests: PHPUnit cross-version compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ SimplePie.compiled.php
 bin/
 vendor/
 composer.lock
+phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 vendor/
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"ext-xmlreader": "*"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~5.4.3 || ~6.5"
+		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"suggest": {
 		"ext-curl": "",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="tests/bootstrap.php">
-	<testsuites>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    backupGlobals="false"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    >
+    <testsuites>
         <testsuite name="SimplePie Test Suite">
             <directory>./tests</directory>
         </testsuite>
         <testsuite name="Old Tests">
-			<file>tests/oldtests.php</file>
+            <file>tests/oldtests.php</file>
         </testsuite>
     </testsuites>
 
     <filter>
-	    <blacklist>
-		    <directory suffix=".php">tests</directory>
-        </blacklist>
-        <whitelist>
-            <directory suffix=".php">SimplePie</directory>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">library</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -41,6 +41,8 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
 /**
  * This is a dirty, dirty hack
  */
@@ -74,11 +76,12 @@ class Mock_CacheNew extends SimplePie_Cache
 
 class CacheTest extends PHPUnit\Framework\TestCase
 {
-	/**
-	 * @expectedException Exception_Success
-	 */
+	use ExpectPHPException;
+
 	public function testDirectOverrideLegacy()
 	{
+		$this->expectException('Exception_Success');
+
 		$feed = new SimplePie();
 		$feed->set_cache_class('Mock_CacheLegacy');
 		$feed->get_registry()->register('File', 'MockSimplePie_File');
@@ -87,11 +90,10 @@ class CacheTest extends PHPUnit\Framework\TestCase
 		$feed->init();
 	}
 
-	/**
-	 * @expectedException Exception_Success
-	 */
 	public function testDirectOverrideNew()
 	{
+		$this->expectException('Exception_Success');
+
 		$feed = new SimplePie();
 		$feed->get_registry()->register('Cache', 'Mock_CacheNew');
 		$feed->get_registry()->register('File', 'MockSimplePie_File');

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -107,7 +107,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	public function test_convert_UTF8($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEquals($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
+		$this->assertEqualsBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
 	}
 
 	/**
@@ -120,7 +120,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
 		if (extension_loaded('mbstring')) {
-			$this->assertEquals($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
 		}
 	}
 
@@ -134,7 +134,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
 		if (extension_loaded('iconv')) {
-			$this->assertEquals($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
+			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
 		}
 	}
 
@@ -150,7 +150,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		if (version_compare(phpversion(), '5.5', '>=') &&
 			extension_loaded('intl')
 		) {
-			$this->assertEquals($expected, Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
+			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
 		}
 	}
 	/**#@-*/
@@ -173,7 +173,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	public function test_convert_UTF16($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEquals($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
+		$this->assertEqualsBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
 	}
 	/**#@-*/
 
@@ -182,7 +182,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse(SimplePie_Misc::change_encoding('', 'TESTENC', 'UTF-8'));
 	}
 
-	public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
+	public static function assertEqualsBin2Hex($expected, $actual, $message = '')
 	{
 		if (is_string($expected))
 		{
@@ -192,7 +192,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		{
 			$actual = bin2hex($actual);
 		}
-		parent::assertEquals($expected, $actual, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
+		static::assertEquals($expected, $actual, $message);
 	}
 }
 

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -42,14 +42,11 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
 class IRITest extends PHPUnit\Framework\TestCase
 {
-    public static function setUpBeforeClass()
-    {
-        if(class_exists('PHPUnit_Framework_Error_Notice')) {
-            class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
-        }
-    }
+	use ExpectPHPException;
 
 	public static function rfc3986_tests()
 	{
@@ -460,11 +457,10 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$this->assertEquals('test', $iri->fragment);
 	}
 
-	/**
-	 * @expectedException PHPUnit\Framework\Error\Notice
-	 */
 	public function testNonexistantProperty()
 	{
+		$this->expectNotice();
+
 		$iri = new SimplePie_IRI();
 		$this->assertFalse(isset($iri->nonexistant_prop));
 		$should_fail = $iri->nonexistant_prop;

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -45,8 +45,12 @@
 
 require_once dirname(__FILE__) . '/bootstrap.php';
 
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
 class LocatorTest extends PHPUnit\Framework\TestCase
 {
+	use ExpectPHPException;
+
 	public static function feedmimetypes()
 	{
 		return array(
@@ -104,11 +108,10 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals($locator->find(SIMPLEPIE_LOCATOR_ALL, $found), $data);
 	}
 
-	/**
-	 * @expectedException SimplePie_Exception
-	 */
 	public function testFailDiscoveryNoDOM()
 	{
+		$this->expectException('SimplePie_Exception');
+
 		$data = new MockSimplePie_File('http://example.com/feed.xml');
 		$data->headers['content-type'] = 'text/html';
 		$data->body = '<!DOCTYPE html><html><body>Hi!</body></html>';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
-require_once dirname(dirname(__FILE__)) . '/autoloader.php';
+require_once dirname(__DIR__) . '/autoloader.php';
+require_once dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
 /**
  * Acts as a fake feed request


### PR DESCRIPTION
This PR makes the test suite cross-version compatible with PHPUnit 5.x-9.x, which then allows the tests to be run on the full range of supported PHP versions, including PHP 8.1 (beta).

Note: this doesn't mean the tests will _pass_, but test failures will/should be addressed in separate PRs.

As this test suite uses a limited set of the PHPUnit functionality, not that much needed to be done and where necessary, I've just added a trait to an individual test file.

If in the future, you'd want the full range of polyfills to be available at all times to all tests, I'd recommend to add a generic `SimplePieTestCase` which either extends one of the Polyfill test cases or includes all the Polyfills traits. The actual test classes can then all extend from that `TestCase`. Or alternatively, all test classes could extend one of the Polyfill test cases instead of the PHPUnit base TestCase.

Fixes #663

## Commit Details

### Tests: make config cross-version compatible

PHPUnit config file:

* Add `backupGlobals="false"`.
    The default value for this setting changed in PHPUnit 6 from `true` to `false`. By explicitly setting it to `false`, the behaviour for the tests will be consistent PHPUnit cross-version.
* Remove the `blacklist` element. This element hasn't been supported since PHPUnit 5.0.
* Point to the correct directory for the source code to allow for recording code coverage.
* Make sure that all src files are taken into consideration when calculating code coverage.
* Add XSD schema reference.
    Note: the config as-is will now validate for PHPUnit 4.4-9.2. For PHPUnit 9.3, the code coverage terminology has changed, though the "old" configuration is still supported.
    If needs be (PHPUnit 10), the config can be updated on the fly by using `--migrate-configuration`.

Other:
* Ignore a locally overloaded PHPUnit config file using the standard `phpunit.xml` file name.

### Composer: add dependency on the PHPUnit Polyfills package

* Adds a dev dependency to the `yoast/phpunit-polyfills` package.
* As that package already requires and manages the installable versions for PHPUnit, remove this as an explicit requirement from `require-dev` in favour of letting the PHPUnit Polyfills package manage the versions.
    This will update the supported PHPUnit versions from `~5.4.3 || ~6.5` to `^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0`.
    Note: the supported versions for PHPUnit 5.x are very specific and restrictive as it specifically targets the versions in which the "forward compatible" alias files for the namespaced classes are available.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test case and test listener.

Refs:
* https://github.com/Yoast/PHPUnit-Polyfills/

Includes
* Adding the PHPUnit cache file, which is automatically created in PHPUnit 8 and 9, to the `.gitignore` file.
* Adding a `require_once` statement to load the PHPUnit Polyfills autoload file from the test bootstrap.

### Tests: switch out @ExpectedException annotations

These annotations are no longer supported in recent PHPUnit versions.

For PHP native errors/warnings/notices, the `TestCase::expectError()`, `TestCase::expectWarning()`, `TestCase::expectNotice()` and `TestCase::expectDeprecation()` methods (and variants) should be used.

For (custom) exceptions, the `TestCase::expectException()` method (and variants) should be used.

This also removes the need for the `setUpBeforeClass()` method in the `IRITest`, which only created an alias for a PHPUnit class.

The new methods and their variants are polyfilled via the PHPUnit Polyfill repo via the included trait.

### EncodingTest: rename a custom assertion

The method `assertEquals()` is a PHPUnit native method and if it is overloaded, the method signature is expected to be the same as the method signature in PHPUnit itself.

However, the method signature for this method has changed a couple of times across PHPUnit versions.

The simplest way to get round this is to rename the custom assertion to not overlap with a PHPUnit native method name.

