### PR TITLE
Allow usage of PSR-16 cache implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/simplepie/simplepie/compare/1.7.0...master)
 
+### Added
+
+- New method `SimplePie\SimplePie::set_cache()` for providing a PSR-16 cache implementation
+
 ## [1.7.0](https://github.com/simplepie/simplepie/compare/1.6.0...1.7.0) - 2022-09-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.8",
+        "psr/simple-cache": "^1 || ^2 || ^3",
         "yoast/phpunit-polyfills": "^1.0.1"
     },
     "suggest": {

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -43,6 +43,8 @@
 
 namespace SimplePie;
 
+use SimplePie\Cache\Base;
+
 /**
  * Used to create cache objects
  *
@@ -81,8 +83,8 @@ class Cache
      *
      * @param string $location URL location (scheme is used to determine handler)
      * @param string $filename Unique identifier for cache object
-     * @param string $extension 'spi' or 'spc'
-     * @return \SimplePie\Cache\Base Type of object depends on scheme of `$location`
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $extension 'spi' or 'spc'
+     * @return Base Type of object depends on scheme of `$location`
      */
     public static function get_handler($location, $filename, $extension)
     {
@@ -111,7 +113,7 @@ class Cache
      * Register a handler
      *
      * @param string $type DSN type to register for
-     * @param string $class Name of handler class. Must implement \SimplePie\Cache\Base
+     * @param class-string<Base> $class Name of handler class. Must implement Base
      */
     public static function register($type, $class)
     {

--- a/src/Cache/Base.php
+++ b/src/Cache/Base.php
@@ -73,7 +73,7 @@ interface Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type);
 

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -85,7 +85,7 @@ class File implements Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type)
     {

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -86,7 +86,7 @@ class Memcache implements Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type)
     {

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -82,8 +82,8 @@ class Memcached implements Base
     /**
      * Create a new cache object
      * @param string $location Location string (from SimplePie::$cache_location)
-     * @param string $name     Unique ID for the cache
-     * @param string $type     Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param string $name Unique ID for the cache
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type)
     {

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -83,7 +83,7 @@ class MySQL extends DB
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type)
     {

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -57,6 +57,23 @@ use SimplePie\SimplePie as SimplePieInstance;
 class Psr16 implements Base
 {
     /**
+     * stored PSR-16 cache implemtentation
+     *
+     * @var CacheInterface
+     */
+    private static $psr16storage = null;
+
+    /**
+     * stored a globally PSR-16 cache implemtentation
+     *
+     * @param CacheInterface $psr16cache
+     */
+    public static function store_psr16_cache(CacheInterface $psr16cache)
+    {
+        static::$psr16storage = $psr16cache;
+    }
+
+    /**
      * PSR-16 cache implemtentation
      *
      * @var CacheInterface
@@ -76,27 +93,18 @@ class Psr16 implements Base
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
      * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
-     * @param CacheInterface $psr16cache
      */
-    public function __construct($location, $name, $type/* , CacheInterface $psr16cache*/)
+    public function __construct($location, $name, $type)
     {
-        if (4 !== func_num_args()) {
+        if (static::$psr16storage === null) {
             throw new Exception(sprintf(
-                'Too few arguments to function %s, 3 passed, but exactly 4 expected.',
-                __METHOD__
+                'You must set an implementation of `%s` via `%s::set_psr16_cache()` first.',
+                CacheInterface::class,
+                SimplePieInstance::class
             ), \E_USER_ERROR);
         }
 
-        $psr16cache = func_get_arg(3);
-
-        if (! $psr16cache instanceof CacheInterface) {
-            throw new Exception(sprintf(
-                'Argument #4 ($psr16cache) in %s must be of type Psr\SimpleCache\CacheInterface.',
-                __METHOD__
-            ), \E_USER_ERROR);
-        }
-
-        $this->psr16cache = $psr16cache;
+        $this->psr16cache = static::$psr16storage;
 
         // BC: hashAlgo sha256 support was added in PHP 7.1
         $hashAlgo = in_array('sha256', hash_algos()) ? 'sha256' : 'sha1';

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -44,6 +44,7 @@
 namespace SimplePie\Cache;
 
 use Exception;
+use InvalidArgumentException;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\SimplePie as SimplePieInstance;
@@ -131,6 +132,14 @@ class Psr16 implements Base
             $data = $data->data;
         }
 
+        if (! is_array($data)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s::save(): Argument #1 ($data) must be of type array|%s',
+                self::class,
+                SimplePieInstance::class
+            ));
+        }
+
         try {
             $set1 = $this->cache->set($this->cacheKey, $data, $this->ttl);
             $set2 = $this->cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
@@ -153,7 +162,7 @@ class Psr16 implements Base
         try {
             $data = $this->cache->get($this->cacheKey, $cacheMiss);
 
-            if ($data === $cacheMiss) {
+            if ($data === $cacheMiss || ! is_array($data)) {
                 return false;
             }
         } catch (CacheException $th) {

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -102,7 +102,7 @@ final class Psr16 implements Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $type)
     {

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -47,6 +47,7 @@ use Exception;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\SimplePie as SimplePieInstance;
+use stdClass;
 
 /**
  * Caches data to the PSR-16 cache implementation
@@ -147,10 +148,12 @@ class Psr16 implements Base
      */
     public function load()
     {
-        try {
-            $data = $this->cache->get($this->cacheKey, $this);
+        $cacheMiss = new stdClass();
 
-            if ($data === $this) {
+        try {
+            $data = $this->cache->get($this->cacheKey, $cacheMiss);
+
+            if ($data === $cacheMiss) {
                 return false;
             }
         } catch (CacheException $th) {
@@ -167,13 +170,15 @@ class Psr16 implements Base
      */
     public function mtime()
     {
+        $cacheMiss = new stdClass();
+
         try {
-            $data = $this->cache->get($this->cacheKey . '_mtime', $this);
+            $data = $this->cache->get($this->cacheKey . '_mtime', $cacheMiss);
         } catch (CacheException $th) {
             return 0;
         }
 
-        if ($data === $this || ! is_int($data)) {
+        if ($data === $cacheMiss || ! is_int($data)) {
             return 0;
         }
 
@@ -187,10 +192,12 @@ class Psr16 implements Base
      */
     public function touch()
     {
-        try {
-            $data = $this->cache->get($this->cacheKey, $this);
+        $cacheMiss = new stdClass();
 
-            if ($data === $this) {
+        try {
+            $data = $this->cache->get($this->cacheKey, $cacheMiss);
+
+            if ($data === $cacheMiss) {
                 return false;
             }
 

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -218,12 +218,12 @@ class Psr16 implements Base
     public function unlink()
     {
         try {
-            $set1 = $this->cache->delete($this->cacheKey);
-            $set2 = $this->cache->delete($this->cacheKey . '_mtime');
+            $unset1 = $this->cache->delete($this->cacheKey);
+            $unset2 = $this->cache->delete($this->cacheKey . '_mtime');
         } catch (CacheException $th) {
             return false;
         }
 
-        return $set1 && $set2;
+        return $unset1 && $unset2;
     }
 }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -33,7 +33,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @copyright 2004-2022 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
  * @author Sam Sneddon
  * @author Ryan McCue
@@ -131,13 +131,13 @@ class Psr16 implements Base
         }
 
         try {
-            $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
-            $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
+            $set1 = $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
+            $set2 = $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $e) {
             return false;
         }
 
-        return true;
+        return $set1 && $set2;
     }
 
     /**
@@ -194,13 +194,13 @@ class Psr16 implements Base
                 return false;
             }
 
-            $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
-            $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
+            $set1 = $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
+            $set2 = $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $th) {
             return false;
         }
 
-        return true;
+        return $set1 && $set2;
     }
 
     /**
@@ -211,10 +211,12 @@ class Psr16 implements Base
     public function unlink()
     {
         try {
-            return $this->psr16cache->delete($this->cacheKey);
-            return $this->psr16cache->delete($this->cacheKey . '_mtime');
+            $set1 = $this->psr16cache->delete($this->cacheKey);
+            $set2 = $this->psr16cache->delete($this->cacheKey . '_mtime');
         } catch (CacheException $th) {
             return false;
         }
+
+        return $set1 && $set2;
     }
 }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -132,6 +132,7 @@ class Psr16 implements Base
 
         try {
             $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
+            $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $e) {
             return false;
         }
@@ -167,14 +168,16 @@ class Psr16 implements Base
     public function mtime()
     {
         try {
-            if ($this->psr16cache->get($this->cacheKey, $this) === $this) {
-                return 0;
-            }
+            $data = $this->psr16cache->get($this->cacheKey . '_mtime', $this);
         } catch (CacheException $th) {
             return 0;
         }
 
-        return time();
+        if ($data === $this || ! is_int($data)) {
+            return 0;
+        }
+
+        return $data;
     }
 
     /**
@@ -191,9 +194,8 @@ class Psr16 implements Base
                 return false;
             }
 
-            $this->psr16cache->delete($this->cacheKey);
-
             $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
+            $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $th) {
             return false;
         }
@@ -209,11 +211,10 @@ class Psr16 implements Base
     public function unlink()
     {
         try {
-            $this->psr16cache->delete($this->cacheKey);
+            return $this->psr16cache->delete($this->cacheKey);
+            return $this->psr16cache->delete($this->cacheKey . '_mtime');
         } catch (CacheException $th) {
             return false;
         }
-
-        return true;
     }
 }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -56,7 +56,7 @@ use stdClass;
  * @package SimplePie
  * @subpackage Caching
  */
-class Psr16 implements Base
+final class Psr16 implements Base
 {
     /**
      * stored PSR-16 cache implementation
@@ -68,6 +68,7 @@ class Psr16 implements Base
     /**
      * stored a globally PSR-16 cache implementation
      *
+     * @internal
      * @param CacheInterface $cache
      */
     public static function store_cache(CacheInterface $cache)

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -88,6 +88,13 @@ class Psr16 implements Base
     private $cacheKey;
 
     /**
+     * cache time to live
+     *
+     * @var int
+     */
+    private $ttl = 3600;
+
+    /**
      * Create a new cache object
      *
      * @param string $location Location string (from SimplePie::$cache_location)
@@ -124,7 +131,7 @@ class Psr16 implements Base
         }
 
         try {
-            $this->psr16cache->set($this->cacheKey, serialize($data));
+            $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
         } catch (CacheException $e) {
             return false;
         }
@@ -149,7 +156,7 @@ class Psr16 implements Base
             return false;
         }
 
-        return unserialize($data);
+        return $data;
     }
 
     /**
@@ -186,7 +193,7 @@ class Psr16 implements Base
 
             $this->psr16cache->delete($this->cacheKey);
 
-            $this->psr16cache->set($this->cacheKey, $data);
+            $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
         } catch (CacheException $th) {
             return false;
         }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2022, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace SimplePie\Cache;
+
+use Exception;
+use Psr\SimpleCache\CacheException;
+use Psr\SimpleCache\CacheInterface;
+use SimplePie\SimplePie as SimplePieInstance;
+
+/**
+ * Caches data to the PSR-16 cache implementation
+ *
+ * @package SimplePie
+ * @subpackage Caching
+ */
+class Psr16 implements Base
+{
+    /**
+     * PSR-16 cache implemtentation
+     *
+     * @var CacheInterface
+     */
+    private $psr16cache;
+
+    /**
+     * PSR-16 cache key
+     *
+     * @var string
+     */
+    private $cacheKey;
+
+    /**
+     * Create a new cache object
+     *
+     * @param string $location Location string (from SimplePie::$cache_location)
+     * @param string $name Unique ID for the cache
+     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param CacheInterface $psr16cache
+     */
+    public function __construct($location, $name, $type/* , CacheInterface $psr16cache*/)
+    {
+        if (4 !== func_num_args()) {
+            throw new Exception(sprintf(
+                'Too few arguments to function %s, 3 passed, but exactly 4 expected.',
+                __METHOD__
+            ), \E_USER_ERROR);
+        }
+
+        $psr16cache = func_get_arg(3);
+
+        if (! $psr16cache instanceof CacheInterface) {
+            throw new Exception(sprintf(
+                'Argument #4 ($psr16cache) in %s must be of type Psr\SimpleCache\CacheInterface.',
+                __METHOD__
+            ), \E_USER_ERROR);
+        }
+
+        $this->psr16cache = $psr16cache;
+
+        // BC: hashAlgo sha256 support was added in PHP 7.1
+        $hashAlgo = in_array('sha256', hash_algos()) ? 'sha256' : 'sha1';
+        $this->cacheKey = hash($hashAlgo, "$location/$name.$type");
+    }
+
+    /**
+     * Save data to the cache
+     *
+     * @param array|SimplePieInstance $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @return bool Successfulness
+     */
+    public function save($data)
+    {
+        if ($data instanceof SimplePieInstance) {
+            $data = $data->data;
+        }
+
+        try {
+            $this->psr16cache->set($this->cacheKey, serialize($data));
+        } catch (CacheException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieve the data saved to the cache
+     *
+     * @return array Data for SimplePie::$data
+     */
+    public function load()
+    {
+        try {
+            $data = $this->psr16cache->get($this->cacheKey, $this);
+
+            if ($data === $this) {
+                return false;
+            }
+        } catch (CacheException $th) {
+            return false;
+        }
+
+        return unserialize($data);
+    }
+
+    /**
+     * Retrieve the last modified time for the cache
+     *
+     * @return int Timestamp
+     */
+    public function mtime()
+    {
+        try {
+            if ($this->psr16cache->get($this->cacheKey, $this) === $this) {
+                return 0;
+            }
+        } catch (CacheException $th) {
+            return 0;
+        }
+
+        return time();
+    }
+
+    /**
+     * Set the last modified time to the current time
+     *
+     * @return bool Success status
+     */
+    public function touch()
+    {
+        try {
+            $data = $this->psr16cache->get($this->cacheKey, $this);
+
+            if ($data === $this) {
+                return false;
+            }
+
+            $this->psr16cache->delete($this->cacheKey);
+
+            $this->psr16cache->set($this->cacheKey, $data);
+        } catch (CacheException $th) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove the cache
+     *
+     * @return bool Success status
+     */
+    public function unlink()
+    {
+        try {
+            $this->psr16cache->delete($this->cacheKey);
+        } catch (CacheException $th) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -55,6 +55,7 @@ use stdClass;
  *
  * @package SimplePie
  * @subpackage Caching
+ * @internal
  */
 final class Psr16 implements Base
 {

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -66,11 +66,11 @@ class Psr16 implements Base
     /**
      * stored a globally PSR-16 cache implemtentation
      *
-     * @param CacheInterface $psr16cache
+     * @param CacheInterface $cache
      */
-    public static function store_psr16_cache(CacheInterface $psr16cache)
+    public static function store_cache(CacheInterface $cache)
     {
-        static::$psr16storage = $psr16cache;
+        static::$psr16storage = $cache;
     }
 
     /**
@@ -78,7 +78,7 @@ class Psr16 implements Base
      *
      * @var CacheInterface
      */
-    private $psr16cache;
+    private $cache;
 
     /**
      * PSR-16 cache key
@@ -105,13 +105,13 @@ class Psr16 implements Base
     {
         if (static::$psr16storage === null) {
             throw new Exception(sprintf(
-                'You must set an implementation of `%s` via `%s::set_psr16_cache()` first.',
+                'You must set an implementation of `%s` via `%s::set_cache()` first.',
                 CacheInterface::class,
                 SimplePieInstance::class
             ), \E_USER_ERROR);
         }
 
-        $this->psr16cache = static::$psr16storage;
+        $this->cache = static::$psr16storage;
 
         // BC: hashAlgo sha256 support was added in PHP 7.1
         $hashAlgo = in_array('sha256', hash_algos()) ? 'sha256' : 'sha1';
@@ -131,8 +131,8 @@ class Psr16 implements Base
         }
 
         try {
-            $set1 = $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
-            $set2 = $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
+            $set1 = $this->cache->set($this->cacheKey, $data, $this->ttl);
+            $set2 = $this->cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $e) {
             return false;
         }
@@ -148,7 +148,7 @@ class Psr16 implements Base
     public function load()
     {
         try {
-            $data = $this->psr16cache->get($this->cacheKey, $this);
+            $data = $this->cache->get($this->cacheKey, $this);
 
             if ($data === $this) {
                 return false;
@@ -168,7 +168,7 @@ class Psr16 implements Base
     public function mtime()
     {
         try {
-            $data = $this->psr16cache->get($this->cacheKey . '_mtime', $this);
+            $data = $this->cache->get($this->cacheKey . '_mtime', $this);
         } catch (CacheException $th) {
             return 0;
         }
@@ -188,14 +188,14 @@ class Psr16 implements Base
     public function touch()
     {
         try {
-            $data = $this->psr16cache->get($this->cacheKey, $this);
+            $data = $this->cache->get($this->cacheKey, $this);
 
             if ($data === $this) {
                 return false;
             }
 
-            $set1 = $this->psr16cache->set($this->cacheKey, $data, $this->ttl);
-            $set2 = $this->psr16cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
+            $set1 = $this->cache->set($this->cacheKey, $data, $this->ttl);
+            $set2 = $this->cache->set($this->cacheKey . '_mtime', time(), $this->ttl);
         } catch (CacheException $th) {
             return false;
         }
@@ -211,8 +211,8 @@ class Psr16 implements Base
     public function unlink()
     {
         try {
-            $set1 = $this->psr16cache->delete($this->cacheKey);
-            $set2 = $this->psr16cache->delete($this->cacheKey . '_mtime');
+            $set1 = $this->cache->delete($this->cacheKey);
+            $set2 = $this->cache->delete($this->cacheKey . '_mtime');
         } catch (CacheException $th) {
             return false;
         }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -57,14 +57,14 @@ use SimplePie\SimplePie as SimplePieInstance;
 class Psr16 implements Base
 {
     /**
-     * stored PSR-16 cache implemtentation
+     * stored PSR-16 cache implementation
      *
      * @var CacheInterface
      */
     private static $psr16storage = null;
 
     /**
-     * stored a globally PSR-16 cache implemtentation
+     * stored a globally PSR-16 cache implementation
      *
      * @param CacheInterface $cache
      */
@@ -74,7 +74,7 @@ class Psr16 implements Base
     }
 
     /**
-     * PSR-16 cache implemtentation
+     * PSR-16 cache implementation
      *
      * @var CacheInterface
      */

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -93,7 +93,7 @@ class Redis implements Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
     public function __construct($location, $name, $options = null)
     {

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -43,6 +43,8 @@
 
 namespace SimplePie;
 
+use SimplePie\Cache\Base;
+
 /**
  * Used for data cleanup and post-processing
  *
@@ -377,7 +379,7 @@ class Sanitize
                     foreach ($images as $img) {
                         if ($img->hasAttribute('src')) {
                             $image_url = call_user_func($this->cache_name_function, $img->getAttribute('src'));
-                            $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, $image_url, 'spi']);
+                            $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, $image_url, Base::TYPE_IMAGE]);
 
                             if ($cache->load()) {
                                 $img->setAttribute('src', $this->image_handler . $image_url);

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -43,6 +43,9 @@
 
 namespace SimplePie;
 
+use Psr\SimpleCache\CacheInterface;
+use SimplePie\Cache\Psr16;
+
 /**
  * SimplePie
  *
@@ -852,6 +855,18 @@ class SimplePie
     public function enable_cache($enable = true)
     {
         $this->cache = (bool) $enable;
+    }
+
+    /**
+     * Set a PSR-16 implementation as cache
+     *
+     * @param CacheInterface $psr16cache The PSR-16 cache implementation
+     */
+    public function set_psr16_cache(CacheInterface $psr16cache)
+    {
+        Psr16::store_psr16_cache($psr16cache);
+        $this->registry->call('Cache', 'register', ['psr16', Psr16::class]);
+        $this->cache_location = 'psr16';
     }
 
     /**

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -44,6 +44,7 @@
 namespace SimplePie;
 
 use Psr\SimpleCache\CacheInterface;
+use SimplePie\Cache\Base;
 use SimplePie\Cache\Psr16;
 
 /**
@@ -1411,7 +1412,7 @@ class SimplePie
             // Decide whether to enable caching
             if ($this->cache && $parsed_feed_url['scheme'] !== '') {
                 $filename = $this->get_cache_filename($this->feed_url);
-                $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, $filename, 'spc']);
+                $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, $filename, Base::TYPE_FEED]);
             }
 
             // Fetch the data via \SimplePie\File into $this->raw_data
@@ -1697,7 +1698,7 @@ class SimplePie
                     if (!$cache->save($this)) {
                         trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
                     }
-                    $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, call_user_func($this->cache_name_function, $file->url), 'spc']);
+                    $cache = $this->registry->call('Cache', 'get_handler', [$this->cache_location, call_user_func($this->cache_name_function, $file->url), Base::TYPE_FEED]);
                 }
             }
             $this->feed_url = $file->url;

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -862,9 +862,9 @@ class SimplePie
      *
      * @param CacheInterface $psr16cache The PSR-16 cache implementation
      */
-    public function set_psr16_cache(CacheInterface $psr16cache)
+    public function set_cache(CacheInterface $cache)
     {
-        Psr16::store_psr16_cache($psr16cache);
+        Psr16::store_cache($cache);
         $this->registry->call('Cache', 'register', ['psr16', Psr16::class]);
         $this->cache_location = 'psr16';
     }

--- a/tests/Fixtures/Exception/Psr16CacheException.php
+++ b/tests/Fixtures/Exception/Psr16CacheException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SimplePie\Tests\Fixtures\Exception;
+
+use Exception;
+use Psr\SimpleCache\CacheException;
+
+/**
+ * BC: This can be an anonymous class in PHP 7+.
+ */
+class Psr16CacheException extends Exception implements CacheException
+{
+}

--- a/tests/Fixtures/FileMock.php
+++ b/tests/Fixtures/FileMock.php
@@ -3,6 +3,7 @@
 namespace SimplePie\Tests\Fixtures;
 
 use SimplePie\File;
+use SimplePie\SimplePie;
 
 /**
  * Acts as a fake feed request
@@ -16,7 +17,7 @@ class FileMock extends File
         $this->headers = [
             'content-type' => 'application/atom+xml'
         ];
-        $this->method = SIMPLEPIE_FILE_SOURCE_REMOTE;
+        $this->method = SimplePie::FILE_SOURCE_REMOTE;
         $this->body = '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />';
         $this->status_code = 200;
     }

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -74,7 +74,7 @@ class Psr16Test extends TestCase
         $this->assertFalse($cache->save($data));
     }
 
-    public function testSaveReturnsTrue()
+    public function testSaveReturnsTrueIfDataAndMtimeCouldBeWritten()
     {
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
@@ -95,7 +95,7 @@ class Psr16Test extends TestCase
         $this->assertTrue($cache->save($data));
     }
 
-    public function testSaveReturnsFalse()
+    public function testSaveReturnsFalseIfDataOrMtimeCouldNotBeWritten()
     {
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
@@ -107,7 +107,7 @@ class Psr16Test extends TestCase
         $this->assertFalse($cache->save($data));
     }
 
-    public function testSaveCatchExceptionAndReturnsFalse()
+    public function testSaveCatchesCacheExceptionAndReturnsFalse()
     {
         $e = new Psr16CacheException();
 
@@ -121,7 +121,7 @@ class Psr16Test extends TestCase
         $this->assertFalse($cache->save($data));
     }
 
-    public function testLoadReturnsData()
+    public function testLoadReturnsCorrectData()
     {
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
@@ -133,11 +133,11 @@ class Psr16Test extends TestCase
         $this->assertSame($data, $cache->load());
     }
 
-    public function testLoadReturnsFalse()
+    public function testLoadReturnsFalseOnCacheMiss()
     {
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('get')->willReturnCallback(function ($a, $b) {
-            return $b;
+        $psr16->expects($this->once())->method('get')->willReturnCallback(function ($key, $default) {
+            return $default;
         });
 
         Psr16::store_cache($psr16);
@@ -169,7 +169,7 @@ class Psr16Test extends TestCase
         $this->assertSame(0, $cache->mtime());
     }
 
-    public function testMtimeReturnsZeroOnException()
+    public function testMtimeReturnsZeroOnCacheException()
     {
         $e = new Psr16CacheException();
 
@@ -182,7 +182,7 @@ class Psr16Test extends TestCase
         $this->assertSame(0, $cache->mtime());
     }
 
-    public function testTouchReturnsTrue()
+    public function testTouchReturnsTrueIfDataAndMtimeCouldBeWritten()
     {
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn(true);
@@ -205,7 +205,7 @@ class Psr16Test extends TestCase
         $this->assertSame(false, $cache->touch());
     }
 
-    public function testTouchReturnsFalseOnException()
+    public function testTouchReturnsFalseOnCacheException()
     {
         $e = new Psr16CacheException();
 
@@ -218,7 +218,7 @@ class Psr16Test extends TestCase
         $this->assertSame(false, $cache->touch());
     }
 
-    public function testUnlinkReturnsTrue()
+    public function testUnlinkReturnsTrueIfDataAndMtimeCouldBeDeleted()
     {
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->exactly(2))->method('delete')->willReturn(true);
@@ -229,7 +229,7 @@ class Psr16Test extends TestCase
         $this->assertSame(true, $cache->unlink());
     }
 
-    public function testUnlinkReturnsFalseOnFalse()
+    public function testUnlinkReturnsFalseIfDataOrMtimeCouldNotBeDeleted()
     {
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->exactly(2))->method('delete')->willReturn(false);
@@ -240,7 +240,7 @@ class Psr16Test extends TestCase
         $this->assertSame(false, $cache->unlink());
     }
 
-    public function testUnlinkReturnsFalseOnException()
+    public function testUnlinkReturnsFalseOnCacheException()
     {
         $e = new Psr16CacheException();
 

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -45,7 +45,6 @@ namespace SimplePie\Tests\Unit\Cache;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
-use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\Cache\Psr16;
 use SimplePie\Tests\Fixtures\Exception\Psr16CacheException;
@@ -55,7 +54,7 @@ class Psr16Test extends TestCase
     public function testImplementationIsGloballyStored()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('You must set an implementation of `Psr\SimpleCache\CacheInterface` via `SimplePie\SimplePie::set_psr16_cache()` first.');
+        $this->expectExceptionMessage('You must set an implementation of `Psr\SimpleCache\CacheInterface` via `SimplePie\SimplePie::set_cache()` first.');
 
         new Psr16('location', 'name', 'type');
     }
@@ -75,7 +74,7 @@ class Psr16Test extends TestCase
             ]
         )->willReturn(true);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertTrue($cache->save($data));
@@ -83,13 +82,11 @@ class Psr16Test extends TestCase
 
     public function testSaveReturnsFalse()
     {
-        $e = new Psr16CacheException();
-
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->exactly(2))->method('set')->willReturn(false);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertFalse($cache->save($data));
@@ -103,7 +100,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('set')->willThrowException($e);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertFalse($cache->save($data));
@@ -115,7 +112,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn($data);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame($data, $cache->load());
@@ -128,7 +125,7 @@ class Psr16Test extends TestCase
             return $b;
         });
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->load());
@@ -140,7 +137,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn($data);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame($data, $cache->mtime());
@@ -151,7 +148,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn(false);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(0, $cache->mtime());
@@ -164,7 +161,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willThrowException($e);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(0, $cache->mtime());
@@ -172,12 +169,11 @@ class Psr16Test extends TestCase
 
     public function testTouchReturnsTrue()
     {
-        $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn(true);
         $psr16->expects($this->exactly(2))->method('set')->willReturn(true);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(true, $cache->touch());
@@ -188,7 +184,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn(false);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->touch());
@@ -201,7 +197,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willThrowException($e);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->touch());
@@ -209,11 +205,10 @@ class Psr16Test extends TestCase
 
     public function testUnlinkReturnsTrue()
     {
-        $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->exactly(2))->method('delete')->willReturn(true);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(true, $cache->unlink());
@@ -224,7 +219,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->exactly(2))->method('delete')->willReturn(false);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->unlink());
@@ -237,7 +232,7 @@ class Psr16Test extends TestCase
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('delete')->willThrowException($e);
 
-        Psr16::store_psr16_cache($psr16);
+        Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->unlink());

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -45,6 +45,7 @@ namespace SimplePie\Tests\Unit\Cache;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\Cache\Psr16;
 
@@ -56,5 +57,62 @@ class Psr16Test extends TestCase
         $this->expectExceptionMessage('You must set an implementation of `Psr\SimpleCache\CacheInterface` via `SimplePie\SimplePie::set_psr16_cache()` first.');
 
         new Psr16('location', 'name', 'type');
+    }
+
+    public function testSaveReturnsTrue()
+    {
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('set')->with(
+            '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7',
+            $data,
+            3600
+        );
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertTrue($cache->save($data));
+    }
+
+    public function testSaveReturnsFalse()
+    {
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('set')->with(
+            '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7',
+            $data,
+            3600
+        )->willThrowException($this->createMock(CacheException::class));
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertFalse($cache->save($data));
+    }
+
+    public function testLoadReturnsData()
+    {
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn($data);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame($data, $cache->load());
+    }
+
+    public function testLoadReturnsFalse()
+    {
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturnCallback(function($a, $b) {
+            return $b;
+        });
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(false, $cache->load());
     }
 }

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -63,10 +63,15 @@ class Psr16Test extends TestCase
     {
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('set')->with(
-            '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7',
-            $data,
-            3600
+        $psr16->expects($this->exactly(2))->method('set')->withConsecutive(
+            [
+                '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7',
+                $data,
+                3600,
+            ],
+            [
+                '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7_mtime'
+            ]
         );
 
         Psr16::store_psr16_cache($psr16);
@@ -79,11 +84,9 @@ class Psr16Test extends TestCase
     {
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('set')->with(
-            '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7',
-            $data,
-            3600
-        )->willThrowException($this->createMock(CacheException::class));
+        $psr16->expects($this->once())->method('set')->willThrowException(
+            $this->createMock(CacheException::class)
+        );
 
         Psr16::store_psr16_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -50,19 +50,11 @@ use SimplePie\Cache\Psr16;
 
 class Psr16Test extends TestCase
 {
-    public function testConstructorArgument4IsPassed()
+    public function testImplementationIsGloballyStored()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Too few arguments to function SimplePie\Cache\Psr16::__construct, 3 passed, but exactly 4 expected.');
+        $this->expectExceptionMessage('You must set an implementation of `Psr\SimpleCache\CacheInterface` via `SimplePie\SimplePie::set_psr16_cache()` first.');
 
         new Psr16('location', 'name', 'type');
-    }
-
-    public function testConstructorArgument4IsCacheInterface()
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Argument #4 ($psr16cache) in SimplePie\Cache\Psr16::__construct must be of type Psr\SimpleCache\CacheInterface.');
-
-        new Psr16('location', 'name', 'type', 'wrong type');
     }
 }

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -73,7 +73,7 @@ class Psr16Test extends TestCase
             [
                 '18bb0a0a94b49eda35e8944672d60a1474ff2895524f0e56c3752c1e0f7853e7_mtime'
             ]
-        );
+        )->willReturn(true);
 
         Psr16::store_psr16_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
@@ -82,6 +82,20 @@ class Psr16Test extends TestCase
     }
 
     public function testSaveReturnsFalse()
+    {
+        $e = new Psr16CacheException();
+
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->exactly(2))->method('set')->willReturn(false);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertFalse($cache->save($data));
+    }
+
+    public function testSaveCatchExceptionAndReturnsFalse()
     {
         $e = new Psr16CacheException();
 
@@ -110,7 +124,7 @@ class Psr16Test extends TestCase
     public function testLoadReturnsFalse()
     {
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('get')->willReturnCallback(function($a, $b) {
+        $psr16->expects($this->once())->method('get')->willReturnCallback(function ($a, $b) {
             return $b;
         });
 
@@ -118,5 +132,114 @@ class Psr16Test extends TestCase
         $cache = new Psr16('location', 'name', 'type');
 
         $this->assertSame(false, $cache->load());
+    }
+
+    public function testMtimeReturnsCorrectInt()
+    {
+        $data = 1234568790;
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn($data);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame($data, $cache->mtime());
+    }
+
+    public function testMtimeReturnsZeroOnNonInteger()
+    {
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn(false);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(0, $cache->mtime());
+    }
+
+    public function testMtimeReturnsZeroOnException()
+    {
+        $e = new Psr16CacheException();
+
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willThrowException($e);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(0, $cache->mtime());
+    }
+
+    public function testTouchReturnsTrue()
+    {
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn(true);
+        $psr16->expects($this->exactly(2))->method('set')->willReturn(true);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(true, $cache->touch());
+    }
+
+    public function testTouchReturnsFalseOnNonInteger()
+    {
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn(false);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(false, $cache->touch());
+    }
+
+    public function testTouchReturnsFalseOnException()
+    {
+        $e = new Psr16CacheException();
+
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willThrowException($e);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(false, $cache->touch());
+    }
+
+    public function testUnlinkReturnsTrue()
+    {
+        $data = [];
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->exactly(2))->method('delete')->willReturn(true);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(true, $cache->unlink());
+    }
+
+    public function testUnlinkReturnsFalseOnFalse()
+    {
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->exactly(2))->method('delete')->willReturn(false);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(false, $cache->unlink());
+    }
+
+    public function testUnlinkReturnsFalseOnException()
+    {
+        $e = new Psr16CacheException();
+
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('delete')->willThrowException($e);
+
+        Psr16::store_psr16_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->assertSame(false, $cache->unlink());
     }
 }

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -83,13 +83,7 @@ class Psr16Test extends TestCase
 
     public function testSaveReturnsFalse()
     {
-        $e = $this->createMock(CacheException::class);
-
-        if (version_compare(PHP_VERSION, '7.0', '<')) {
-            $e = new Psr16CacheException();
-        } else if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $e = new class extends \Exception implements CacheException {};
-        }
+        $e = new Psr16CacheException();
 
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -148,14 +148,15 @@ class Psr16Test extends TestCase
 
     public function testMtimeReturnsCorrectInt()
     {
-        $data = 1234568790;
+        $mtime = 1234568790;
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('get')->willReturn($data);
+        // Modification time is stored as a separate cache key
+        $psr16->expects($this->once())->method('get')->willReturn($mtime);
 
         Psr16::store_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');
 
-        $this->assertSame($data, $cache->mtime());
+        $this->assertSame($mtime, $cache->mtime());
     }
 
     public function testMtimeReturnsZeroOnNonInteger()

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -48,6 +48,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\Cache\Psr16;
+use SimplePie\Tests\Fixtures\Exception\Psr16CacheException;
 
 class Psr16Test extends TestCase
 {
@@ -84,8 +85,9 @@ class Psr16Test extends TestCase
     {
         $e = $this->createMock(CacheException::class);
 
-        // BC
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
+        if (version_compare(PHP_VERSION, '7.0', '<')) {
+            $e = new Psr16CacheException();
+        } else if (version_compare(PHP_VERSION, '8.0', '<')) {
             $e = new class extends \Exception implements CacheException {};
         }
 

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -44,6 +44,7 @@
 namespace SimplePie\Tests\Unit\Cache;
 
 use Exception;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 use SimplePie\Cache\Psr16;
@@ -57,6 +58,20 @@ class Psr16Test extends TestCase
         $this->expectExceptionMessage('You must set an implementation of `Psr\SimpleCache\CacheInterface` via `SimplePie\SimplePie::set_cache()` first.');
 
         new Psr16('location', 'name', 'type');
+    }
+
+    public function testSaveWithWrongDataTypeThrowsInvalidArgumentException()
+    {
+        $data = 'string';
+        $psr16 = $this->createMock(CacheInterface::class);
+
+        Psr16::store_cache($psr16);
+        $cache = new Psr16('location', 'name', 'type');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('SimplePie\Cache\Psr16::save(): Argument #1 ($data) must be of type array|SimplePie\SimplePie');
+
+        $this->assertFalse($cache->save($data));
     }
 
     public function testSaveReturnsTrue()

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2022, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2022 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace SimplePie\Tests\Unit\Cache;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+use SimplePie\Cache\Psr16;
+
+class Psr16Test extends TestCase
+{
+    public function testConstructorArgument4IsPassed()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Too few arguments to function SimplePie\Cache\Psr16::__construct, 3 passed, but exactly 4 expected.');
+
+        new Psr16('location', 'name', 'type');
+    }
+
+    public function testConstructorArgument4IsCacheInterface()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Argument #4 ($psr16cache) in SimplePie\Cache\Psr16::__construct must be of type Psr\SimpleCache\CacheInterface.');
+
+        new Psr16('location', 'name', 'type', 'wrong type');
+    }
+}

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -82,11 +82,16 @@ class Psr16Test extends TestCase
 
     public function testSaveReturnsFalse()
     {
+        $e = $this->createMock(CacheException::class);
+
+        // BC
+        if (version_compare(PHP_VERSION, '8.0', '<')) {
+            $e = new class extends \Exception implements CacheException {};
+        }
+
         $data = [];
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('set')->willThrowException(
-            $this->createMock(CacheException::class)
-        );
+        $psr16->expects($this->once())->method('set')->willThrowException($e);
 
         Psr16::store_psr16_cache($psr16);
         $cache = new Psr16('location', 'name', 'type');

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -44,6 +44,7 @@
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
 use SimplePie\SimplePie;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
@@ -236,6 +237,19 @@ class SimplePieTest extends TestCase
         $feed = $this->createFeedWithTemplate($data, $content);
         $item = $feed->get_item();
         $this->assertSame($content, $item->get_content());
+    }
+
+    public function testSetPsr16Cache()
+    {
+        $psr16 = $this->createMock(CacheInterface::class);
+        $psr16->expects($this->once())->method('get')->willReturn('a:0:{}');
+
+        $feed = new SimplePie();
+        $feed->set_psr16_cache($psr16);
+        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $feed->set_feed_url('http://example.com/feed/');
+
+        $feed->init();
     }
 
     public function testLegacyCallOfSetCacheClass()

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -246,7 +246,7 @@ class SimplePieTest extends TestCase
         $psr16->expects($this->exactly(2))->method('set')->willReturn(true);
 
         $feed = new SimplePie();
-        $feed->set_psr16_cache($psr16);
+        $feed->set_cache($psr16);
         $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
         $feed->set_feed_url('http://example.com/feed/');
 

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -242,7 +242,7 @@ class SimplePieTest extends TestCase
     public function testSetPsr16Cache()
     {
         $psr16 = $this->createMock(CacheInterface::class);
-        $psr16->expects($this->once())->method('get')->willReturn('a:0:{}');
+        $psr16->expects($this->once())->method('get')->willReturn([]);
 
         $feed = new SimplePie();
         $feed->set_psr16_cache($psr16);

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -243,6 +243,7 @@ class SimplePieTest extends TestCase
     {
         $psr16 = $this->createMock(CacheInterface::class);
         $psr16->expects($this->once())->method('get')->willReturn([]);
+        $psr16->expects($this->exactly(2))->method('set')->willReturn(true);
 
         $feed = new SimplePie();
         $feed->set_psr16_cache($psr16);


### PR DESCRIPTION
Hi 👋 

this PR allows the usage of an extern [PSR-16](https://www.php-fig.org/psr/psr-16/) cache implementation by registering a new cache type in `Cache` class. 

I propose this feature for SimplePie 1.8.0, see roadmap #731.

Next steps could be to deprecate the usage of the internal cache solutions (mysql, file, redis, memcache and memcached) and remove them in v2 in favor of PSR-16.