### PR TITLE
Make status_code nullable

### DIFF
--- a/build/charset.php
+++ b/build/charset.php
@@ -10,7 +10,7 @@ function normalize_character_set($charset)
 function build_character_set_list()
 {
 	$file = new SimplePie_File('http://www.iana.org/assignments/character-sets');
-	if (!$file->success && !($file->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($file->status_code === 200 || $file->status_code > 206 && $file->status_code < 300)))
+	if (!$file->success && $file->method & SIMPLEPIE_FILE_SOURCE_REMOTE !== 0 && $file->status_code !== 200 && !($file->status_code > 206 && $file->status_code < 300))
 	{
 		return false;
 	}

--- a/src/File.php
+++ b/src/File.php
@@ -61,7 +61,7 @@ class File
 	var $success = true;
 	var $headers = array();
 	var $body;
-	var $status_code = 0;
+	var $status_code = null;
 	var $redirects = 0;
 	var $error;
 	var $method = \SimplePie\SimplePie::FILE_SOURCE_NONE;
@@ -121,7 +121,7 @@ class File
 					curl_setopt($fp, CURLOPT_ENCODING, 'none');
 					$this->headers = curl_exec($fp);
 				}
-				$this->status_code = curl_getinfo($fp, CURLINFO_HTTP_CODE);
+				$this->status_code = curl_getinfo($fp, CURLINFO_HTTP_CODE) ?: null;
 				if (curl_errno($fp))
 				{
 					$this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp);

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -412,11 +412,11 @@ class SimplePie
 	public $error;
 
 	/**
-	 * @var int HTTP status code
+	 * @var int|null HTTP status code
 	 * @see SimplePie::status_code()
 	 * @access private
 	 */
-	public $status_code = 0;
+	public $status_code = null;
 
 	/**
 	 * @var object Instance of \SimplePie\Sanitize (or other class)
@@ -1698,7 +1698,7 @@ class SimplePie
 		$this->status_code = $file->status_code;
 
 		// If the file connection has an error, set SimplePie::error to that and quit
-		if (!$file->success && !($file->method & self::FILE_SOURCE_REMOTE === 0 || ($file->status_code === 200 || $file->status_code > 206 && $file->status_code < 300)))
+		if (!$file->success && $file->method & self::FILE_SOURCE_REMOTE !== 0 && $file->status_code !== 200 && !($file->status_code > 206 && $file->status_code < 300))
 		{
 			$this->error = $file->error;
 			return !empty($this->data);
@@ -1711,7 +1711,7 @@ class SimplePie
 
 			if (!$locate->is_feed($file))
 			{
-				$copyStatusCode = $file->status_code;
+				$copyStatusCode = $file->status_code ?: '(not available)';
 				$copyContentType = $file->headers['content-type'];
 				try
 				{
@@ -1806,7 +1806,7 @@ class SimplePie
 	/**
 	 * Get the last HTTP status code
 	 *
-	 * @return int Status code
+	 * @return int|null Status code
 	 */
 	public function status_code()
 	{


### PR DESCRIPTION
This is to distinguish a status_code being set on the type level, making it harder to forget the case – static analysis would notify you.

This is technically a BC break but so is https://github.com/simplepie/simplepie/pull/728 and `null` behaves just like `0` from the perspective of non-strict comparison so I would not expect issues in legacy applications.
