### PR TITLE
Fix status_code type

### DIFF
--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -429,7 +429,7 @@ class SimplePie
 	 * @see SimplePie::status_code()
 	 * @access private
 	 */
-	public $status_code;
+	public $status_code = 0;
 
 	/**
 	 * @var object Instance of SimplePie_Sanitize (or other class)

--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -59,7 +59,7 @@ class SimplePie_File
 	var $success = true;
 	var $headers = array();
 	var $body;
-	var $status_code;
+	var $status_code = 0;
 	var $redirects = 0;
 	var $error;
 	var $method = SIMPLEPIE_FILE_SOURCE_NONE;

--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -157,7 +157,7 @@ class SimplePie_HTTP_Parser
 		}
 
 		$this->http_version = '';
-		$this->status_code = '';
+		$this->status_code = 0;
 		$this->reason = '';
 		$this->headers = array();
 		$this->body = '';


### PR DESCRIPTION
`$status_code` is declared as `int` but was sometimes `null` or `string`, breaking some contracts.
Downstream: https://github.com/FreshRSS/FreshRSS/pull/4301
