### PR TITLE
Type declarations in cache

### DIFF
--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -80,7 +80,7 @@ final class BaseDataCache implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get_data($key, $default = null)
+    public function get_data(string $key, $default = null)
     {
         $data = $this->cache->load();
 
@@ -123,7 +123,7 @@ final class BaseDataCache implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set_data($key, array $value, $ttl = null)
+    public function set_data(string $key, array $value, ?int $ttl = null): bool
     {
         if (! is_int($ttl)) {
             $ttl = 3600;
@@ -150,7 +150,7 @@ final class BaseDataCache implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function delete_data($key)
+    public function delete_data(string $key): bool
     {
         return $this->cache->unlink();
     }

--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -125,7 +125,7 @@ final class BaseDataCache implements DataCache
      */
     public function set_data(string $key, array $value, ?int $ttl = null): bool
     {
-        if (! is_int($ttl)) {
+        if ($ttl === null) {
             $ttl = 3600;
         }
 

--- a/src/Cache/DataCache.php
+++ b/src/Cache/DataCache.php
@@ -73,7 +73,7 @@ interface DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get_data($key, $default = null);
+    public function get_data(string $key, $default = null);
 
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
@@ -94,7 +94,7 @@ interface DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set_data($key, array $value, $ttl = null);
+    public function set_data(string $key, array $value, ?int $ttl = null): bool;
 
     /**
      * Delete an item from the cache by its unique key.
@@ -111,5 +111,5 @@ interface DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function delete_data($key);
+    public function delete_data(string $key): bool;
 }

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -88,7 +88,7 @@ final class Psr16 implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get_data($key, $default = null)
+    public function get_data(string $key, $default = null)
     {
         $data = $this->cache->get($key, $default);
 
@@ -118,7 +118,7 @@ final class Psr16 implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set_data($key, array $value, $ttl = null)
+    public function set_data(string $key, array $value, ?int $ttl = null): bool
     {
         return $this->cache->set($key, $value, $ttl);
     }
@@ -138,7 +138,7 @@ final class Psr16 implements DataCache
      * @throws InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function delete_data($key)
+    public function delete_data(string $key): bool
     {
         return $this->cache->delete($key);
     }

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1631,13 +1631,13 @@ class SimplePie
                                 // Set raw_data to false here too, to signify that the cache
                                 // is still valid.
                                 $this->raw_data = false;
-                                $cache->set_data($cacheKey, $this->data, $this->cache_duration + time());
+                                $cache->set_data($cacheKey, $this->data, $this->cache_duration);
                                 return true;
                             }
                         } else {
                             $this->check_modified = false;
                             if ($this->force_cache_fallback) {
-                                $cache->set_data($cacheKey, $this->data, $this->cache_duration + time());
+                                $cache->set_data($cacheKey, $this->data, $this->cache_duration);
                                 return true;
                             }
 

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -96,6 +96,8 @@ class CachingTest extends TestCase
                     return true;
                 });
 
+                $psr16->method('delete')->willReturn(true);
+
                 $feed->set_cache($psr16);
                 break;
 


### PR DESCRIPTION
This PR will add parameter and return type declarations to the new internal `DataCache` interface from #752. It will also fix the setting of two `$ttl`.