### PR TITLE
PHP 8.2: explicitly declare properties

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -58,6 +58,8 @@ if (!class_exists('SimplePie'))
  */
 class SimplePie_Autoloader
 {
+	protected $path;
+
 	/**
 	 * Constructor
 	 */

--- a/library/SimplePie/Cache/Redis.php
+++ b/library/SimplePie/Cache/Redis.php
@@ -152,7 +152,7 @@ class SimplePie_Cache_Redis implements SimplePie_Cache_Base {
         if ($data !== false) {
             $return = $this->cache->set($this->name, $data);
             if ($this->options['expire']) {
-                return $this->cache->expire($this->name, $this->ttl);
+                return $this->cache->expire($this->name, $this->options['expire']);
             }
             return $return;
         }

--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -64,6 +64,7 @@ class SimplePie_Locator
 	var $max_checked_feeds = 10;
 	var $force_fsockopen = false;
 	var $curl_options = array();
+	var $dom;
 	protected $registry;
 
 	public function __construct(SimplePie_File $file, $timeout = 10, $useragent = null, $max_checked_feeds = 10, $force_fsockopen = false, $curl_options = array())

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -71,6 +71,7 @@ class SimplePie_Sanitize
 	var $useragent = '';
 	var $force_fsockopen = false;
 	var $replace_url_attributes = null;
+	var $registry;
 
 	/**
 	 * List of domains for which to force HTTPS.


### PR DESCRIPTION
## Context

Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

## Commits

### Locator: explicitly declare all properties 

In this case, the `$dom` property is referenced multiple times throughout this class, so falls in the "known property" category.

### Sanitize: explicitly declare all properties

In this case, the `$registry` property is referenced multiple times throughout this class, so falls in the "known property" category.

### Autoloader: explicitly declare all properties

In this case, the `$path` property is referenced a couple of times throughout this class, so falls in the "known property" category.

### 🆕 SimplePie_Cache_Redis: fix bug for using undefined property

The `$ttl` property is not declared, not set on this cache, nor its parent, which means that it would always be passed as `null`.

As the call to the `Redis::expire()` method is within a `if ($this->options['expire'])` condition and a similar call to the `Redis::expire()` method in the `SimplePie_Cache_Redis::save()` method, also uses `$this->options['expire']` for the "ttl" value, changing the passed parameter to `$this->options['expire']` seems the correct fix.

## QA

The existing unit tests already cover these changes.

~~A scan with @exakat reveals one more issue, but I'm not sure how to fix that one:~~

~~The `SimplePie_Cache_Redis::touch()` method refers to (uses) a `$ttl` property, but this property is not declared on the class, nor set anywhere, so it is unclear what the value of the property should be when explicitly declaring it on the class.~~
