### PR TITLE
remove check for E_USER_DEPRECATED definition

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -103,7 +103,7 @@ class Cache
      */
     public function create($location, $filename, $extension)
     {
-        trigger_error('Cache::create() has been replaced with Cache::get_handler(). Switch to the registry system to use this.', E_USER_DEPRECATED);
+        trigger_error('Cache::create() has been replaced with Cache::get_handler(). Switch to the registry system to use this.', \E_USER_DEPRECATED);
         return self::get_handler($location, $filename, $extension);
     }
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -678,8 +678,7 @@ class SimplePie
         $this->registry = new \SimplePie\Registry();
 
         if (func_num_args() > 0) {
-            $level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-            trigger_error('Passing parameters to the constructor is no longer supported. Please use set_feed_url(), set_cache_location(), and set_cache_duration() directly.', $level);
+            trigger_error('Passing parameters to the constructor is no longer supported. Please use set_feed_url(), set_cache_location(), and set_cache_duration() directly.', \E_USER_DEPRECATED);
 
             $args = func_get_args();
             switch (count($args)) {
@@ -2849,8 +2848,7 @@ class SimplePie
      */
     public function set_favicon_handler($page = false, $qs = 'i')
     {
-        $level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-        trigger_error('Favicon handling has been removed, please use your own handling', $level);
+        trigger_error('Favicon handling has been removed, please use your own handling', \E_USER_DEPRECATED);
         return false;
     }
 
@@ -2861,8 +2859,7 @@ class SimplePie
      */
     public function get_favicon()
     {
-        $level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-        trigger_error('Favicon handling has been removed, please use your own handling', $level);
+        trigger_error('Favicon handling has been removed, please use your own handling', \E_USER_DEPRECATED);
 
         if (($url = $this->get_link()) !== null) {
             return 'https://www.google.com/s2/favicons?domain=' . urlencode($url);
@@ -2881,13 +2878,11 @@ class SimplePie
     public function __call($method, $args)
     {
         if (strpos($method, 'subscribe_') === 0) {
-            $level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-            trigger_error('subscribe_*() has been deprecated, implement the callback yourself', $level);
+            trigger_error('subscribe_*() has been deprecated, implement the callback yourself', \E_USER_DEPRECATED);
             return '';
         }
         if ($method === 'enable_xml_dump') {
-            $level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-            trigger_error('enable_xml_dump() has been deprecated, use get_raw_data() instead', $level);
+            trigger_error('enable_xml_dump() has been deprecated, use get_raw_data() instead', \E_USER_DEPRECATED);
             return false;
         }
 


### PR DESCRIPTION
`E_USER_DEPRECATED` is always defined since PHP 5.3, therefore, the check is no longer needed.

The checks were introduced when SimplePie still supported PHP 5.2.