### PR TITLE
fix: better deal with proxy returning proxy headers (in response to cURL's Proxy-Connection header)

### DIFF
--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -508,10 +508,12 @@ class SimplePie_HTTP_Parser
 		$data = explode("\r\n\r\n", $headers, $count);
 		$data = array_pop($data);
 		if (false !== stripos($data, "HTTP/1.0 200 Connection established\r\n")) {
-			$data = end(explode("\r\n\r\n", $data, 2));
+			$exploded = explode("\r\n\r\n", $data, 2);
+			$data = end($exploded);
 		}
 		if (false !== stripos($data, "HTTP/1.1 200 Connection established\r\n")) {
-			$data = end(explode("\r\n\r\n", $data, 2));
+			$exploded = explode("\r\n\r\n", $data, 2);
+			$data = end($exploded);
 		}
 		return $data;
 	}

--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -507,11 +507,11 @@ class SimplePie_HTTP_Parser
 	{
 		$data = explode("\r\n\r\n", $headers, $count);
 		$data = array_pop($data);
-		if (false !== stripos($data, "HTTP/1.0 200 Connection established\r\n\r\n")) {
-			$data = str_ireplace("HTTP/1.0 200 Connection established\r\n\r\n", '', $data);
+		if (false !== stripos($data, "HTTP/1.0 200 Connection established\r\n")) {
+			$data = end(explode("\r\n\r\n", $data, 2));
 		}
-		if (false !== stripos($data, "HTTP/1.1 200 Connection established\r\n\r\n")) {
-			$data = str_ireplace("HTTP/1.1 200 Connection established\r\n\r\n", '', $data);
+		if (false !== stripos($data, "HTTP/1.1 200 Connection established\r\n")) {
+			$data = end(explode("\r\n\r\n", $data, 2));
 		}
 		return $data;
 	}


### PR DESCRIPTION
Some HTTP proxy returns headers like this:

```
HTTP/1.1 200 Connection established\r\n
Connection: close\r\n
(Other headers...)
\r\n
(Headers and bodies of actual HTTP response)
```

So the code just detecting `"HTTP/1.0 200 Connection established\r\n\r\n"` won't work with these proxies.

A better way will be split the payload by `\r\n\r\n`, skip the first part and keep the remaining parts.