### PR TITLE
Tests: use the correct parameter order

### DIFF
--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -77,7 +77,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-		$this->assertSame($feed, $data);
+		$this->assertSame($data, $feed);
 	}
 
 	public function testInvalidMIMEType()
@@ -92,7 +92,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-		$this->assertSame($feed, null);
+		$this->assertSame(null, $feed);
 	}
 
 	public function testDirectNoDOM()
@@ -105,7 +105,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 		$locator->set_registry($registry);
 
 		$this->assertTrue($locator->is_feed($data));
-		$this->assertSame($locator->find(SIMPLEPIE_LOCATOR_ALL, $found), $data);
+		$this->assertSame($data, $locator->find(SIMPLEPIE_LOCATOR_ALL, $found));
 	}
 
 	public function testFailDiscoveryNoDOM()


### PR DESCRIPTION
For PHPUnit assertions which expect an `$expected` and a `$result` parameter, the parameter order is always `( $expected, $result, ...).

While it may not seem important to use the correct parameter order for assertions doing a straight comparison, in actual fact, it is.
The PHPUnit output when the assertions fail expects this order and the failure message will be reversed if the parameters are passed in reversed order which leads to confusion and makes it more difficult to debug a failing test.

Only three assertions in the test suite did not comply with this. Fixed now.