### PR TITLE
FIx a small typo in the `error()` function Docblock

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1785,7 +1785,7 @@ class SimplePie
 	}
 
 	/**
-	 * Get the error message for the occured error
+	 * Get the error message for the occurred error
 	 *
 	 * @return string|array Error message, or array of messages for multifeeds
 	 */


### PR DESCRIPTION
This is a very tiny typo in a Docblock. Definitely not important, but I spotted this on WordPress vendor file and wanted to give a feedback here :)