### PR TITLE
Fix/708 version bump for `1.5.8` release

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -33,7 +33,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.5.6
+ * @version 1.5.8
  * @copyright 2004-2017 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
  * @author Sam Sneddon
@@ -50,7 +50,7 @@ define('SIMPLEPIE_NAME', 'SimplePie');
 /**
  * SimplePie Version
  */
-define('SIMPLEPIE_VERSION', '1.5.6');
+define('SIMPLEPIE_VERSION', '1.5.8');
 
 /**
  * SimplePie Build


### PR DESCRIPTION
Closes #708 

The `@version` tag and the `SIMPLEPIE_VERSION` constant in the `SimplePie.php` file are updated for the `1.5.8` release.