### PR TITLE
CacheTest: handle different exceptions PHP cross-version

### DIFF
--- a/library/SimplePie/Registry.php
+++ b/library/SimplePie/Registry.php
@@ -208,7 +208,8 @@ class SimplePie_Registry
 			{
 				case 'Cache':
 					// For backwards compatibility with old non-static
-					// Cache::create() methods
+					// Cache::create() methods in PHP < 8.0.
+					// No longer supported as of PHP 8.0.
 					if ($method === 'get_handler')
 					{
 						$result = @call_user_func_array(array($class, 'create'), $parameters);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -80,7 +80,14 @@ class CacheTest extends PHPUnit\Framework\TestCase
 
 	public function testDirectOverrideLegacy()
 	{
-		$this->expectException('Exception_Success');
+		if (PHP_VERSION_ID < 80000) {
+			$this->expectException('Exception_Success');
+		} else {
+			// PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
+			// This is no longer supported in PHP, so there is just no way to continue to provide BC
+			// for the old non-static cache methods.
+			$this->expectError();
+		}
 
 		$feed = new SimplePie();
 		$feed->set_cache_class('Mock_CacheLegacy');


### PR DESCRIPTION
The legacy manner of caching was PHP deprecated for quite a while already, but can no longer be supported in PHP 8 as support for calling a non-static method statically has been removed.

This updates the inline comments in the `SimplePie_Registry::call()` method along those lines and adjusts the exception expected by the `CacheTest::testDirectOverrideLegacy()` to match.