### PR TITLE
Fix item get_base

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -151,15 +151,21 @@ class Item
     }
 
     /**
-     * Get the base URL value from the parent feed
-     *
-     * Uses `<xml:base>`
+     * Get the base URL value.
+     * Uses `<xml:base>`, or item link, or feed base URL.
      *
      * @param array $element
      * @return string
      */
     public function get_base($element = [])
     {
+        if (!empty($element['xml_base_explicit']) && isset($element['xml_base'])) {
+            return $element['xml_base'];
+        }
+        $link = $this->get_permalink();
+        if ($link != null) {
+            return $link;
+        }
         return $this->feed->get_base($element);
     }
 

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -3346,7 +3346,8 @@ EOT
         </content>
     </entry>
 </feed>
-EOT,
+EOT
+                ,
                 '<a href="http://example.net/tests/test2/hello.html#world">Hello</a>',
             ],
             'Test item get_base item link' => [
@@ -3363,7 +3364,8 @@ EOT,
         </content>
     </entry>
 </feed>
-EOT,
+EOT
+                ,
                 '<a href="http://example.net/tests/test1/hello.html#world">Hello</a>',
             ],
             'Test item get_base feed link' => [
@@ -3379,7 +3381,8 @@ EOT,
         </content>
     </entry>
 </feed>
-EOT,
+EOT
+                ,
                 '<a href="http://example.net/tests/hello.html#world">Hello</a>',
             ],
         ];

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -3314,6 +3314,78 @@ EOT
     }
 
     /**
+     * @dataProvider getBaseProvider
+     */
+    public function test_get_base($data, $expected)
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data($data);
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        $this->assertInstanceOf(Item::class, $item);
+
+        $this->assertSame($expected, $item->get_content());
+    }
+
+    public function getBaseProvider()
+    {
+        return [
+            'Test item get_base xml:base' => [
+<<<EOT
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">Test get_base 1</title>
+    <link rel="alternate" type="text/html" href="http://example.net/tests/"/>
+    <entry>
+        <title>Test get_base 1.1</title>
+        <link rel="alternate" type="text/html" href="http://example.net/tests/test1/example.html"/>
+        <id>tag:example.net,2022:1</id>
+        <content type="html" xml:base="http://example.net/tests/test2/">
+            &lt;a href="hello.html#world"&gt;Hello&lt;/a&gt;
+        </content>
+    </entry>
+</feed>
+EOT,
+                '<a href="http://example.net/tests/test2/hello.html#world">Hello</a>',
+            ],
+            'Test item get_base item link' => [
+<<<EOT
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">Test get_base 2</title>
+    <link rel="alternate" type="text/html" href="http://example.net/tests/"/>
+    <entry>
+        <title>Test get_base 2.1</title>
+        <link rel="alternate" type="text/html" href="http://example.net/tests/test1/example.html"/>
+        <id>tag:example.net,2022:2</id>
+        <content type="html">
+            &lt;a href="hello.html#world"&gt;Hello&lt;/a&gt;
+        </content>
+    </entry>
+</feed>
+EOT,
+                '<a href="http://example.net/tests/test1/hello.html#world">Hello</a>',
+            ],
+            'Test item get_base feed link' => [
+<<<EOT
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">Test get_base 3</title>
+    <link rel="alternate" type="text/html" href="http://example.net/tests/"/>
+    <entry>
+        <title>Test get_base 3.1</title>
+        <id>tag:example.net,2022:3</id>
+        <content type="xhtml">
+            <div xmlns="http://www.w3.org/1999/xhtml"><a href="hello.html#world">Hello</a></div>
+        </content>
+    </entry>
+</feed>
+EOT,
+                '<a href="http://example.net/tests/hello.html#world">Hello</a>',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider getPermalinkDataProvider
      */
     public function test_get_permalink($data, $expected)


### PR DESCRIPTION
SimplePie was not using the best base link for an item content (instead, it was directly using the feed base).
See `<xml:base>` example in https://datatracker.ietf.org/doc/html/rfc4287#section-1.1
First uses item `<xml:base>` if it exists, or the item own link, or the feed's base URL rules (feed URL, or Web site URL)
Downstream issue https://github.com/FreshRSS/FreshRSS/issues/4562
Downstream PR https://github.com/FreshRSS/FreshRSS/pull/4565

