### PR TITLE
Re-enable xml:base for all supported RSS formats

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -2215,7 +2215,7 @@ class SimplePie
 	 */
 	public function get_base($element = array())
 	{
-		if (!($this->get_type() & SIMPLEPIE_TYPE_RSS_SYNDICATION) && !empty($element['xml_base_explicit']) && isset($element['xml_base']))
+		if (!empty($element['xml_base_explicit']) && isset($element['xml_base']))
 		{
 			return $element['xml_base'];
 		}


### PR DESCRIPTION
SimplePie already has the mechanism for supporting `xml:base` but it is disabled for some feed types.

So this PR reverts the commit disabling it https://github.com/simplepie/simplepie/commit/e49c578817aa504d8d05cd7f33857aeda9d41908 (see also my question there)

Specification, e.g. Atom:
* https://datatracker.ietf.org/doc/html/rfc4287#section-2

> Any element defined by this specification MAY have an xml:base attribute

While RSS 2.0 is silent on the matter https://cyber.harvard.edu/rss/relativeURI.html , here are examples of use from the same epoch:
* https://rssweblog.com/?guid=20050627094747
* https://www.drupal.org/project/views/issues/943762
