### PR TITLE
added: Sanitize::rename_attributes()

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -651,7 +651,7 @@ class SimplePie
 	public $strip_htmltags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style');
 
 	/**
-	 * @var array Stores the default tags to be stripped by rename_attributes().
+	 * @var array Stores the default attributes to be renamed by rename_attributes().
 	 * @see SimplePie::rename_attributes()
 	 * @access private
 	 */

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -651,6 +651,13 @@ class SimplePie
 	public $strip_htmltags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style');
 
 	/**
+	 * @var array Stores the default tags to be stripped by rename_attributes().
+	 * @see SimplePie::rename_attributes()
+	 * @access private
+	 */
+	public $rename_attributes = array();
+
+	/**
 	 * @var bool Should we throw exceptions, or use the old-style error property?
 	 * @access private
 	 */
@@ -1216,6 +1223,15 @@ class SimplePie
 		{
 			$this->sanitize->encode_instead_of_strip($tags);
 		}
+	}
+
+	public function rename_attributes($tags = '', $encode = null)
+	{
+		if ($tags === '')
+		{
+			$tags = $this->rename_attributes;
+		}
+		$this->sanitize->rename_attributes($tags);
 	}
 
 	public function encode_instead_of_strip($enable = true)

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1225,18 +1225,18 @@ class SimplePie
 		}
 	}
 
-	public function rename_attributes($tags = '', $encode = null)
-	{
-		if ($tags === '')
-		{
-			$tags = $this->rename_attributes;
-		}
-		$this->sanitize->rename_attributes($tags);
-	}
-
 	public function encode_instead_of_strip($enable = true)
 	{
 		$this->sanitize->encode_instead_of_strip($enable);
+	}
+
+	public function rename_attributes($attribs = '')
+	{
+		if ($attribs === '')
+		{
+			$attribs = $this->rename_attributes;
+		}
+		$this->sanitize->rename_attributes($attribs);
 	}
 
 	public function strip_attributes($attribs = '')

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -61,6 +61,7 @@ class SimplePie_Sanitize
 	var $strip_htmltags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style');
 	var $encode_instead_of_strip = false;
 	var $strip_attributes = array('bgsound', 'expr', 'id', 'style', 'onclick', 'onerror', 'onfinish', 'onmouseover', 'onmouseout', 'onfocus', 'onblur', 'lowsrc', 'dynsrc');
+	var $rename_attributes = array();
 	var $add_attributes = array('audio' => array('preload' => 'none'), 'iframe' => array('sandbox' => 'allow-scripts allow-same-origin'), 'video' => array('preload' => 'none'));
 	var $strip_comments = false;
 	var $output_encoding = 'UTF-8';
@@ -142,6 +143,25 @@ class SimplePie_Sanitize
 		if ($force_fsockopen)
 		{
 			$this->force_fsockopen = (string) $force_fsockopen;
+		}
+	}
+
+	public function rename_attributes($tags = array())
+	{
+		if ($tags)
+		{
+			if (is_array($tags))
+			{
+				$this->rename_attributes = $tags;
+			}
+			else
+			{
+				$this->rename_attributes = explode(',', $tags);
+			}
+		}
+		else
+		{
+			$this->rename_attributes = false;
 		}
 	}
 
@@ -371,6 +391,14 @@ class SimplePie_Sanitize
 					foreach ($this->strip_htmltags as $tag)
 					{
 						$this->strip_tag($tag, $document, $xpath, $type);
+					}
+				}
+
+				if ($this->rename_attributes)
+				{
+					foreach ($this->rename_attributes as $attrib)
+					{
+						$this->rename_attr($attrib, $xpath);
 					}
 				}
 
@@ -638,6 +666,17 @@ class SimplePie_Sanitize
 
 		foreach ($elements as $element)
 		{
+			$element->removeAttribute($attrib);
+		}
+	}
+
+	protected function rename_attr($attrib, $xpath)
+	{
+		$elements = $xpath->query('//*[@' . $attrib . ']');
+
+		foreach ($elements as $element)
+		{
+			$element->setAttribute('data-sanitized-' . $attrib, $element->getAttribute($attrib));
 			$element->removeAttribute($attrib);
 		}
 	}

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -146,25 +146,6 @@ class SimplePie_Sanitize
 		}
 	}
 
-	public function rename_attributes($attribs = array())
-	{
-		if ($attribs)
-		{
-			if (is_array($attribs))
-			{
-				$this->rename_attributes = $attribs;
-			}
-			else
-			{
-				$this->rename_attributes = explode(',', $attribs);
-			}
-		}
-		else
-		{
-			$this->rename_attributes = false;
-		}
-	}
-
 	public function strip_htmltags($tags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style'))
 	{
 		if ($tags)
@@ -187,6 +168,25 @@ class SimplePie_Sanitize
 	public function encode_instead_of_strip($encode = false)
 	{
 		$this->encode_instead_of_strip = (bool) $encode;
+	}
+
+	public function rename_attributes($attribs = array())
+	{
+		if ($attribs)
+		{
+			if (is_array($attribs))
+			{
+				$this->rename_attributes = $attribs;
+			}
+			else
+			{
+				$this->rename_attributes = explode(',', $attribs);
+			}
+		}
+		else
+		{
+			$this->rename_attributes = false;
+		}
 	}
 
 	public function strip_attributes($attribs = array('bgsound', 'expr', 'id', 'style', 'onclick', 'onerror', 'onfinish', 'onmouseover', 'onmouseout', 'onfocus', 'onblur', 'lowsrc', 'dynsrc'))

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -146,17 +146,17 @@ class SimplePie_Sanitize
 		}
 	}
 
-	public function rename_attributes($tags = array())
+	public function rename_attributes($attribs = array())
 	{
-		if ($tags)
+		if ($attribs)
 		{
-			if (is_array($tags))
+			if (is_array($attribs))
 			{
-				$this->rename_attributes = $tags;
+				$this->rename_attributes = $attribs;
 			}
 			else
 			{
-				$this->rename_attributes = explode(',', $tags);
+				$this->rename_attributes = explode(',', $attribs);
 			}
 		}
 		else


### PR DESCRIPTION
I want to bring a new method that we implemented into Simplepie of FreshRSS: https://github.com/FreshRSS/FreshRSS/pull/4175

The use case:
Simplepie can clean the HTML with `strip_attributes()`, but in some cases it would be very useful to keep the information of some attributes under another attribute name, f.e. `id` and `class`
The new `rename_attributes()` methods enables it. The `id` and `class` attributes could be renamed to `data-sanitized-id` / `data-sanitized-class`.

The benefit: when HTML/XML/RSS is included into an existing HTML DOM the imported HTML/XML/RSS could have id/class attributes that are already defined in the DOM, but with another meaning. Rename this attributes brings id/class out of standard CSS behavior but keeps the information. It is still possible to style it with `div[data-sanitized-class*="CLASSNAME"]`

It would be a pleasure to extend Simplepie with this little improvement.