### PR TITLE
Use native array_replace_recursive

### DIFF
--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -98,7 +98,7 @@ class Memcache implements Base
                 'prefix' => 'simplepie_',
             ],
         ];
-        $this->options = \SimplePie\Misc::array_merge_recursive($this->options, \SimplePie\Cache::parse_URL($location));
+        $this->options = array_replace_recursive($this->options, \SimplePie\Cache::parse_URL($location));
 
         $this->name = $this->options['extras']['prefix'] . md5("$name:$type");
 

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -95,7 +95,7 @@ class Memcached implements Base
                 'prefix'  => 'simplepie_',
             ],
         ];
-        $this->options = \SimplePie\Misc::array_merge_recursive($this->options, \SimplePie\Cache::parse_URL($location));
+        $this->options = array_replace_recursive($this->options, \SimplePie\Cache::parse_URL($location));
 
         $this->name = $this->options['extras']['prefix'] . md5("$name:$type");
 

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -99,7 +99,7 @@ class MySQL extends DB
             ],
         ];
 
-        $this->options = \SimplePie\Misc::array_merge_recursive($this->options, \SimplePie\Cache::parse_URL($location));
+        $this->options = array_replace_recursive($this->options, \SimplePie\Cache::parse_URL($location));
 
         // Path is prefixed with a "/"
         $this->options['dbname'] = substr($this->options['path'], 1);

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -204,7 +204,15 @@ class Misc
      */
     public static function array_merge_recursive($array1, $array2)
     {
-        return array_replace_recursive($array1, $array2);
+        foreach ($array2 as $key => $value) {
+            if (is_array($value)) {
+                $array1[$key] = Misc::array_merge_recursive($array1[$key], $value);
+            } else {
+                $array1[$key] = $value;
+            }
+        }
+
+        return $array1;
     }
 
     public static function parse_url($url)

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -199,17 +199,12 @@ class Misc
         return $url;
     }
 
+    /**
+     * @deprecated since SimplePie 1.7.1, use PHP native array_replace_recursive() instead.
+     */
     public static function array_merge_recursive($array1, $array2)
     {
-        foreach ($array2 as $key => $value) {
-            if (is_array($value)) {
-                $array1[$key] = Misc::array_merge_recursive($array1[$key], $value);
-            } else {
-                $array1[$key] = $value;
-            }
-        }
-
-        return $array1;
+        return array_replace_recursive($array1, $array2);
     }
 
     public static function parse_url($url)


### PR DESCRIPTION
Since PHP 5.3+, there is a native equivalent to the SimplePie Misc function to merge arrays: https://php.net/array-replace-recursive
Improvement of https://github.com/simplepie/simplepie/pull/268
