### PR TITLE
GH Actions: run tests against PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     name: "PHP: ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout code
@@ -42,12 +43,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.1)"
-        if: ${{ matrix.php < '8.1' }}
+      - name: "Install Composer dependencies (PHP < 8.2)"
+        if: ${{ matrix.php < '8.2' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: "Install Composer dependencies (PHP 8.1)"
-        if: ${{ matrix.php >= '8.1' }}
+      - name: "Install Composer dependencies (PHP 8.2)"
+        if: ${{ matrix.php >= '8.2' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs


### PR DESCRIPTION
The first alpha of PHP 8.2 was released nearly two weeks ago, so let's start testing against PHP 8.2
