### PR TITLE
Fix error handling

### DIFF
--- a/src/Misc.php
+++ b/src/Misc.php
@@ -142,7 +142,7 @@ class Misc
 
     public static function error($message, $level, $file, $line)
     {
-        if ((ini_get('error_reporting') & $level) > 0) {
+        if ((error_reporting() & $level) > 0) {
             switch ($level) {
                 case E_USER_ERROR:
                     $note = 'PHP Error';


### PR DESCRIPTION
On PHP 8.1, the following error is triggered when feed content is invalid: `Uncaught Exception TypeError: Unsupported operand types: int & string in ./vendor/simplepie/simplepie/library/SimplePie/Misc.php at line 155`.

Following code snippet can be used to reproduce:
```php
$feed = new SimplePie();
$feed->enable_cache(false);
$feed->set_raw_data('notavalidcontent');
$feed->force_feed(true);
$feed->init();
```