### PR TITLE
Fix an PHP 8 issue with the 1.3 branch

### DIFF
--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -541,8 +541,8 @@ class SimplePie_Parse_Date
 	 */
 	public function __construct()
 	{
-		$this->day_pcre = '(' . implode(array_keys($this->day), '|') . ')';
-		$this->month_pcre = '(' . implode(array_keys($this->month), '|') . ')';
+		$this->day_pcre = '(' . implode('|', array_keys($this->day)) . ')';
+		$this->month_pcre = '(' . implode('|', array_keys($this->month)) . ')';
 
 		static $cache;
 		if (!isset($cache[get_class($this)]))


### PR DESCRIPTION
Hi,

within Joomla 3 we still have to ship the 1.3 version of simplepie as we are required to still support PHP 5.3 but this version gets the issue patched here when used on PHP 8: https://github.com/joomla/joomla-cms/issues/36120

This change here should fix it. So the question is do you still accept changes to this branch and would do a release of the 1.3 branch?

Thanks