### PR TITLE
Update CHANGELOG.md, follow keepachangelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,55 @@
-## 1.5.5 (May 1, 2020)
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.5.7](https://github.com/simplepie/simplepie/compare/1.5.6...1.5.7) - 2021-12-19
+
+* Fix PHP8 crash due to insufficient isset test by @Alkarex in #670
+* gitignore tests by @Alkarex in #671
+* Reduce memory when parsing large feeds by @Alkarex in #672
+* PHP8 catch ValueError for loadHTML() by @Alkarex in #673
+* Provide access to HTTP status code by @Alkarex in #674
+* Fix wrong type hint by @Alkarex in #678
+* Force HTTPS for selected domains by @Alkarex in #676
+* Prevent cache polution by @Alkarex in #675
+* Fix typo in comment by @Alkarex in #680
+* Remove HTTP credentials in HTTP Referer by @Alkarex in #681
+* CI: switch to GH Actions by @jrfnl in #688
+* PHP 8.1: fix "passing null to non-nullable" deprecation notice by @jrfnl in #689
+* Tests: PHPUnit cross-version compatibility by @jrfnl in #690
+* Tests: use strict assertions by @jrfnl in #692
+* CacheTest: handle different exceptions PHP cross-version by @jrfnl in #691
+* GH Actions: don't allow builds to fail on PHP 8.0 or 8.1 by @jrfnl in #693
+* Tests: use the correct parameter order by @jrfnl in #694
+* PHPUnit: update configuration by @jrfnl in #696
+* fix: better deal with proxy returning proxy headers (in response to cURL's Proxy-Connection header) by @shunf4 in #698
+* Handle multiple Link headers by @voegelas in #700
+* PHP 8.2: explicitly declare properties by @jrfnl in #705
+* New Contributor: @shunf4 made their first contribution in #698
+* New Contributor: @voegelas made their first contribution in #700
+
+## [1.5.6](https://github.com/simplepie/simplepie/compare/1.5.5...1.5.6) - 2020-10-14
+
+* PHP 8.0: prevent ValueError for invalid encoding (#657)
+* Travis: test against more recent PHP versions (#653)
+* PHP 8.0: handle removal of get_magic_quotes_gpc() (#654)
+* PHP 7.4/8.0: curly brace array access deprecated & removed (#655)
+* PHP 8.0: required parameters are no longer allowed after optional parameters (#656)
+* Fix permanent_url for HTTP 301 (#660)
+* Fix typo in MIME type in Content_Type_Sniffer (#661) 
+
+## [1.5.5](https://github.com/simplepie/simplepie/compare/1.5.4...1.5.5) - 2020-05-01
 
 * Ensure that feeds retrieved with `force_feed` do not share the same cache as those retrieved without. [#643](https://github.com/simplepie/simplepie/pull/643)
 * Removed references to removed PHP directives and some PHP < 5.6 checks. [#645](https://github.com/simplepie/simplepie/pull/645)
 * Corrected incorrect alumni name. [#638](https://github.com/simplepie/simplepie/pull/638)
 
-## 1.5.4 (December 17, 2019)
+## [1.5.4](https://github.com/simplepie/simplepie/compare/1.5.3...1.5.4) - 2019-12-17
 
 * PHP 5.6 or newer is now required. [#625](https://github.com/simplepie/simplepie/pull/625)
 * Fixed invalid docblock parameter types [#633](https://github.com/simplepie/simplepie/pull/633)
@@ -12,7 +57,7 @@
 * PHP 7.4 support: Fixed instances of accessing array offset on null type values. [#628](https://github.com/simplepie/simplepie/pull/628)
 * Return an effective feed URL when asking for non-permanent `subscribe_url`. [#627](https://github.com/simplepie/simplepie/pull/627)
 
-## 1.5.3 (September 22, 2019)
+## [1.5.3](https://github.com/simplepie/simplepie/compare/1.5.2...1.5.3) - 2019-09-22
 
 * Replaced `pow()` call with `**` operator (micro performance optimization). [#622](https://github.com/simplepie/simplepie/pull/622)
 * Match links containing `feed` in the Locator class. [#621](https://github.com/simplepie/simplepie/pull/621)
@@ -20,7 +65,7 @@
 * Added support for Russian dates. [#607](https://github.com/simplepie/simplepie/pull/607)
 * Preemptively changed `is_writeable()` calls to `is_writable()` in case the former is deprecated in PHP. [#604](https://github.com/simplepie/simplepie/pull/604)
 
-## 1.5.2 (August 2, 2018)
+## [1.5.2](https://github.com/simplepie/simplepie/compare/1.5.1...1.5.2) - 2018-08-02
 
 * Added support for PHPUnit 6. [#565](https://github.com/simplepie/simplepie/pull/565)
 * Added PHP module requirements to Composer. [#590](https://github.com/simplepie/simplepie/pull/590)
@@ -35,7 +80,7 @@
 * Fixed a bug where URL fragments are included when `SimplePie_File` normalizes URLs when really old versions of cURL are used. [#564](https://github.com/simplepie/simplepie/pull/564)
 * Updated `SimplePie_Locator` to respect cURL options specified. [#561](https://github.com/simplepie/simplepie/pull/561)
 
-## 1.5.1 (November 17, 2017)
+## [1.5.1](https://github.com/simplepie/simplepie/compare/1.5...1.5.1) - 2017-11-17
 
 * Fixed photos so they are not added if the URL is empty. [#530](https://github.com/simplepie/simplepie/pull/530)
 * Fixed issues with retrieving feeds from behind a proxy. [#512](https://github.com/simplepie/simplepie/pull/512)/[#548](https://github.com/simplepie/simplepie/pull/548)
@@ -48,14 +93,14 @@
 * Update the registry if the Sanitize class has been changed. [#532](https://github.com/simplepie/simplepie/pull/532)
 * Changed the sanitization type for author and category back to text from HTML. [#531](https://github.com/simplepie/simplepie/pull/531)
 
-## 1.5 (April 17, 2017)
+## [1.5](https://github.com/simplepie/simplepie/compare/1.4.3...1.5) - 2017-04-17
 
 * Introduced `SimplePie_Category->get_type()` for retrieving category type. [#492](https://github.com/simplepie/simplepie/pull/492)
 * Added `$enable_exceptions` to the class property declarations for `SimplePie` class. [#504](https://github.com/simplepie/simplepie/pull/504)
 * Titles are now parsed for ATOM10 enclosure links. [#507](https://github.com/simplepie/simplepie/pull/507)
 * `$item->get_id()` can now be forced to return the supplied ID instead of generating a new one. [#509](https://github.com/simplepie/simplepie/pull/509)
 
-## 1.4.3 (November 26, 2016)
+## [1.4.3](https://github.com/simplepie/simplepie/compare/1.4.2...1.4.3) - 2016-11-26
 
 * Removed support for PHP 5.2. [#469](https://github.com/simplepie/simplepie/pull/469)
 * Added support for the PHP `UConverter` class. [#485](https://github.com/simplepie/simplepie/pull/485)
@@ -76,18 +121,18 @@
 * Fixed misspelled occurrences of "separated". [#459](https://github.com/simplepie/simplepie/pull/459) 
 * Improvements to the compatibility test and error messages. [#488](https://github.com/simplepie/simplepie/pull/488)
 
-## 1.4.2 (June 14, 2016)
+## [1.4.2](https://github.com/simplepie/simplepie/compare/1.4.1...1.4.2) - 2016-06-14
 
 * Fixed a bug with IRI parsing.
 * More cleanly separates discovery of microformats and parsing when php-mf2 is not present. 
 
-## 1.4.1 (June 2, 2016)
+## [1.4.1](https://github.com/simplepie/simplepie/compare/1.4.0...1.4.1) - 2016-06-02
 
 * Fixed inconsistent hash results in `SimplePie_Item->get_id()`.
 * Leading and trailing whitespace is now trimmed from XML feed content to prevent errors. [#445](https://github.com/simplepie/simplepie/pull/445)
 * Improved support for microformat feeds.
 
-## 1.4.0 (April 25, 2016)
+## [1.4.0](https://github.com/simplepie/simplepie/compare/1.4-beta...1.4.0) - 2016-04-25
 
 * Dropped support for PHP 5.2. [#348](https://github.com/simplepie/simplepie/pull/348)
 * Serialized data is now used for hashing in `SimplePie_Item->get_id()`. [#348](https://github.com/simplepie/simplepie/pull/348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,43 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased](https://github.com/simplepie/simplepie/compare/1.5.7...master)
 
 ## [1.5.7](https://github.com/simplepie/simplepie/compare/1.5.6...1.5.7) - 2021-12-19
 
-* Fix PHP8 crash due to insufficient isset test by @Alkarex in #670
-* gitignore tests by @Alkarex in #671
-* Reduce memory when parsing large feeds by @Alkarex in #672
-* PHP8 catch ValueError for loadHTML() by @Alkarex in #673
-* Provide access to HTTP status code by @Alkarex in #674
-* Fix wrong type hint by @Alkarex in #678
-* Force HTTPS for selected domains by @Alkarex in #676
-* Prevent cache polution by @Alkarex in #675
-* Fix typo in comment by @Alkarex in #680
-* Remove HTTP credentials in HTTP Referer by @Alkarex in #681
-* CI: switch to GH Actions by @jrfnl in #688
-* PHP 8.1: fix "passing null to non-nullable" deprecation notice by @jrfnl in #689
-* Tests: PHPUnit cross-version compatibility by @jrfnl in #690
-* Tests: use strict assertions by @jrfnl in #692
-* CacheTest: handle different exceptions PHP cross-version by @jrfnl in #691
-* GH Actions: don't allow builds to fail on PHP 8.0 or 8.1 by @jrfnl in #693
-* Tests: use the correct parameter order by @jrfnl in #694
-* PHPUnit: update configuration by @jrfnl in #696
-* fix: better deal with proxy returning proxy headers (in response to cURL's Proxy-Connection header) by @shunf4 in #698
-* Handle multiple Link headers by @voegelas in #700
-* PHP 8.2: explicitly declare properties by @jrfnl in #705
-* New Contributor: @shunf4 made their first contribution in #698
-* New Contributor: @voegelas made their first contribution in #700
+* Fix PHP8 crash due to insufficient isset test by @Alkarex in [#670](https://github.com/simplepie/simplepie/pull/670)
+* gitignore tests by @Alkarex in [#671](https://github.com/simplepie/simplepie/pull/671)
+* Reduce memory when parsing large feeds by @Alkarex in [#672](https://github.com/simplepie/simplepie/pull/672)
+* PHP8 catch ValueError for loadHTML() by @Alkarex in [#673](https://github.com/simplepie/simplepie/pull/673)
+* Provide access to HTTP status code by @Alkarex in [#674](https://github.com/simplepie/simplepie/pull/674)
+* Fix wrong type hint by @Alkarex in [#678](https://github.com/simplepie/simplepie/pull/678)
+* Force HTTPS for selected domains by @Alkarex in [#676](https://github.com/simplepie/simplepie/pull/676)
+* Prevent cache polution by @Alkarex in [#675](https://github.com/simplepie/simplepie/pull/675)
+* Fix typo in comment by @Alkarex in [#680](https://github.com/simplepie/simplepie/pull/680)
+* Remove HTTP credentials in HTTP Referer by @Alkarex in [#681](https://github.com/simplepie/simplepie/pull/681)
+* CI: switch to GH Actions by @jrfnl in [#688](https://github.com/simplepie/simplepie/pull/688)
+* PHP 8.1: fix "passing null to non-nullable" deprecation notice by @jrfnl in [#689](https://github.com/simplepie/simplepie/pull/689)
+* Tests: PHPUnit cross-version compatibility by @jrfnl in [#690](https://github.com/simplepie/simplepie/pull/690)
+* Tests: use strict assertions by @jrfnl in [#692](https://github.com/simplepie/simplepie/pull/692)
+* CacheTest: handle different exceptions PHP cross-version by @jrfnl in [#691](https://github.com/simplepie/simplepie/pull/691)
+* GH Actions: don't allow builds to fail on PHP 8.0 or 8.1 by @jrfnl in [#693](https://github.com/simplepie/simplepie/pull/693)
+* Tests: use the correct parameter order by @jrfnl in [#694](https://github.com/simplepie/simplepie/pull/694)
+* PHPUnit: update configuration by @jrfnl in [#696](https://github.com/simplepie/simplepie/pull/696)
+* fix: better deal with proxy returning proxy headers (in response to cURL's Proxy-Connection header) by @shunf4 in [#698](https://github.com/simplepie/simplepie/pull/698)
+* Handle multiple Link headers by @voegelas in [#700](https://github.com/simplepie/simplepie/pull/700)
+* PHP 8.2: explicitly declare properties by @jrfnl in [#705](https://github.com/simplepie/simplepie/pull/705)
+* New Contributor: @shunf4 made their first contribution in [#698](https://github.com/simplepie/simplepie/pull/698)
+* New Contributor: @voegelas made their first contribution in [#700](https://github.com/simplepie/simplepie/pull/700)
 
 ## [1.5.6](https://github.com/simplepie/simplepie/compare/1.5.5...1.5.6) - 2020-10-14
 
-* PHP 8.0: prevent ValueError for invalid encoding (#657)
-* Travis: test against more recent PHP versions (#653)
-* PHP 8.0: handle removal of get_magic_quotes_gpc() (#654)
-* PHP 7.4/8.0: curly brace array access deprecated & removed (#655)
-* PHP 8.0: required parameters are no longer allowed after optional parameters (#656)
-* Fix permanent_url for HTTP 301 (#660)
-* Fix typo in MIME type in Content_Type_Sniffer (#661) 
+* PHP 8.0: prevent ValueError for invalid encoding [#657](https://github.com/simplepie/simplepie/pull/657)
+* Travis: test against more recent PHP versions [#653](https://github.com/simplepie/simplepie/pull/653)
+* PHP 8.0: handle removal of get_magic_quotes_gpc() [#654](https://github.com/simplepie/simplepie/pull/654)
+* PHP 7.4/8.0: curly brace array access deprecated & removed [#655](https://github.com/simplepie/simplepie/pull/655)
+* PHP 8.0: required parameters are no longer allowed after optional parameters [#656](https://github.com/simplepie/simplepie/pull/656)
+* Fix permanent_url for HTTP 301 [#660](https://github.com/simplepie/simplepie/pull/660)
+* Fix typo in MIME type in Content_Type_Sniffer [#661](https://github.com/simplepie/simplepie/pull/661) 
 
 ## [1.5.5](https://github.com/simplepie/simplepie/compare/1.5.4...1.5.5) - 2020-05-01
 


### PR DESCRIPTION
I've noted that the `CHANGELOG.md` was not updated since 1.5.5, so I updated it. And I formated the file to follow the [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) format.

I couldn't find a note if this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as I assumed in the CHANGELOG.md, so please correct me if I'm wrong.