### PR TITLE
Create interface RegistryAware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New method `SimplePie\SimplePie::set_cache()` for providing a PSR-16 cache implementation
+- New interface `SimplePie\RegistryAware` to inject the `Registry` instance into classes created by `Registry`.
 
 ### Deprecated
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -53,7 +53,7 @@ namespace SimplePie;
  * @package \SimplePie\SimplePie
  * @subpackage API
  */
-class Item
+class Item implements RegistryAware
 {
     /**
      * Parent feed
@@ -102,7 +102,7 @@ class Item
      * @since 1.3
      * @param \SimplePie\Registry $registry
      */
-    public function set_registry(\SimplePie\Registry $registry)
+    public function set_registry(\SimplePie\Registry $registry)/* : void */
     {
         $this->registry = $registry;
     }

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -51,7 +51,7 @@ namespace SimplePie;
  *
  * @package SimplePie
  */
-class Locator
+class Locator implements RegistryAware
 {
     public $useragent;
     public $timeout;
@@ -93,7 +93,7 @@ class Locator
         }
     }
 
-    public function set_registry(\SimplePie\Registry $registry)
+    public function set_registry(\SimplePie\Registry $registry)/* : void */
     {
         $this->registry = $registry;
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -52,7 +52,7 @@ namespace SimplePie;
  * @package SimplePie
  * @subpackage Parsing
  */
-class Parser
+class Parser implements RegistryAware
 {
     public $error_code;
     public $error_string;
@@ -71,7 +71,7 @@ class Parser
     public $encoding;
     protected $registry;
 
-    public function set_registry(\SimplePie\Registry $registry)
+    public function set_registry(\SimplePie\Registry $registry)/* : void */
     {
         $this->registry = $registry;
     }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -178,7 +178,10 @@ class Registry
             $instance = $reflector->newInstanceArgs($parameters);
         }
 
-        if (method_exists($instance, 'set_registry')) {
+        if ($instance instanceof RegistryAware) {
+            $instance->set_registry($this);
+        } else if (method_exists($instance, 'set_registry')) {
+            trigger_error(sprintf('Using the method "set_registry()" without implementing "%s" is deprecated since SimplePie 1.8, implement "%s" in "%s".', RegistryAware::class, RegistryAware::class, $class), \E_USER_DEPRECATED);
             $instance->set_registry($this);
         }
         return $instance;

--- a/src/RegistryAware.php
+++ b/src/RegistryAware.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2022, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2022 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace SimplePie;
+
+/**
+ * Handles the injection of Registry into other class
+ *
+ * {@see \SimplePie\SimplePie::get_registry()}
+ *
+ * @package SimplePie
+ */
+interface RegistryAware
+{
+    /**
+     * Set the Registry into the class
+     *
+     * @param Registry $registry
+     *
+     * @return void
+     */
+    public function set_registry(Registry $registry)/* : void */;
+}

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -56,7 +56,7 @@ use SimplePie\Cache\DataCache;
  * @package SimplePie
  * @todo Move to using an actual HTML parser (this will allow tags to be properly stripped, and to switch between HTML and XHTML), this will also make it easier to shorten a string while preserving HTML tags
  */
-class Sanitize
+class Sanitize implements RegistryAware
 {
     // Private vars
     public $base;
@@ -118,7 +118,7 @@ class Sanitize
         }
     }
 
-    public function set_registry(\SimplePie\Registry $registry)
+    public function set_registry(\SimplePie\Registry $registry)/* : void */
     {
         $this->registry = $registry;
     }

--- a/src/Source.php
+++ b/src/Source.php
@@ -53,7 +53,7 @@ namespace SimplePie;
  * @package SimplePie
  * @subpackage API
  */
-class Source
+class Source implements RegistryAware
 {
     public $item;
     public $data = [];
@@ -65,7 +65,7 @@ class Source
         $this->data = $data;
     }
 
-    public function set_registry(\SimplePie\Registry $registry)
+    public function set_registry(\SimplePie\Registry $registry)/* : void */
     {
         $this->registry = $registry;
     }


### PR DESCRIPTION
Classes created by the `Registry` class could have a method `set_registry()`. The `Registry` instance will then set itself into the created instance by calling `->set_registry($this)`.

This PR creates a new interface `RegistryAware` that defines the method in a type safe way.