### PR TITLE
Declare strict_types=1 in every file

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,7 +12,6 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
-        'declare_strict_types' => false,
         'void_return' => false,
         '@PHPUnit84Migration:risky' => true,
     ])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The class `SimplePie\Cache\Redis` is deprecated, use implementation of `Psr\SimpleCache\CacheInterface` instead
 - The interface `SimplePie\Cache\Base` is deprecated, use interface `Psr\SimpleCache\CacheInterface` instead
 
+### Fixed
+
+- The method `SimplePie\SimplePie::get_image_height()` returns the pixel number as `int` instead of `float`
+- The method `SimplePie\SimplePie::get_image_width()` returns the pixel number as `int` instead of `float`
+
 ## [1.7.0](https://github.com/simplepie/simplepie/compare/1.6.0...1.7.0) - 2022-09-30
 
 ### Added

--- a/build/bootstrap.php
+++ b/build/bootstrap.php
@@ -1,4 +1,6 @@
 <?php
 
+declare(strict_types=1);
+
 require_once dirname(__DIR__) . '/SimplePie.compiled.php';
 require_once dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';

--- a/build/charset.php
+++ b/build/charset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once '../autoloader.php';
 
 function normalize_character_set($charset)

--- a/build/compile.php
+++ b/build/compile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // Set up our constants
 define('SP_PATH', dirname(__FILE__, 2));
 define('COMPILED', SP_PATH . DIRECTORY_SEPARATOR . 'SimplePie.compiled.php');

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Author.php
+++ b/library/SimplePie/Author.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache.php
+++ b/library/SimplePie/Cache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Base.php
+++ b/library/SimplePie/Cache/Base.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/DB.php
+++ b/library/SimplePie/Cache/DB.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/File.php
+++ b/library/SimplePie/Cache/File.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Memcache.php
+++ b/library/SimplePie/Cache/Memcache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Memcached.php
+++ b/library/SimplePie/Cache/Memcached.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Redis.php
+++ b/library/SimplePie/Cache/Redis.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SimplePie Redis Cache Extension
  *

--- a/library/SimplePie/Caption.php
+++ b/library/SimplePie/Caption.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Category.php
+++ b/library/SimplePie/Category.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Content/Type/Sniffer.php
+++ b/library/SimplePie/Content/Type/Sniffer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Copyright.php
+++ b/library/SimplePie/Copyright.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Core.php
+++ b/library/SimplePie/Core.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Credit.php
+++ b/library/SimplePie/Credit.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Decode/HTML/Entities.php
+++ b/library/SimplePie/Decode/HTML/Entities.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Enclosure.php
+++ b/library/SimplePie/Enclosure.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Exception.php
+++ b/library/SimplePie/Exception.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/IRI.php
+++ b/library/SimplePie/IRI.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Net/IPv6.php
+++ b/library/SimplePie/Net/IPv6.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Parser.php
+++ b/library/SimplePie/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Rating.php
+++ b/library/SimplePie/Rating.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Registry.php
+++ b/library/SimplePie/Registry.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Restriction.php
+++ b/library/SimplePie/Restriction.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Source.php
+++ b/library/SimplePie/Source.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/XML/Declaration/Parser.php
+++ b/library/SimplePie/XML/Declaration/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/gzdecode.php
+++ b/library/SimplePie/gzdecode.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Author.php
+++ b/src/Author.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Base.php
+++ b/src/Cache/Base.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/DB.php
+++ b/src/Cache/DB.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/DataCache.php
+++ b/src/Cache/DataCache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Caption.php
+++ b/src/Caption.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Category.php
+++ b/src/Category.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Content/Type/Sniffer.php
+++ b/src/Content/Type/Sniffer.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Copyright.php
+++ b/src/Copyright.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Credit.php
+++ b/src/Credit.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *
@@ -1112,7 +1114,7 @@ class Enclosure
                     $type = 'audio/x-ms-wma';
                     break;
 
-                // Video mime-types
+                    // Video mime-types
                 case '3gp':
                 case '3gpp':
                     $type = 'video/3gpp';
@@ -1175,7 +1177,7 @@ class Enclosure
                     $type = 'video/x-ms-wvx';
                     break;
 
-                // Flash mime-types
+                    // Flash mime-types
                 case 'spl':
                     $type = 'application/futuresplash';
                     break;

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -877,6 +877,7 @@ class Enclosure
         $widescreen = false;
         $handler = $this->get_handler();
         $type = $this->get_real_type();
+        $placeholder = '';
 
         // Process options and reassign values as necessary
         if (is_array($options)) {

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -1114,7 +1114,7 @@ class Enclosure
                     $type = 'audio/x-ms-wma';
                     break;
 
-                    // Video mime-types
+                // Video mime-types
                 case '3gp':
                 case '3gpp':
                     $type = 'video/3gpp';
@@ -1177,7 +1177,7 @@ class Enclosure
                     $type = 'video/x-ms-wvx';
                     break;
 
-                    // Flash mime-types
+                // Flash mime-types
                 case 'spl':
                     $type = 'application/futuresplash';
                     break;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/File.php
+++ b/src/File.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -204,6 +204,8 @@ class Gzdecode
     public function parse()
     {
         if ($this->compressed_size >= $this->min_compressed_size) {
+            $len = 0;
+
             // Check ID1, ID2, and CM
             if (substr($this->compressed_data, 0, 3) !== "\x1F\x8B\x08") {
                 return false;

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -472,7 +472,7 @@ class Parser
             $encoded = substr($encoded, $chunk_length + $length + 2);
 
             // BC for PHP < 8.0: substr() can return bool instead of string
-            $encoded === false ? '' : $encoded;
+            $encoded = ($encoded === false) ? '' : $encoded;
 
             if (trim($encoded) === '0' || empty($encoded)) {
                 $this->state = self::STATE_EMIT;

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -468,8 +468,11 @@ class Parser
             }
 
             $chunk_length = strlen($matches[0]);
-            $decoded .= $part = substr($encoded, $chunk_length, $length);
+            $decoded .= substr($encoded, $chunk_length, $length);
             $encoded = substr($encoded, $chunk_length + $length + 2);
+
+            // BC for PHP < 8.0: substr() can return bool instead of string
+            $encoded = strval($encoded);
 
             if (trim($encoded) === '0' || empty($encoded)) {
                 $this->state = self::STATE_EMIT;

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -472,7 +472,7 @@ class Parser
             $encoded = substr($encoded, $chunk_length + $length + 2);
 
             // BC for PHP < 8.0: substr() can return bool instead of string
-            $encoded = strval($encoded);
+            $encoded === false ? '' : $encoded;
 
             if (trim($encoded) === '0' || empty($encoded)) {
                 $this->state = self::STATE_EMIT;

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -378,7 +378,7 @@ class IRI
                 $output = substr_replace($output, '', intval(strrpos($output, '/')));
             } elseif ($input === '/..') {
                 $input = '/';
-                $output = substr_replace($output, '', strrpos($output, '/'));
+                $output = substr_replace($output, '', intval(strrpos($output, '/')));
             }
             // D: if the input buffer consists only of "." or "..", then remove that from the input buffer; otherwise,
             elseif ($input === '.' || $input === '..') {

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -545,7 +545,7 @@ class IRI
         $start = 0;
         $character = 0;
         $length = 0;
-        $valid = true; // By default we are valid
+        $valid = true;
 
         // Loop over each and every byte, and set $value to its value
         for ($i = 1, $len = count($bytes); $i < $len; $i++) {
@@ -555,6 +555,9 @@ class IRI
             if (!$remaining) {
                 // Start position
                 $start = $i;
+
+                // By default we are valid
+                $valid = true;
 
                 // One byte sequence:
                 if ($value <= 0x7F) {

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *
@@ -373,7 +375,7 @@ class IRI
             // C: if the input buffer begins with a prefix of "/../" or "/..", where ".." is a complete path segment, then replace that prefix with "/" in the input buffer and remove the last segment and its preceding "/" (if any) from the output buffer; otherwise,
             elseif (strpos($input, '/../') === 0) {
                 $input = substr($input, 3);
-                $output = substr_replace($output, '', strrpos($output, '/'));
+                $output = substr_replace($output, '', intval(strrpos($output, '/')));
             } elseif ($input === '/..') {
                 $input = '/';
                 $output = substr_replace($output, '', strrpos($output, '/'));
@@ -817,7 +819,7 @@ class IRI
         } else {
             $iuserinfo = null;
         }
-        if (($port_start = strpos($remaining, ':', strpos($remaining, ']'))) !== false) {
+        if (($port_start = strpos($remaining, ':', intval(strpos($remaining, ']')))) !== false) {
             if (($port = substr($remaining, $port_start + 1)) === false) {
                 $port = null;
             }

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -422,6 +422,7 @@ class IRI
         $strlen = strlen($string);
         while (($position += strspn($string, $extra_chars, $position)) < $strlen) {
             $value = ord($string[$position]);
+            $character = 0;
 
             // Start position
             $start = $position;
@@ -539,18 +540,21 @@ class IRI
         // at the first byte!).
         $string = '';
         $remaining = 0;
+        $start = 0;
+        $character = 0;
+        $length = 0;
 
         // Loop over each and every byte, and set $value to its value
         for ($i = 1, $len = count($bytes); $i < $len; $i++) {
             $value = hexdec($bytes[$i]);
 
+            // By default we are valid
+            $valid = true;
+
             // If we're the first byte of sequence:
             if (!$remaining) {
                 // Start position
                 $start = $i;
-
-                // By default we are valid
-                $valid = true;
 
                 // One byte sequence:
                 if ($value <= 0x7F) {

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -540,16 +540,16 @@ class IRI
         // at the first byte!).
         $string = '';
         $remaining = 0;
+
+        // these variables will be initialized in the loop but PHPStan is not able to detect it currently
         $start = 0;
         $character = 0;
         $length = 0;
+        $valid = true; // By default we are valid
 
         // Loop over each and every byte, and set $value to its value
         for ($i = 1, $len = count($bytes); $i < $len; $i++) {
             $value = hexdec($bytes[$i]);
-
-            // By default we are valid
-            $valid = true;
 
             // If we're the first byte of sequence:
             if (!$remaining) {

--- a/src/Item.php
+++ b/src/Item.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *
@@ -1799,7 +1801,7 @@ class Misc
 
     public static function atom_03_construct_type($attribs)
     {
-        if (isset($attribs['']['mode']) && strtolower(trim($attribs['']['mode']) === 'base64')) {
+        if (isset($attribs['']['mode']) && strtolower(trim($attribs['']['mode'])) === 'base64') {
             $mode = \SimplePie\SimplePie::CONSTRUCT_BASE64;
         } else {
             $mode = \SimplePie\SimplePie::CONSTRUCT_NONE;

--- a/src/Net/IPv6.php
+++ b/src/Net/IPv6.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *
@@ -726,7 +728,7 @@ class Date
             // Convert the number of seconds to an integer, taking decimals into account
             $second = round((int)$match[6] + (int)$match[7] / (10 ** strlen($match[7])));
 
-            return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
+            return gmmktime(intval($match[4]), intval($match[5]), intval($second), intval($match[2]), intval($match[3]), intval($match[1])) - $timezone;
         }
 
         return false;
@@ -855,7 +857,7 @@ class Date
                 $second = 0;
             }
 
-            return gmmktime($match[5], $match[6], $second, $month, $match[2], $match[4]) - $timezone;
+            return gmmktime(intval($match[5]), intval($match[6]), intval($second), intval($month), intval($match[2]), intval($match[4])) - $timezone;
         }
 
         return false;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Rating.php
+++ b/src/Rating.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -171,7 +171,7 @@ class Registry
 
         if ($instance instanceof RegistryAware) {
             $instance->set_registry($this);
-        } else if (method_exists($instance, 'set_registry')) {
+        } elseif (method_exists($instance, 'set_registry')) {
             trigger_error(sprintf('Using the method "set_registry()" without implementing "%s" is deprecated since SimplePie 1.8, implement "%s" in "%s".', RegistryAware::class, RegistryAware::class, $class), \E_USER_DEPRECATED);
             $instance->set_registry($this);
         }

--- a/src/RegistryAware.php
+++ b/src/RegistryAware.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Restriction.php
+++ b/src/Restriction.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *
@@ -2755,7 +2757,7 @@ class SimplePie
     public function get_image_width()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'width')) {
-            return round($return[0]['data']);
+            return round(intval($return[0]['data']));
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
             return 88.0;
         }
@@ -2776,7 +2778,7 @@ class SimplePie
     public function get_image_height()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'height')) {
-            return round($return[0]['data']);
+            return round(intval($return[0]['data']));
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
             return 31.0;
         }

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2757,7 +2757,7 @@ class SimplePie
     public function get_image_width()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'width')) {
-            return round(intval($return[0]['data']));
+            return intval($return[0]['data']);
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
             return 88.0;
         }
@@ -2778,7 +2778,7 @@ class SimplePie
     public function get_image_height()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'height')) {
-            return round(intval($return[0]['data']));
+            return intval($return[0]['data']);
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
             return 31.0;
         }

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2749,17 +2749,17 @@ class SimplePie
      *
      * RSS 2.0 feeds are allowed to have a "feed logo" width.
      *
-     * Uses `<image><width>` or defaults to 88.0 if no width is specified and
+     * Uses `<image><width>` or defaults to 88 if no width is specified and
      * the feed is an RSS 2.0 feed.
      *
-     * @return int|float|null
+     * @return int|null
      */
     public function get_image_width()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'width')) {
             return intval($return[0]['data']);
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
-            return 88.0;
+            return 88;
         }
 
         return null;
@@ -2770,17 +2770,17 @@ class SimplePie
      *
      * RSS 2.0 feeds are allowed to have a "feed logo" height.
      *
-     * Uses `<image><height>` or defaults to 31.0 if no height is specified and
+     * Uses `<image><height>` or defaults to 31 if no height is specified and
      * the feed is an RSS 2.0 feed.
      *
-     * @return int|float|null
+     * @return int|null
      */
     public function get_image_height()
     {
         if ($return = $this->get_image_tags(self::NAMESPACE_RSS_20, 'height')) {
             return intval($return[0]['data']);
         } elseif ($this->get_type() & self::TYPE_RSS_SYNDICATION && $this->get_image_tags(self::NAMESPACE_RSS_20, 'url')) {
-            return 31.0;
+            return 31;
         }
 
         return null;

--- a/src/Source.php
+++ b/src/Source.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/XML/Declaration/Parser.php
+++ b/src/XML/Declaration/Parser.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/BCTest.php
+++ b/tests/BCTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  *

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  *

--- a/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
+++ b/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Fixtures/Cache/LegacyCacheMock.php
+++ b/tests/Fixtures/Cache/LegacyCacheMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures\Cache;
 
 use Exception;

--- a/tests/Fixtures/Cache/NewCacheMock.php
+++ b/tests/Fixtures/Cache/NewCacheMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures\Cache;
 
 use Exception;

--- a/tests/Fixtures/Exception/SuccessException.php
+++ b/tests/Fixtures/Exception/SuccessException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures\Exception;
 
 use Exception;

--- a/tests/Fixtures/FileMock.php
+++ b/tests/Fixtures/FileMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures;
 
 use SimplePie\File;

--- a/tests/Fixtures/FileWithRedirectMock.php
+++ b/tests/Fixtures/FileWithRedirectMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures;
 
 /**

--- a/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
+++ b/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SimplePie\Tests\Fixtures;
 
 use SimplePie\Misc;

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * HTTP parsing tests
  *

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * IRI test cases
  *

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Tests for SimplePie_Item
  *

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Tests for autodiscovery
  *

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/AuthorTest.php
+++ b/tests/Unit/AuthorTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/BaseDataCacheTest.php
+++ b/tests/Unit/Cache/BaseDataCacheTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/BaseTest.php
+++ b/tests/Unit/Cache/BaseTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/DBTest.php
+++ b/tests/Unit/Cache/DBTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/FileTest.php
+++ b/tests/Unit/Cache/FileTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MemcacheTest.php
+++ b/tests/Unit/Cache/MemcacheTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MemcachedTest.php
+++ b/tests/Unit/Cache/MemcachedTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MySQLTest.php
+++ b/tests/Unit/Cache/MySQLTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/RedisTest.php
+++ b/tests/Unit/Cache/RedisTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CaptionTest.php
+++ b/tests/Unit/CaptionTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Content/Type/SnifferTest.php
+++ b/tests/Unit/Content/Type/SnifferTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CopyrightTest.php
+++ b/tests/Unit/CopyrightTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CreditTest.php
+++ b/tests/Unit/CreditTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/GzdecodeTest.php
+++ b/tests/Unit/GzdecodeTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/MiscTest.php
+++ b/tests/Unit/MiscTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Net/IPv6Test.php
+++ b/tests/Unit/Net/IPv6Test.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Parse/DateTest.php
+++ b/tests/Unit/Parse/DateTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RatingTest.php
+++ b/tests/Unit/RatingTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RestrictionTest.php
+++ b/tests/Unit/RestrictionTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -1102,7 +1102,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 0.91-Netscape URL Default' => [
 <<<EOT
@@ -1116,7 +1116,7 @@ EOT
 </rss>
 EOT
                 ,
-                31.0,
+                31,
             ],
             'Test RSS 0.91-Userland Atom 1.0 Icon Default' => [
 <<<EOT
@@ -1151,7 +1151,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 0.91-Userland URL Default' => [
 <<<EOT
@@ -1164,7 +1164,7 @@ EOT
 </rss>
 EOT
                 ,
-                31.0,
+                31,
             ],
             'Test RSS 0.92 Atom 1.0 Icon Default' => [
 <<<EOT
@@ -1199,7 +1199,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 0.92 URL Default' => [
 <<<EOT
@@ -1212,7 +1212,7 @@ EOT
 </rss>
 EOT
                 ,
-                31.0,
+                31,
             ],
             'Test RSS 1.0 Atom 1.0 Icon Default' => [
 <<<EOT
@@ -1280,7 +1280,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 2.0 URL Default' => [
 <<<EOT
@@ -1293,7 +1293,7 @@ EOT
 </rss>
 EOT
                 ,
-                31.0,
+                31,
             ],
         ];
     }
@@ -1985,7 +1985,7 @@ EOT
 </rss>
 EOT
                 ,
-                88.0,
+                88,
             ],
             'Test RSS 0.91-Netscape Width' => [
 <<<EOT
@@ -1999,7 +1999,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 0.91-Userland Atom 1.0 Icon' => [
 <<<EOT
@@ -2034,7 +2034,7 @@ EOT
 </rss>
 EOT
                 ,
-                88.0,
+                88,
             ],
             'Test RSS 0.91-Userland Width' => [
 <<<EOT
@@ -2047,7 +2047,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 0.92 Atom 1.0 Icon' => [
 <<<EOT
@@ -2082,7 +2082,7 @@ EOT
 </rss>
 EOT
                 ,
-                88.0,
+                88,
             ],
             'Test RSS 0.92 Width' => [
 <<<EOT
@@ -2095,7 +2095,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
             'Test RSS 1.0 Atom 1.0 Icon' => [
 <<<EOT
@@ -2163,7 +2163,7 @@ EOT
 </rss>
 EOT
                 ,
-                88.0,
+                88,
             ],
             'Test RSS 2.0 Width' => [
 <<<EOT
@@ -2176,7 +2176,7 @@ EOT
 </rss>
 EOT
                 ,
-                100.0,
+                100,
             ],
         ];
     }

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/XML/Declaration/ParserTest.php
+++ b/tests/Unit/XML/Declaration/ParserTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // require the composer autoload.php file
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 


### PR DESCRIPTION
By default, PHP will coerce values of the wrong type into the expected scalar type declaration if possible. It is possible to enable [strict mode](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict), so only a value corresponding exactly to the type declaration will be accepted, otherwise a `TypeError` will be thrown.

This PR enables strict mode in all files. In most of the classes, everything works as expected but in a few classes I had to cast some values explicitly. I could even find and fix some bugs:

- Fixed a [bug in the `Misc` class](https://github.com/simplepie/simplepie/pull/763/files#diff-3dd17bdf04ae7a362e844d2f16376a40b4cfbbe707f512a02c1cd8831419b7d0L1802)
- Fixed `SimplePie::get_image_height()` and `get_image_width()` returning `int|null` instead of `int|float|null`, introduced in https://github.com/simplepie/simplepie/commit/33a8f76cdf6eb55131d8d9616034661c04882b9f

I've also checked and fixed most of the errors for PHPStan Level 1.

I will keep this PR as draft until the other open PRs are merged so I can later add the strict types in the new classes and interfaces created by theses PRs.