### PR TITLE
Tests: use strict assertions

### DIFF
--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -107,7 +107,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	public function test_convert_UTF8($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEqualsBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
+		$this->assertSameBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
 	}
 
 	/**
@@ -120,7 +120,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
 		if (extension_loaded('mbstring')) {
-			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+			$this->assertSameBin2Hex($expected, Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
 		}
 	}
 
@@ -134,7 +134,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
 		if (extension_loaded('iconv')) {
-			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
+			$this->assertSameBin2Hex($expected, Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
 		}
 	}
 
@@ -150,7 +150,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		if (version_compare(phpversion(), '5.5', '>=') &&
 			extension_loaded('intl')
 		) {
-			$this->assertEqualsBin2Hex($expected, Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
+			$this->assertSameBin2Hex($expected, Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
 		}
 	}
 	/**#@-*/
@@ -173,7 +173,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 	public function test_convert_UTF16($input, $expected, $encoding)
 	{
 		$encoding = SimplePie_Misc::encoding($encoding);
-		$this->assertEqualsBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
+		$this->assertSameBin2Hex($expected, SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
 	}
 	/**#@-*/
 
@@ -182,7 +182,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse(SimplePie_Misc::change_encoding('', 'TESTENC', 'UTF-8'));
 	}
 
-	public static function assertEqualsBin2Hex($expected, $actual, $message = '')
+	public static function assertSameBin2Hex($expected, $actual, $message = '')
 	{
 		if (is_string($expected))
 		{
@@ -192,7 +192,7 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 		{
 			$actual = bin2hex($actual);
 		}
-		static::assertEquals($expected, $actual, $message);
+		static::assertSame($expected, $actual, $message);
 	}
 }
 

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -74,11 +74,11 @@ class HTTPParserTest extends PHPUnit\Framework\TestCase
 		$data = SimplePie_HTTP_Parser::prepareHeaders($data);
 		$parser = new SimplePie_HTTP_Parser($data);
 		$this->assertTrue($parser->parse());
-		$this->assertEquals(1.1, $parser->http_version);
-		$this->assertEquals(200, $parser->status_code);
-		$this->assertEquals('OK', $parser->reason);
-		$this->assertEquals(array('content-type' => 'text/plain'), $parser->headers);
-		$this->assertEquals($expected, $parser->body);
+		$this->assertSame(1.1, $parser->http_version);
+		$this->assertSame(200, $parser->status_code);
+		$this->assertSame('OK', $parser->reason);
+		$this->assertSame(array('content-type' => 'text/plain'), $parser->headers);
+		$this->assertSame($expected, $parser->body);
 
 	}
 
@@ -91,11 +91,11 @@ class HTTPParserTest extends PHPUnit\Framework\TestCase
 		$data = SimplePie_HTTP_Parser::prepareHeaders($data);
 		$parser = new SimplePie_HTTP_Parser($data);
 		$this->assertTrue($parser->parse());
-		$this->assertEquals(1.1, $parser->http_version);
-		$this->assertEquals(200, $parser->status_code);
-		$this->assertEquals('OK', $parser->reason);
-		$this->assertEquals(array('content-type' => 'text/plain'), $parser->headers);
-		$this->assertEquals($expected, $parser->body);
+		$this->assertSame(1.1, $parser->http_version);
+		$this->assertSame(200, $parser->status_code);
+		$this->assertSame('OK', $parser->reason);
+		$this->assertSame(array('content-type' => 'text/plain'), $parser->headers);
+		$this->assertSame($expected, $parser->body);
 	}
 
 	/**
@@ -107,10 +107,10 @@ class HTTPParserTest extends PHPUnit\Framework\TestCase
 		$data = SimplePie_HTTP_Parser::prepareHeaders($data);
 		$parser = new SimplePie_HTTP_Parser($data);
 		$this->assertTrue($parser->parse());
-		$this->assertEquals(1.1, $parser->http_version);
-		$this->assertEquals(200, $parser->status_code);
-		$this->assertEquals('OK', $parser->reason);
-		$this->assertEquals(array('content-type' => 'text/plain'), $parser->headers);
-		$this->assertEquals($expected, $parser->body);
+		$this->assertSame(1.1, $parser->http_version);
+		$this->assertSame(200, $parser->status_code);
+		$this->assertSame('OK', $parser->reason);
+		$this->assertSame(array('content-type' => 'text/plain'), $parser->headers);
+		$this->assertSame($expected, $parser->body);
 	}
 }

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -104,7 +104,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testStringRFC3986($relative, $expected)
 	{
 		$base = new SimplePie_IRI('http://a/b/c/d;p?q');
-		$this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
+		$this->assertSame($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
 	}
 
 	/**
@@ -123,8 +123,8 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testBothStringRFC3986($relative, $expected)
 	{
 		$base = 'http://a/b/c/d;p?q';
-		$this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
-		$this->assertEquals($expected, (string) SimplePie_IRI::absolutize($base, $relative));
+		$this->assertSame($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
+		$this->assertSame($expected, (string) SimplePie_IRI::absolutize($base, $relative));
 	}
 
 	public static function sp_tests()
@@ -155,7 +155,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testStringSP($base, $relative, $expected)
 	{
 		$base = new SimplePie_IRI($base);
-		$this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
+		$this->assertSame($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
 	}
 
 	/**
@@ -185,7 +185,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	{
 		$base = new SimplePie_IRI('http://example.com/');
 		$base->set_query($query);
-		$this->assertEquals($expected, $base->get_iri());
+		$this->assertSame($expected, $base->get_iri());
 	}
 
 	/**
@@ -213,7 +213,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testAbsolutizeString($base, $relative, $expected)
 	{
 		$base = new SimplePie_IRI($base);
-		$this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
+		$this->assertSame($expected, SimplePie_IRI::absolutize($base, $relative)->get_iri());
 	}
 
 	/**
@@ -315,7 +315,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testStringNormalization($input, $output)
 	{
 		$input = new SimplePie_IRI($input);
-		$this->assertEquals($output, $input->get_iri());
+		$this->assertSame($output, $input->get_iri());
 	}
 
 	/**
@@ -342,7 +342,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 	public function testURIConversion($input, $output)
 	{
 		$input = new SimplePie_IRI($input);
-		$this->assertEquals($output, $input->get_uri());
+		$this->assertSame($output, $input->get_uri());
 	}
 
 	public static function equivalence_tests()
@@ -415,12 +415,12 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$iri->path = '/test/';
 		$iri->fragment = 'test';
 
-		$this->assertEquals('http', $iri->scheme);
-		$this->assertEquals('user:password', $iri->userinfo);
-		$this->assertEquals('example.com', $iri->host);
-		$this->assertEquals(80, $iri->port);
-		$this->assertEquals('/test/', $iri->path);
-		$this->assertEquals('test', $iri->fragment);
+		$this->assertSame('http', $iri->scheme);
+		$this->assertSame('user:password', $iri->userinfo);
+		$this->assertSame('example.com', $iri->host);
+		$this->assertSame(80, $iri->port);
+		$this->assertSame('/test/', $iri->path);
+		$this->assertSame('test', $iri->fragment);
 	}
 
 	public function testReadAliased()
@@ -432,12 +432,12 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$iri->path = '/test/';
 		$iri->fragment = 'test';
 
-		$this->assertEquals('http', $iri->scheme);
-		$this->assertEquals('user:password', $iri->userinfo);
-		$this->assertEquals('example.com', $iri->host);
-		$this->assertEquals(80, $iri->port);
-		$this->assertEquals('/test/', $iri->path);
-		$this->assertEquals('test', $iri->fragment);
+		$this->assertSame('http', $iri->scheme);
+		$this->assertSame('user:password', $iri->userinfo);
+		$this->assertSame('example.com', $iri->host);
+		$this->assertSame(80, $iri->port);
+		$this->assertSame('/test/', $iri->path);
+		$this->assertSame('test', $iri->fragment);
 	}
 
 	public function testWriteAliased()
@@ -449,12 +449,12 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$iri->path = '/test/';
 		$iri->fragment = 'test';
 
-		$this->assertEquals('http', $iri->scheme);
-		$this->assertEquals('user:password', $iri->userinfo);
-		$this->assertEquals('example.com', $iri->host);
-		$this->assertEquals(80, $iri->port);
-		$this->assertEquals('/test/', $iri->path);
-		$this->assertEquals('test', $iri->fragment);
+		$this->assertSame('http', $iri->scheme);
+		$this->assertSame('user:password', $iri->userinfo);
+		$this->assertSame('example.com', $iri->host);
+		$this->assertSame(80, $iri->port);
+		$this->assertSame('/test/', $iri->path);
+		$this->assertSame('test', $iri->fragment);
 	}
 
 	public function testNonexistantProperty()
@@ -471,8 +471,8 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$iri = new SimplePie_IRI('http://example.com/a/?b=c#d');
 		$iri->host = null;
 
-		$this->assertEquals(null, $iri->host);
-		$this->assertEquals('http:/a/?b=c#d', (string) $iri);
+		$this->assertSame(null, $iri->host);
+		$this->assertSame('http:/a/?b=c#d', (string) $iri);
 	}
 
 	public function testBadPort()
@@ -480,7 +480,7 @@ class IRITest extends PHPUnit\Framework\TestCase
 		$iri = new SimplePie_IRI();
 		$iri->port = 'example';
 
-		$this->assertEquals(null, $iri->port);
+		$this->assertSame(null, $iri->port);
 	}
 }
 

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -104,7 +104,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -119,7 +119,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -134,7 +134,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -149,7 +149,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -164,7 +164,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -184,7 +184,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	/**
@@ -204,7 +204,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 	</channel>
 </rss>';
 		$feed = $this->checkFromTemplate($data, $title);
-		$this->assertEquals($expected, $feed->get_title());
+		$this->assertSame($expected, $feed->get_title());
 	}
 
 	public function testItemWithEmptyContent()
@@ -221,7 +221,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
 		$content = 'item description';
 		$feed = $this->checkFromTemplate($data, $content);
 		$item = $feed->get_item();
-		$this->assertEquals($content, $item->get_content());
+		$this->assertSame($content, $item->get_content());
 	}
 
 }

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -77,7 +77,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-		$this->assertEquals($feed, $data);
+		$this->assertSame($feed, $data);
 	}
 
 	public function testInvalidMIMEType()
@@ -92,7 +92,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-		$this->assertEquals($feed, null);
+		$this->assertSame($feed, null);
 	}
 
 	public function testDirectNoDOM()
@@ -105,7 +105,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$this->assertTrue($locator->is_feed($data));
-		$this->assertEquals($locator->find(SIMPLEPIE_LOCATOR_ALL, $found), $data);
+		$this->assertSame($locator->find(SIMPLEPIE_LOCATOR_ALL, $found), $data);
 	}
 
 	public function testFailDiscoveryNoDOM()
@@ -173,7 +173,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$success = array_filter($expected, array(get_class(), 'filter_success'));
 
 		$found = array_map(array(get_class(), 'map_url_file'), $all);
-		$this->assertEquals($success, $found);
+		$this->assertSame($success, $found);
 	}
 
 	protected static function filter_success($url)

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -50,7 +50,7 @@ class SanitizeTest extends PHPUnit\Framework\TestCase
 	{
 		$sanitize = new SimplePie_Sanitize();
 
-		$this->assertEquals(
+		$this->assertSame(
 <<<EOT
 &lt;head&gt; &amp; &lt;body&gt; /\ ' === ' &amp; " === ". Sbohem bez šátečku! Тут был Лёха.
 EOT

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -52,7 +52,7 @@ class SubscribeUrlTest extends PHPUnit\Framework\TestCase
 
 		$feed->init();
 
-		$this->assertEquals('https://example.com/feed/2019-10-07', $feed->subscribe_url());
-		$this->assertEquals('https://example.com/feed/', $feed->subscribe_url(true));
+		$this->assertSame('https://example.com/feed/2019-10-07', $feed->subscribe_url());
+		$this->assertSame('https://example.com/feed/', $feed->subscribe_url(true));
 	}
 }


### PR DESCRIPTION
### Tests: use strict assertions

PHPUnit contains a variety of assertions and the ones available have been extended hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison `==` and `assertSame()` does a strict type `===` comparison.

The only real exception to this is when comparing two objects, as in that case, the objectID will not be the same, so those should still use `assertEquals()` - or the PHPUnit 9.4.0 `assertObjectEquals()` method for comparing value objects using a callback method in the ValueObject class.

### Tests: use strict assertions in custom assertion

The custom `assertEqualsBin2Hex()` assertion was using `assertEquals()` as well.
When changing this to `assertSame()`, it makes sense to also change the custom assertion method name to `assertSameBin2Hex()` and adjust all calls to the method.

