### PR TITLE
GH Actions: don't allow builds to fail on PHP 8.0 or 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
 
     name: "PHP: ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.0' || matrix.php == '8.1' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -34,12 +32,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.0)"
-        if: ${{ matrix.php < '8.0' }}
+      - name: "Install Composer dependencies (PHP < 8.1)"
+        if: ${{ matrix.php < '8.1' }}
         uses: "ramsey/composer-install@v1"
 
-      - name: "Install Composer dependencies (PHP 8.0)"
-        if: ${{ matrix.php >= '8.0' }}
+      - name: "Install Composer dependencies (PHP 8.1)"
+        if: ${{ matrix.php >= '8.1' }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs


### PR DESCRIPTION
Now the test suite has been made cross-version compatible AND the PHP 8.1 incompatibility has been fixed AND the PHP 8.0 feature removal causing a test failure has been dealt with... the tests will run and pass on PHP 8.0 and 8.1.

Let's keep it that way by not allowing them to fail anymore.