### PR TITLE
Add audio, video @src elements/attribute for URL resolution

### DIFF
--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -221,9 +221,9 @@ class SimplePie_Sanitize
 	 * Set element/attribute key/value pairs of HTML attributes
 	 * containing URLs that need to be resolved relative to the feed
 	 *
-	 * Defaults to |a|@href, |area|@href, |blockquote|@cite, |del|@cite,
-	 * |form|@action, |img|@longdesc, |img|@src, |input|@src, |ins|@cite,
-	 * |q|@cite
+	 * Defaults to |a|@href, |area|@href, |audio|@src, |blockquote|@cite,
+	 * |del|@cite, |form|@action, |img|@longdesc, |img|@src, |input|@src,
+	 * |ins|@cite, |q|@cite, |video|@src
 	 *
 	 * @since 1.0
 	 * @param array|null $element_attribute Element/attribute key/value pairs, null for default
@@ -235,6 +235,7 @@ class SimplePie_Sanitize
 			$element_attribute = array(
 				'a' => 'href',
 				'area' => 'href',
+				'audio' => 'src',
 				'blockquote' => 'cite',
 				'del' => 'cite',
 				'form' => 'action',
@@ -244,7 +245,8 @@ class SimplePie_Sanitize
 				),
 				'input' => 'src',
 				'ins' => 'cite',
-				'q' => 'cite'
+				'q' => 'cite',
+				'video' => 'src'
 			);
 		}
 		$this->replace_url_attributes = (array) $element_attribute;

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -453,6 +453,8 @@ class SimplePie_Sanitize
 				{
 					$data = preg_replace('/^<div' . SIMPLEPIE_PCRE_XML_ATTRIBUTE . '>/', '<div>', $data);
 				}
+
+				$data = str_replace('</source>', '', $data);
 			}
 
 			if ($type & SIMPLEPIE_CONSTRUCT_IRI)

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -223,7 +223,7 @@ class SimplePie_Sanitize
 	 *
 	 * Defaults to |a|@href, |area|@href, |audio|@src, |blockquote|@cite,
 	 * |del|@cite, |form|@action, |img|@longdesc, |img|@src, |input|@src,
-	 * |ins|@cite, |q|@cite, |video|@src
+	 * |ins|@cite, |q|@cite, |source|@src, |video|@src
 	 *
 	 * @since 1.0
 	 * @param array|null $element_attribute Element/attribute key/value pairs, null for default
@@ -246,7 +246,11 @@ class SimplePie_Sanitize
 				'input' => 'src',
 				'ins' => 'cite',
 				'q' => 'cite',
-				'video' => 'src'
+				'source' => 'src',
+				'video' => array(
+					'poster',
+					'src'
+				)
 			);
 		}
 		$this->replace_url_attributes = (array) $element_attribute;

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -66,7 +66,53 @@ EOT
 		);
 	}
 
-    public function testSanitizeURLResolution()
+
+    public function sanitizeURLProvider()
+    {
+        return array(
+            'simple absolute valid a href, resolved' => array(
+                '<a href="/path/to/doc">link</a>',
+                '<a href="http://example.com/path/to/doc">link</a>'
+            ),
+            'image valid fully qualified src, no change expected' => array(
+                '<img src="http://2.example.com/image.jpg">',
+                '<img src="http://2.example.com/image.jpg">'
+            ),
+            'image valid relative src, resolved' => array(
+                '<img src="image.jpg">',
+                '<img src="http://example.com/image.jpg">'
+            ),
+            'image valid absolute src, resolved' => array(
+                '<img src="/image.jpg">',
+                '<img src="http://example.com/image.jpg">'
+            ),
+            'audio relative src, resolved, fixed' => array(
+                '<audio src="a.mp3" />',
+                '<audio src="http://example.com/a.mp3" preload="none"></audio>'
+            ),
+            'audio absolute source src path, resolved, fixed' => array(
+                '<audio><source src="/a/b.wav" /></audio>',
+                '<audio preload="none"><source src="http://example.com/a/b.wav"></audio>'
+            ),
+            'audio with alternative source src absolute paths, resolved, fixed' => array(
+                '<audio><source src="a/b.wav" /><source src="/c/d.mp3" /></audio>',
+                '<audio preload="none"><source src="http://example.com/a/b.wav"><source src="http://example.com/c/d.mp3"></audio>'
+            ),
+            'video src relative, resolved, fixed' => array(
+                '<video src="./b.mpeg" />',
+                '<video src="http://example.com/b.mpeg" preload="none"></video>'
+            ),
+            'video with alternative source src, resolved, fixed' => array(
+                '<video><source src="a/b.mpeg" /><source src="/c/../d.mov"></video>',
+                '<video preload="none"><source src="http://example.com/a/b.mpeg"><source src="http://example.com/d.mov"></video>'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider sanitizeURLProvider
+     */
+    public function testSanitizeURLResolution($given, $expected)
     {
         $sanitize = new SimplePie_Sanitize();
 
@@ -76,34 +122,6 @@ EOT
 
         $base = 'http://example.com/';
 
-        $tests = array(
-            'a 1 <a href="/path/to/doc">link</a>'
-                => 'a 1 <a href="http://example.com/path/to/doc">link</a>',
-            'other <img src="http://2.example.com/image.jpg">'
-                => 'other <img src="http://2.example.com/image.jpg">',
-            'img 1 <img src="image.jpg">'
-                => 'img 1 <img src="http://example.com/image.jpg">',
-            'img 2 <img src="/image.jpg">'
-                => 'img 2 <img src="http://example.com/image.jpg">',
-            'img 3 <img src="/path/image.jpg">'
-                => 'img 3 <img src="http://example.com/path/image.jpg">',
-            'audio 1 <audio src="a.mp3" />'
-                => 'audio 1 <audio src="http://example.com/a.mp3" preload="none"></audio>',
-            'audio 2 <audio><source src="/a/b.wav" /></audio>'
-                => 'audio 2 <audio preload="none"><source src="http://example.com/a/b.wav"></audio>',
-            'audio 3 <audio><source src="/a/b.wav" /><source src="/c/d.mp3" /></audio>'
-                => 'audio 3 <audio preload="none"><source src="http://example.com/a/b.wav"><source src="http://example.com/c/d.mp3"></audio>',
-            'video 1 <video src="./b.mpeg" />'
-                => 'video 1 <video src="http://example.com/b.mpeg" preload="none"></video>',
-            'video 2 <video><source src="a/b.mpeg"></video>'
-                => 'video 2 <video preload="none"><source src="http://example.com/a/b.mpeg"></video>',
-            'video 3 <video><source src="a/b.mpeg" /><source src="c/d.mov"></video>'
-                => 'video 3 <video preload="none"><source src="http://example.com/a/b.mpeg"><source src="http://example.com/c/d.mov"></video>',
-        );
-
-        foreach ($tests as $input => $expected)
-        {
-            $this->assertSame($expected, $sanitize->sanitize($input, SIMPLEPIE_CONSTRUCT_HTML, $base));
-        }
+        $this->assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
     }
 }

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -65,4 +65,45 @@ EOT
 			'XML input (with corresponding xml entities) should be cleaned and converted to utf-8 escaped HTML'
 		);
 	}
+
+    public function testSanitizeURLResolution()
+    {
+        $sanitize = new SimplePie_Sanitize();
+
+        $registry = new SimplePie_Registry();
+        $registry->register('Misc', 'SimplePie_Misc');
+        $sanitize->set_registry($registry);
+
+        $base = 'http://example.com/';
+
+        $tests = array(
+            'a 1 <a href="/path/to/doc">link</a>'
+                => 'a 1 <a href="http://example.com/path/to/doc">link</a>',
+            'other <img src="http://2.example.com/image.jpg">'
+                => 'other <img src="http://2.example.com/image.jpg">',
+            'img 1 <img src="image.jpg">'
+                => 'img 1 <img src="http://example.com/image.jpg">',
+            'img 2 <img src="/image.jpg">'
+                => 'img 2 <img src="http://example.com/image.jpg">',
+            'img 3 <img src="/path/image.jpg">'
+                => 'img 3 <img src="http://example.com/path/image.jpg">',
+            'audio 1 <audio src="a.mp3" />'
+                => 'audio 1 <audio src="http://example.com/a.mp3" preload="none"></audio>',
+            'audio 2 <audio><source src="/a/b.wav" /></audio>'
+                => 'audio 2 <audio preload="none"><source src="http://example.com/a/b.wav"></audio>',
+            'audio 3 <audio><source src="/a/b.wav" /><source src="/c/d.mp3" /></audio>'
+                => 'audio 3 <audio preload="none"><source src="http://example.com/a/b.wav"><source src="http://example.com/c/d.mp3"></audio>',
+            'video 1 <video src="./b.mpeg" />'
+                => 'video 1 <video src="http://example.com/b.mpeg" preload="none"></video>',
+            'video 2 <video><source src="a/b.mpeg"></video>'
+                => 'video 2 <video preload="none"><source src="http://example.com/a/b.mpeg"></video>',
+            'video 3 <video><source src="a/b.mpeg" /><source src="c/d.mov"></video>'
+                => 'video 3 <video preload="none"><source src="http://example.com/a/b.mpeg"><source src="http://example.com/c/d.mov"></video>',
+        );
+
+        foreach ($tests as $input => $expected)
+        {
+            $this->assertSame($expected, $sanitize->sanitize($input, SIMPLEPIE_CONSTRUCT_HTML, $base));
+        }
+    }
 }


### PR DESCRIPTION
Independently from enclosures, it happens that audio/video contents are also embedded through `<audio src="" />` and `<video src="" />` tags.
Those deserve their source URLs to be properly resolved too. 😛 

However I'm not 100% aware of the history of SimplePie, so there may be a reason those were left out (other than they're just rather recent elements). Thanks!

* [x] Tests ok
* [x] Linter ok
* (couldn't find a Makefile though as it's hinted in the PR notes)