### PR TITLE
fix file iteration

### DIFF
--- a/build/compile.php
+++ b/build/compile.php
@@ -51,6 +51,10 @@ $compiled .= remove_header($contents) . "\n";
 $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(SP_PATH . '/library/SimplePie'));
 foreach($files as $file_path => $info)
 {
+	/** @var SplFileInfo $info */
+	if (in_array($info->getFilename(), array('.', '..'))) {
+		continue;
+	}
 	$contents = file_get_contents($file_path);
 	$compiled .= remove_header($contents) . "\n";
 }

--- a/build/compile.php
+++ b/build/compile.php
@@ -48,13 +48,9 @@ $contents = file_get_contents(SP_PATH . '/library/SimplePie.php');
 $compiled .= remove_header($contents) . "\n";
 
 // Add all the files in the SimplePie directory
-$files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(SP_PATH . '/library/SimplePie'));
+$files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(SP_PATH . '/library/SimplePie', FilesystemIterator::SKIP_DOTS));
 foreach($files as $file_path => $info)
 {
-	/** @var SplFileInfo $info */
-	if (in_array($info->getFilename(), array('.', '..'))) {
-		continue;
-	}
 	$contents = file_get_contents($file_path);
 	$compiled .= remove_header($contents) . "\n";
 }


### PR DESCRIPTION
This fix is to address the special case where function call `file_get_contents(".")` and `file_get_contents("..")` are made when running script _build/compile.php_ of version `1.3.x` (or from branch `one-dot-three`).

The calls trigger `E_WARNING` level errors, as explained on [php.net](https://www.php.net/file_get_contents).