### PR TITLE
Item::get_date: fix return type on unparsable date

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -662,7 +662,7 @@ class Item
 
             if (!empty($this->data['date']['raw'])) {
                 $parser = $this->registry->call('Parse_Date', 'get');
-                $this->data['date']['parsed'] = $parser->parse($this->data['date']['raw']);
+                $this->data['date']['parsed'] = $parser->parse($this->data['date']['raw']) ?: null;
             } else {
                 $this->data['date'] = null;
             }
@@ -704,7 +704,7 @@ class Item
 
             if (!empty($this->data['updated']['raw'])) {
                 $parser = $this->registry->call('Parse_Date', 'get');
-                $this->data['updated']['parsed'] = $parser->parse($this->data['updated']['raw']);
+                $this->data['updated']['parsed'] = $parser->parse($this->data['updated']['raw']) ?: null;
             } else {
                 $this->data['updated'] = null;
             }


### PR DESCRIPTION
The `Parse\Date::parse` method can return `false` when it fails to parse the value and `get_date` will return it as is but its PHPDoc annotation does not allow returning booleans.

Let’s fix it by converting such values to `null`.

Fixes: https://github.com/fossar/selfoss/issues/1384