### PR TITLE
Clarify branching strategy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,13 +80,16 @@ be aware of our [coding standards](http://simplepie.org/wiki/misc/coding_standar
 The main development for the next minor release happens in `master` branch.
 Please create your pull requests primarily against this branch.
 
-The branch `one-dot-seven` may receive backport of features, bug fixes and security fixes (if possible).
-It will become end of life if [WordPress drops support for PHP 5.6](https://wordpress.org/about/requirements/).
+We do not actively provide bug fixes or security fixes for older versions. Nevertheless,
+you are welcome to create backport PRs if you still need support for older PHP versions.
+Please open your PR agains the appropriate branch.
 
 | branch                                                                     | requires    |
 |----------------------------------------------------------------------------|-------------|
 | [master](https://github.com/simplepie/simplepie/tree/master)               | PHP 7.2.0+  |
 | [one-dot-seven](https://github.com/simplepie/simplepie/tree/one-dot-seven) | PHP 5.6.0+  |
+| [one-dot-three](https://github.com/simplepie/simplepie/tree/one-dot-three) | PHP 5.2.0+  |
+
 
 Authors and contributors
 ------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -85,7 +85,7 @@ be aware of our [coding standards](http://simplepie.org/wiki/misc/coding_standar
 The main development happens in branch `v1.x`.
 Please create your pull requests primarily against this branch.
 
-The branch `v1.7` may receive backport of features and security fixes (if possible).
+The branch `v1.7` may receive backport of features, bug fixes and security fixes (if possible).
 It will become end of life if [WordPress drops support for PHP 5.6](https://wordpress.org/about/requirements/).
 
 Authors and contributors

--- a/README.markdown
+++ b/README.markdown
@@ -77,16 +77,16 @@ If you'd like to contribute to SimplePie, the best way to get started is to fork
 the project on GitHub and send pull requests for patches. When doing so, please
 be aware of our [coding standards](http://simplepie.org/wiki/misc/coding_standards).
 
-| branch                                                   | requires    |
-|----------------------------------------------------------|-------------|
-| [v1.x](https://github.com/simplepie/simplepie/tree/v1.x) | PHP 7.2.0+  |
-| [v1.7](https://github.com/simplepie/simplepie/tree/v1.7) | PHP 5.6.0+  |
-
-The main development happens in branch `v1.x`.
+The main development for the next minor release happens in `master` branch.
 Please create your pull requests primarily against this branch.
 
-The branch `v1.7` may receive backport of features, bug fixes and security fixes (if possible).
+The branch `one-dot-seven` may receive backport of features, bug fixes and security fixes (if possible).
 It will become end of life if [WordPress drops support for PHP 5.6](https://wordpress.org/about/requirements/).
+
+| branch                                                                     | requires    |
+|----------------------------------------------------------------------------|-------------|
+| [master](https://github.com/simplepie/simplepie/tree/master)               | PHP 7.2.0+  |
+| [one-dot-seven](https://github.com/simplepie/simplepie/tree/one-dot-seven) | PHP 5.6.0+  |
 
 Authors and contributors
 ------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -75,10 +75,18 @@ to be prioritized.
 
 If you'd like to contribute to SimplePie, the best way to get started is to fork
 the project on GitHub and send pull requests for patches. When doing so, please
-be aware of our [coding standards][].
+be aware of our [coding standards](http://simplepie.org/wiki/misc/coding_standards).
 
-[coding standards]: http://simplepie.org/wiki/misc/coding_standards
+| branch                                                   | requires    |
+|----------------------------------------------------------|-------------|
+| [v1.x](https://github.com/simplepie/simplepie/tree/v1.x) | PHP 7.2.0+  |
+| [v1.7](https://github.com/simplepie/simplepie/tree/v1.7) | PHP 5.6.0+  |
 
+The main development happens in branch `v1.x`.
+Please create your pull requests primarily against this branch.
+
+The branch `v1.7` may receive backport of features and security fixes (if possible).
+It will become end of life if [WordPress drops support for PHP 5.6](https://wordpress.org/about/requirements/).
 
 Authors and contributors
 ------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -82,7 +82,7 @@ Please create your pull requests primarily against this branch.
 
 We do not actively provide bug fixes or security fixes for older versions. Nevertheless,
 you are welcome to create backport PRs if you still need support for older PHP versions.
-Please open your PR agains the appropriate branch.
+Please open your PR against the appropriate branch.
 
 | branch                                                                     | requires    |
 |----------------------------------------------------------------------------|-------------|


### PR DESCRIPTION
In https://github.com/simplepie/simplepie/pull/743#issuecomment-1254737133 we discussed the introduction of a new branching workflow, which is then also described in the README.md. Now that version 1.7.0 is released, **it would be the perfect time to do so before merging any other PRs.** My proposal is that the branches could look like this:

- `v1.7` (LTS for PHP 5.6)
- `v1.x` (Other 1.x versions like 1.8.0, 1.9.0, etc)
- `v2.x` (All 2.x versions like 2.0.0, etc.)

Bug fixes or security fixes are created against the latest branch (`v1.x` or `v2.x`) and can then be backported to the `v1.7` branch.

The current `master` branch will then no longer be needed.

@mblaney What do you think about the idea of a new branching strategy? The roadmap for that might look like this:

1. Rename branch master to `v1.x` (`v1.x` will be the new default branch)
2. Create new branch `v1.7` from `v1.x` branch.
3. Edit `README.markdown` to explain new branching strategy. **(Will be done by this PR.)**
4. Add note in `v1.7` branch about LTS. I can create a PR for this.
