### PR TITLE
Remove broken BC code in Registry

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -160,17 +160,6 @@ class Registry
     {
         $class = $this->get_class($type);
 
-        if (in_array($class, $this->legacy)) {
-            switch ($type) {
-                case 'locator':
-                    // Legacy: file, timeout, useragent, file_class, max_checked_feeds, content_type_sniffer_class
-                    // Specified: file, timeout, useragent, max_checked_feeds
-                    $replacement = [$this->get_class('file'), $parameters[3], $this->get_class('content_type_sniffer')];
-                    array_splice($parameters, 3, 1, $replacement);
-                    break;
-            }
-        }
-
         if (!method_exists($class, '__construct')) {
             $instance = new $class();
         } else {


### PR DESCRIPTION
While working on the `Registry` class I noted this BC code that actually never worked. It was introduced in https://github.com/simplepie/simplepie/commit/f6e63e6ba8e4a198283bb2323aa498fd0d6a216e (version 1.3).

The code was intended to fix a BC break in the `Locator::__construct()` method. But because the switch looks for `locator` instead of (uppercase) `Locator` there was no chance to register a BC class that matches this requirement. Please note also the wrong lower case in `$this->get_class('file')` and `$this->get_class('content_type_sniffer')` that would always return `null` instead of a class name. Also I could not find any complaints about a BC break for the changed parameter in the `Locator::__construct()` method. 

Therefor I propose to remove this BC code, that actually never worked. 