### PR TITLE
Replace cache_name_function with NameFilter class

### DIFF
--- a/src/Cache/CallableNameFilter.php
+++ b/src/Cache/CallableNameFilter.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2022, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2022 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace SimplePie\Cache;
+
+/**
+ * Creating a cache filename with callables
+ *
+ * @package SimplePie
+ * @subpackage Caching
+ */
+class CallableNameFilter implements NameFilter
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * Method to create cache filename with
+     *
+     * @param string $name The name for the cache.
+     *
+     * @return string the new cache name
+     */
+    public function filter(string $name): string
+    {
+        return call_user_func($this->callable, $name);
+    }
+}

--- a/src/Cache/NameFilter.php
+++ b/src/Cache/NameFilter.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2022, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2022 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace SimplePie\Cache;
+
+/**
+ * Interface for creating a cache filename
+ *
+ * @package SimplePie
+ * @subpackage Caching
+ */
+interface NameFilter
+{
+    /**
+     * Method to create cache filename with
+     *
+     * @param string $name The name for the cache.
+     *
+     * @return string the new cache name
+     */
+    public function filter(string $name): string;
+}

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -43,9 +43,12 @@
 
 namespace SimplePie;
 
+use InvalidArgumentException;
 use SimplePie\Cache\Base;
 use SimplePie\Cache\BaseDataCache;
+use SimplePie\Cache\CallableNameFilter;
 use SimplePie\Cache\DataCache;
+use SimplePie\Cache\NameFilter;
 
 /**
  * Used for data cleanup and post-processing
@@ -74,6 +77,11 @@ class Sanitize
     public $enable_cache = true;
     public $cache_location = './cache';
     public $cache_name_function = 'md5';
+
+    /**
+     * @var NameFilter
+     */
+    private $cache_namefilter;
     public $timeout = 10;
     public $useragent = '';
     public $force_fsockopen = false;
@@ -133,9 +141,23 @@ class Sanitize
             $this->cache_location = (string) $cache_location;
         }
 
-        if ($cache_name_function) {
-            $this->cache_name_function = (string) $cache_name_function;
+        if (! is_string($cache_name_function) && ! is_object($cache_name_function) && ! $cache_name_function instanceof NameFilter) {
+            throw new InvalidArgumentException(sprintf(
+                '%s(): Argument #3 ($cache_name_function) must be of type %s',
+                __METHOD__,
+                NameFilter::class
+            ), 1);
         }
+
+        // BC: $cache_name_function could be a callable as string
+        if (is_string($cache_name_function)) {
+            // trigger_error(sprintf('Providing $cache_name_function as string in "%s()" is deprecated since SimplePie 1.8.0, provide "" instead.', __METHOD__, NameFilter::class), \E_USER_DEPRECATED);
+            $this->cache_name_function = (string) $cache_name_function;
+
+            $cache_name_function = new CallableNameFilter($cache_name_function);
+        }
+
+        $this->cache_namefilter = $cache_name_function;
 
         if ($cache !== null) {
             $this->cache = $cache;
@@ -395,7 +417,7 @@ class Sanitize
 
                     foreach ($images as $img) {
                         if ($img->hasAttribute('src')) {
-                            $image_url = call_user_func($this->cache_name_function, $img->getAttribute('src'));
+                            $image_url = $this->cache_namefilter->filter($img->getAttribute('src'));
                             $cache = $this->get_cache($image_url);
 
                             if ($cache->get_data($image_url, false)) {


### PR DESCRIPTION
It is possible to change the name of a cached value by providing a callable string via `SimplePie\SimplePie::set_cache_name_function()`. The default function is `md5()`. This gives us two problems: 

1. The provided callable is not guarantied to return a string. This could lead to errors.
2. A callable could also be an array. Something like this is not possible:

```php
$simplepie->set_cache_name_function(['Classname', 'static_method']);
```

This PR adds a new interface `SimplePie\Cache\NameFilter` that will be used internally. Implementations can be set via the new method `SimplePie\SimplePie::set_cache_namefilter()`. For BC reasons there is also a new class `SimplePie\Cache\CallableNameFilter`, that handles all kinds of callables (not just strings).

```php
$simplepie->set_cache_namefilter(new \SimplePie\Cache\CallableNameFilter(['Classname', 'static_method']);
```

This PR also deprecates the `SimplePie\SimplePie::set_cache_name_function()` method.