### PR TITLE
Registry: Allow using class-strings instead of magic strings

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -102,11 +102,12 @@ class Cache
     /**
      * Create a new SimplePie\Cache object
      *
-     * @deprecated Use {@see get_handler} instead
+     * @deprecated since SimplePie 1.3.1, use {@see get_handler()} instead
      */
     public function create($location, $filename, $extension)
     {
-        trigger_error('Cache::create() has been replaced with Cache::get_handler(). Switch to the registry system to use this.', \E_USER_DEPRECATED);
+        trigger_error('Cache::create() has been replaced with Cache::get_handler() since SimplePie 1.3.1, use the registry system instead.', \E_USER_DEPRECATED);
+
         return self::get_handler($location, $filename, $extension);
     }
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -253,9 +253,9 @@ class Item
     {
         if (!isset($this->data['title'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'title')) {
-                $this->data['title'] = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+                $this->data['title'] = $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
             } elseif ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'title')) {
-                $this->data['title'] = $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+                $this->data['title'] = $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
             } elseif ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_10, 'title')) {
                 $this->data['title'] = $this->sanitize($return[0]['data'], \SimplePie\SimplePie::CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
             } elseif ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_090, 'title')) {
@@ -291,10 +291,10 @@ class Item
     public function get_description($description_only = false)
     {
         if (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'summary')) &&
-            ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
+            ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
             return $return;
         } elseif (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'summary')) &&
-                ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
+                ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
             return $return;
         } elseif (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_10, 'description')) &&
                 ($return = $this->sanitize($tags[0]['data'], \SimplePie\SimplePie::CONSTRUCT_MAYBE_HTML, $this->get_base($tags[0])))) {
@@ -341,10 +341,10 @@ class Item
     public function get_content($content_only = false)
     {
         if (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'content')) &&
-            ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
+            ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_10_content_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
             return $return;
         } elseif (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'content')) &&
-                ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
+                ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
             return $return;
         } elseif (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
                 ($return = $this->sanitize($tags[0]['data'], \SimplePie\SimplePie::CONSTRUCT_HTML, $this->get_base($tags[0])))) {
@@ -419,7 +419,7 @@ class Item
             if (isset($category['attribs']['']['label'])) {
                 $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, $label, $type]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label, $type]);
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_20, $type) as $category) {
             // This is really the label, but keep this as the term also for BC.
@@ -430,15 +430,15 @@ class Item
             } else {
                 $scheme = null;
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, null, $type]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, null, $type]);
         }
 
         $type = 'subject';
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, $type) as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null, $type]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null, $type]);
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_10, $type) as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null, $type]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null, $type]);
         }
 
         if (!empty($categories)) {
@@ -507,7 +507,7 @@ class Item
                 $email = $this->sanitize($contributor['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'contributor') as $contributor) {
@@ -524,7 +524,7 @@ class Item
                 $email = $this->sanitize($contributor['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_03]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
 
@@ -560,7 +560,7 @@ class Item
                 $email = $this->sanitize($author['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         if ($author = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'author')) {
@@ -577,20 +577,20 @@ class Item
                 $email = $this->sanitize($author[0]['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_03]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
         if ($author = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_RSS_20, 'author')) {
-            $authors[] = $this->registry->create('Author', [null, null, $this->sanitize($author[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT)]);
+            $authors[] = $this->registry->create(Author::class, [null, null, $this->sanitize($author[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT)]);
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_10, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'author') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
 
         if (!empty($authors)) {
@@ -615,7 +615,7 @@ class Item
     public function get_copyright()
     {
         if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'rights')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, 'rights')) {
             return $this->sanitize($return[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
         } elseif ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_DC_10, 'rights')) {
@@ -661,7 +661,7 @@ class Item
             }
 
             if (!empty($this->data['date']['raw'])) {
-                $parser = $this->registry->call('Parse_Date', 'get');
+                $parser = $this->registry->call(Parse\Date::class, 'get');
                 $this->data['date']['parsed'] = $parser->parse($this->data['date']['raw']) ?: null;
             } else {
                 $this->data['date'] = null;
@@ -703,7 +703,7 @@ class Item
             }
 
             if (!empty($this->data['updated']['raw'])) {
-                $parser = $this->registry->call('Parse_Date', 'get');
+                $parser = $this->registry->call(Parse\Date::class, 'get');
                 $this->data['updated']['parsed'] = $parser->parse($this->data['updated']['raw']) ?: null;
             } else {
                 $this->data['updated'] = null;
@@ -867,7 +867,7 @@ class Item
 
             $keys = array_keys($this->data['links']);
             foreach ($keys as $key) {
-                if ($this->registry->call('Misc', 'is_isegment_nz_nc', [$key])) {
+                if ($this->registry->call(Misc::class, 'is_isegment_nz_nc', [$key])) {
                     if (isset($this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key])) {
                         $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key] = array_merge($this->data['links'][$key], $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key]);
                         $this->data['links'][$key] =& $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key];
@@ -967,7 +967,7 @@ class Item
                     if (isset($caption['data'])) {
                         $caption_text = $this->sanitize($caption['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $captions_parent[] = $this->registry->create('Caption', [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
+                    $captions_parent[] = $this->registry->create(Caption::class, [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
                 }
             } elseif ($captions = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'text')) {
                 foreach ($captions as $caption) {
@@ -991,7 +991,7 @@ class Item
                     if (isset($caption['data'])) {
                         $caption_text = $this->sanitize($caption['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $captions_parent[] = $this->registry->create('Caption', [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
+                    $captions_parent[] = $this->registry->create(Caption::class, [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
                 }
             }
             if (is_array($captions_parent)) {
@@ -1014,7 +1014,7 @@ class Item
                 if (isset($category['attribs']['']['label'])) {
                     $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                 }
-                $categories_parent[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                $categories_parent[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
             }
             foreach ((array) $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'category') as $category) {
                 $term = null;
@@ -1031,7 +1031,7 @@ class Item
                 if (isset($category['attribs']['']['label'])) {
                     $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                 }
-                $categories_parent[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                $categories_parent[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
             }
             foreach ((array) $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'category') as $category) {
                 $term = null;
@@ -1040,14 +1040,14 @@ class Item
                 if (isset($category['attribs']['']['text'])) {
                     $label = $this->sanitize($category['attribs']['']['text'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                 }
-                $categories_parent[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                $categories_parent[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
 
                 if (isset($category['child'][\SimplePie\SimplePie::NAMESPACE_ITUNES]['category'])) {
                     foreach ((array) $category['child'][\SimplePie\SimplePie::NAMESPACE_ITUNES]['category'] as $subcategory) {
                         if (isset($subcategory['attribs']['']['text'])) {
                             $label = $this->sanitize($subcategory['attribs']['']['text'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                         }
-                        $categories_parent[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                        $categories_parent[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
                     }
                 }
             }
@@ -1065,7 +1065,7 @@ class Item
                 if (isset($copyright[0]['data'])) {
                     $copyright_label = $this->sanitize($copyright[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                 }
-                $copyrights_parent = $this->registry->create('Copyright', [$copyright_url, $copyright_label]);
+                $copyrights_parent = $this->registry->create(Copyright::class, [$copyright_url, $copyright_label]);
             } elseif ($copyright = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'copyright')) {
                 $copyright_url = null;
                 $copyright_label = null;
@@ -1075,7 +1075,7 @@ class Item
                 if (isset($copyright[0]['data'])) {
                     $copyright_label = $this->sanitize($copyright[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                 }
-                $copyrights_parent = $this->registry->create('Copyright', [$copyright_url, $copyright_label]);
+                $copyrights_parent = $this->registry->create(Copyright::class, [$copyright_url, $copyright_label]);
             }
 
             // CREDITS
@@ -1095,7 +1095,7 @@ class Item
                     if (isset($credit['data'])) {
                         $credit_name = $this->sanitize($credit['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $credits_parent[] = $this->registry->create('Credit', [$credit_role, $credit_scheme, $credit_name]);
+                    $credits_parent[] = $this->registry->create(Credit::class, [$credit_role, $credit_scheme, $credit_name]);
                 }
             } elseif ($credits = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'credit')) {
                 foreach ($credits as $credit) {
@@ -1113,7 +1113,7 @@ class Item
                     if (isset($credit['data'])) {
                         $credit_name = $this->sanitize($credit['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $credits_parent[] = $this->registry->create('Credit', [$credit_role, $credit_scheme, $credit_name]);
+                    $credits_parent[] = $this->registry->create(Credit::class, [$credit_role, $credit_scheme, $credit_name]);
                 }
             }
             if (is_array($credits_parent)) {
@@ -1250,7 +1250,7 @@ class Item
                     if (isset($rating['data'])) {
                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $ratings_parent[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                    $ratings_parent[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                 }
             } elseif ($ratings = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'explicit')) {
                 foreach ($ratings as $rating) {
@@ -1259,7 +1259,7 @@ class Item
                     if (isset($rating['data'])) {
                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $ratings_parent[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                    $ratings_parent[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                 }
             } elseif ($ratings = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'rating')) {
                 foreach ($ratings as $rating) {
@@ -1273,7 +1273,7 @@ class Item
                     if (isset($rating['data'])) {
                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $ratings_parent[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                    $ratings_parent[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                 }
             } elseif ($ratings = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'explicit')) {
                 foreach ($ratings as $rating) {
@@ -1282,7 +1282,7 @@ class Item
                     if (isset($rating['data'])) {
                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $ratings_parent[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                    $ratings_parent[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                 }
             }
             if (is_array($ratings_parent)) {
@@ -1304,7 +1304,7 @@ class Item
                     if (isset($restriction['data'])) {
                         $restriction_value = $this->sanitize($restriction['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $restrictions_parent[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                    $restrictions_parent[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                 }
             } elseif ($restrictions = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'block')) {
                 foreach ($restrictions as $restriction) {
@@ -1314,7 +1314,7 @@ class Item
                     if (isset($restriction['data']) && strtolower($restriction['data']) === 'yes') {
                         $restriction_relationship = 'deny';
                     }
-                    $restrictions_parent[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                    $restrictions_parent[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                 }
             } elseif ($restrictions = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'restriction')) {
                 foreach ($restrictions as $restriction) {
@@ -1330,7 +1330,7 @@ class Item
                     if (isset($restriction['data'])) {
                         $restriction_value = $this->sanitize($restriction['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
-                    $restrictions_parent[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                    $restrictions_parent[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                 }
             } elseif ($restrictions = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'block')) {
                 foreach ($restrictions as $restriction) {
@@ -1340,7 +1340,7 @@ class Item
                     if (isset($restriction['data']) && strtolower($restriction['data']) === 'yes') {
                         $restriction_relationship = 'deny';
                     }
-                    $restrictions_parent[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                    $restrictions_parent[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                 }
             }
             if (is_array($restrictions_parent)) {
@@ -1510,7 +1510,7 @@ class Item
                                     if (isset($caption['data'])) {
                                         $caption_text = $this->sanitize($caption['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $captions[] = $this->registry->create('Caption', [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
+                                    $captions[] = $this->registry->create(Caption::class, [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
                                 }
                                 if (is_array($captions)) {
                                     $captions = array_values(array_unique($captions));
@@ -1537,7 +1537,7 @@ class Item
                                     if (isset($caption['data'])) {
                                         $caption_text = $this->sanitize($caption['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $captions[] = $this->registry->create('Caption', [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
+                                    $captions[] = $this->registry->create(Caption::class, [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
                                 }
                                 if (is_array($captions)) {
                                     $captions = array_values(array_unique($captions));
@@ -1563,7 +1563,7 @@ class Item
                                     if (isset($category['attribs']['']['label'])) {
                                         $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $categories[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                                    $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
                                 }
                             }
                             if (isset($group['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['category'])) {
@@ -1582,7 +1582,7 @@ class Item
                                     if (isset($category['attribs']['']['label'])) {
                                         $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $categories[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                                    $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
                                 }
                             }
                             if (is_array($categories) && is_array($categories_parent)) {
@@ -1603,7 +1603,7 @@ class Item
                                 if (isset($content['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'])) {
                                     $copyright_label = $this->sanitize($content['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $copyrights = $this->registry->create('Copyright', [$copyright_url, $copyright_label]);
+                                $copyrights = $this->registry->create(Copyright::class, [$copyright_url, $copyright_label]);
                             } elseif (isset($group['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'])) {
                                 $copyright_url = null;
                                 $copyright_label = null;
@@ -1613,7 +1613,7 @@ class Item
                                 if (isset($group['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'])) {
                                     $copyright_label = $this->sanitize($group['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $copyrights = $this->registry->create('Copyright', [$copyright_url, $copyright_label]);
+                                $copyrights = $this->registry->create(Copyright::class, [$copyright_url, $copyright_label]);
                             } else {
                                 $copyrights = $copyrights_parent;
                             }
@@ -1635,7 +1635,7 @@ class Item
                                     if (isset($credit['data'])) {
                                         $credit_name = $this->sanitize($credit['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $credits[] = $this->registry->create('Credit', [$credit_role, $credit_scheme, $credit_name]);
+                                    $credits[] = $this->registry->create(Credit::class, [$credit_role, $credit_scheme, $credit_name]);
                                 }
                                 if (is_array($credits)) {
                                     $credits = array_values(array_unique($credits));
@@ -1656,7 +1656,7 @@ class Item
                                     if (isset($credit['data'])) {
                                         $credit_name = $this->sanitize($credit['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $credits[] = $this->registry->create('Credit', [$credit_role, $credit_scheme, $credit_name]);
+                                    $credits[] = $this->registry->create(Credit::class, [$credit_role, $credit_scheme, $credit_name]);
                                 }
                                 if (is_array($credits)) {
                                     $credits = array_values(array_unique($credits));
@@ -1762,7 +1762,7 @@ class Item
                                     if (isset($rating['data'])) {
                                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $ratings[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                                    $ratings[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                                 }
                                 if (is_array($ratings)) {
                                     $ratings = array_values(array_unique($ratings));
@@ -1779,7 +1779,7 @@ class Item
                                     if (isset($rating['data'])) {
                                         $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $ratings[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                                    $ratings[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                                 }
                                 if (is_array($ratings)) {
                                     $ratings = array_values(array_unique($ratings));
@@ -1803,7 +1803,7 @@ class Item
                                     if (isset($restriction['data'])) {
                                         $restriction_value = $this->sanitize($restriction['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $restrictions[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                                    $restrictions[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                                 }
                                 if (is_array($restrictions)) {
                                     $restrictions = array_values(array_unique($restrictions));
@@ -1822,7 +1822,7 @@ class Item
                                     if (isset($restriction['data'])) {
                                         $restriction_value = $this->sanitize($restriction['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                     }
-                                    $restrictions[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                                    $restrictions[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                                 }
                                 if (is_array($restrictions)) {
                                     $restrictions = array_values(array_unique($restrictions));
@@ -1859,7 +1859,7 @@ class Item
                                 $title = $title_parent;
                             }
 
-                            $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width]);
+                            $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width]);
                         }
                     }
                 }
@@ -1966,7 +1966,7 @@ class Item
                                 if (isset($caption['data'])) {
                                     $caption_text = $this->sanitize($caption['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $captions[] = $this->registry->create('Caption', [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
+                                $captions[] = $this->registry->create(Caption::class, [$caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text]);
                             }
                             if (is_array($captions)) {
                                 $captions = array_values(array_unique($captions));
@@ -1992,7 +1992,7 @@ class Item
                                 if (isset($category['attribs']['']['label'])) {
                                     $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $categories[] = $this->registry->create('Category', [$term, $scheme, $label]);
+                                $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
                             }
                         }
                         if (is_array($categories) && is_array($categories_parent)) {
@@ -2015,7 +2015,7 @@ class Item
                             if (isset($content['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'])) {
                                 $copyright_label = $this->sanitize($content['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['copyright'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                             }
-                            $copyrights = $this->registry->create('Copyright', [$copyright_url, $copyright_label]);
+                            $copyrights = $this->registry->create(Copyright::class, [$copyright_url, $copyright_label]);
                         } else {
                             $copyrights = $copyrights_parent;
                         }
@@ -2037,7 +2037,7 @@ class Item
                                 if (isset($credit['data'])) {
                                     $credit_name = $this->sanitize($credit['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $credits[] = $this->registry->create('Credit', [$credit_role, $credit_scheme, $credit_name]);
+                                $credits[] = $this->registry->create(Credit::class, [$credit_role, $credit_scheme, $credit_name]);
                             }
                             if (is_array($credits)) {
                                 $credits = array_values(array_unique($credits));
@@ -2113,7 +2113,7 @@ class Item
                                 if (isset($rating['data'])) {
                                     $rating_value = $this->sanitize($rating['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $ratings[] = $this->registry->create('Rating', [$rating_scheme, $rating_value]);
+                                $ratings[] = $this->registry->create(Rating::class, [$rating_scheme, $rating_value]);
                             }
                             if (is_array($ratings)) {
                                 $ratings = array_values(array_unique($ratings));
@@ -2137,7 +2137,7 @@ class Item
                                 if (isset($restriction['data'])) {
                                     $restriction_value = $this->sanitize($restriction['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                                 }
-                                $restrictions[] = $this->registry->create('Restriction', [$restriction_relationship, $restriction_type, $restriction_value]);
+                                $restrictions[] = $this->registry->create(Restriction::class, [$restriction_relationship, $restriction_type, $restriction_value]);
                             }
                             if (is_array($restrictions)) {
                                 $restrictions = array_values(array_unique($restrictions));
@@ -2167,7 +2167,7 @@ class Item
                             $title = $title_parent;
                         }
 
-                        $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width]);
+                        $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width]);
                     }
                 }
             }
@@ -2204,7 +2204,7 @@ class Item
                     }
 
                     // Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-                    $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title, $width]);
+                    $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title, $width]);
                 }
             }
 
@@ -2235,7 +2235,7 @@ class Item
                     }
 
                     // Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-                    $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
+                    $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
                 }
             }
 
@@ -2267,13 +2267,13 @@ class Item
                     }
 
                     // Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-                    $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
+                    $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
                 }
             }
 
             if (sizeof($this->data['enclosures']) === 0 && ($url || $type || $length || $bitrate || $captions_parent || $categories_parent || $channels || $copyrights_parent || $credits_parent || $description_parent || $duration_parent || $expression || $framerate || $hashes_parent || $height || $keywords_parent || $lang || $medium || $player_parent || $ratings_parent || $restrictions_parent || $samplingrate || $thumbnails_parent || $title_parent || $width)) {
                 // Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-                $this->data['enclosures'][] = $this->registry->create('Enclosure', [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
+                $this->data['enclosures'][] = $this->registry->create(Enclosure::class, [$url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width]);
             }
 
             $this->data['enclosures'] = array_values(array_unique($this->data['enclosures']));
@@ -2342,7 +2342,7 @@ class Item
     public function get_source()
     {
         if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'source')) {
-            return $this->registry->create('Source', [$this, $return[0]]);
+            return $this->registry->create(Source::class, [$this, $return[0]]);
         }
 
         return null;

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -105,7 +105,7 @@ class Locator
         }
 
         if ($this->file->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE) {
-            $sniffer = $this->registry->create('Content_Type_Sniffer', [$this->file]);
+            $sniffer = $this->registry->create(Content\Type\Sniffer::class, [$this->file]);
             if ($sniffer->get_type() !== 'text/html') {
                 return null;
             }
@@ -142,7 +142,7 @@ class Locator
     public function is_feed($file, $check_html = false)
     {
         if ($file->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE) {
-            $sniffer = $this->registry->create('Content_Type_Sniffer', [$file]);
+            $sniffer = $this->registry->create(Content\Type\Sniffer::class, [$file]);
             $sniffed = $sniffer->get_type();
             $mime_types = ['application/rss+xml', 'application/rdf+xml',
                                 'text/rdf', 'application/atom+xml', 'text/xml',
@@ -169,7 +169,7 @@ class Locator
         $elements = $this->dom->getElementsByTagName('base');
         foreach ($elements as $element) {
             if ($element->hasAttribute('href')) {
-                $base = $this->registry->call('Misc', 'absolutize_url', [trim($element->getAttribute('href')), $this->http_base]);
+                $base = $this->registry->call(Misc::class, 'absolutize_url', [trim($element->getAttribute('href')), $this->http_base]);
                 if ($base === false) {
                     continue;
                 }
@@ -207,24 +207,24 @@ class Locator
                 break;
             }
             if ($link->hasAttribute('href') && $link->hasAttribute('rel')) {
-                $rel = array_unique($this->registry->call('Misc', 'space_separated_tokens', [strtolower($link->getAttribute('rel'))]));
+                $rel = array_unique($this->registry->call(Misc::class, 'space_separated_tokens', [strtolower($link->getAttribute('rel'))]));
                 $line = method_exists($link, 'getLineNo') ? $link->getLineNo() : 1;
 
                 if ($this->base_location < $line) {
-                    $href = $this->registry->call('Misc', 'absolutize_url', [trim($link->getAttribute('href')), $this->base]);
+                    $href = $this->registry->call(Misc::class, 'absolutize_url', [trim($link->getAttribute('href')), $this->base]);
                 } else {
-                    $href = $this->registry->call('Misc', 'absolutize_url', [trim($link->getAttribute('href')), $this->http_base]);
+                    $href = $this->registry->call(Misc::class, 'absolutize_url', [trim($link->getAttribute('href')), $this->http_base]);
                 }
                 if ($href === false) {
                     continue;
                 }
 
-                if (!in_array($href, $done) && in_array('feed', $rel) || (in_array('alternate', $rel) && !in_array('stylesheet', $rel) && $link->hasAttribute('type') && in_array(strtolower($this->registry->call('Misc', 'parse_mime', [$link->getAttribute('type')])), ['text/html', 'application/rss+xml', 'application/atom+xml'])) && !isset($feeds[$href])) {
+                if (!in_array($href, $done) && in_array('feed', $rel) || (in_array('alternate', $rel) && !in_array('stylesheet', $rel) && $link->hasAttribute('type') && in_array(strtolower($this->registry->call(Misc::class, 'parse_mime', [$link->getAttribute('type')])), ['text/html', 'application/rss+xml', 'application/atom+xml'])) && !isset($feeds[$href])) {
                     $this->checked_feeds++;
                     $headers = [
                         'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
                     ];
-                    $feed = $this->registry->create('File', [$href, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
+                    $feed = $this->registry->create(File::class, [$href, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
                     if ($feed->success && ($feed->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed, true)) {
                         $feeds[$href] = $feed;
                     }
@@ -246,18 +246,18 @@ class Locator
         foreach ($links as $link) {
             if ($link->hasAttribute('href')) {
                 $href = trim($link->getAttribute('href'));
-                $parsed = $this->registry->call('Misc', 'parse_url', [$href]);
+                $parsed = $this->registry->call(Misc::class, 'parse_url', [$href]);
                 if ($parsed['scheme'] === '' || preg_match('/^(https?|feed)?$/i', $parsed['scheme'])) {
                     if (method_exists($link, 'getLineNo') && $this->base_location < $link->getLineNo()) {
-                        $href = $this->registry->call('Misc', 'absolutize_url', [trim($link->getAttribute('href')), $this->base]);
+                        $href = $this->registry->call(Misc::class, 'absolutize_url', [trim($link->getAttribute('href')), $this->base]);
                     } else {
-                        $href = $this->registry->call('Misc', 'absolutize_url', [trim($link->getAttribute('href')), $this->http_base]);
+                        $href = $this->registry->call(Misc::class, 'absolutize_url', [trim($link->getAttribute('href')), $this->http_base]);
                     }
                     if ($href === false) {
                         continue;
                     }
 
-                    $current = $this->registry->call('Misc', 'parse_url', [$this->file->url]);
+                    $current = $this->registry->call(Misc::class, 'parse_url', [$this->file->url]);
 
                     if ($parsed['authority'] === '' || $parsed['authority'] === $current['authority']) {
                         $this->local[] = $href;
@@ -290,7 +290,7 @@ class Locator
         $query = '//a[@rel and @href] | //link[@rel and @href]';
         foreach ($xpath->query($query) as $link) {
             $href = trim($link->getAttribute('href'));
-            $parsed = $this->registry->call('Misc', 'parse_url', [$href]);
+            $parsed = $this->registry->call(Misc::class, 'parse_url', [$href]);
             if ($parsed['scheme'] === '' ||
                 preg_match('/^https?$/i', $parsed['scheme'])) {
                 if (method_exists($link, 'getLineNo') &&
@@ -335,7 +335,7 @@ class Locator
                 $headers = [
                     'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
                 ];
-                $feed = $this->registry->create('File', [$value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
+                $feed = $this->registry->create(File::class, [$value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
                 if ($feed->success && ($feed->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed)) {
                     return [$feed];
                 } else {
@@ -357,7 +357,7 @@ class Locator
                 $headers = [
                     'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
                 ];
-                $feed = $this->registry->create('File', [$value, $this->timeout, 5, null, $this->useragent, $this->force_fsockopen, $this->curl_options]);
+                $feed = $this->registry->create(File::class, [$value, $this->timeout, 5, null, $this->useragent, $this->force_fsockopen, $this->curl_options]);
                 if ($feed->success && ($feed->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed)) {
                     return [$feed];
                 } else {

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -295,21 +295,17 @@ class Locator
                 preg_match('/^https?$/i', $parsed['scheme'])) {
                 if (method_exists($link, 'getLineNo') &&
                     $this->base_location < $link->getLineNo()) {
-                    $href =
-                        $this->registry->call(
-                            'Misc',
-                            'absolutize_url',
-                            [trim($link->getAttribute('href')),
-                                                    $this->base]
-                        );
+                    $href = $this->registry->call(
+                        Misc::class,
+                        'absolutize_url',
+                        [trim($link->getAttribute('href')), $this->base]
+                    );
                 } else {
-                    $href =
-                        $this->registry->call(
-                            'Misc',
-                            'absolutize_url',
-                            [trim($link->getAttribute('href')),
-                                                    $this->http_base]
-                        );
+                    $href = $this->registry->call(
+                        Misc::class,
+                        'absolutize_url',
+                        [trim($link->getAttribute('href')), $this->http_base]
+                    );
                 }
                 if ($href === false) {
                     return null;

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1979,7 +1979,7 @@ class Misc
         // UTF-32 Big Endian Without BOM
         elseif (substr($data, 0, 20) === "\x00\x00\x00\x3C\x00\x00\x00\x3F\x00\x00\x00\x78\x00\x00\x00\x6D\x00\x00\x00\x6C") {
             if ($pos = strpos($data, "\x00\x00\x00\x3F\x00\x00\x00\x3E")) {
-                $parser = $registry->create('XML_Declaration_Parser', [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32BE', 'UTF-8')]);
+                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32BE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -1989,7 +1989,7 @@ class Misc
         // UTF-32 Little Endian Without BOM
         elseif (substr($data, 0, 20) === "\x3C\x00\x00\x00\x3F\x00\x00\x00\x78\x00\x00\x00\x6D\x00\x00\x00\x6C\x00\x00\x00") {
             if ($pos = strpos($data, "\x3F\x00\x00\x00\x3E\x00\x00\x00")) {
-                $parser = $registry->create('XML_Declaration_Parser', [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32LE', 'UTF-8')]);
+                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32LE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -1999,7 +1999,7 @@ class Misc
         // UTF-16 Big Endian Without BOM
         elseif (substr($data, 0, 10) === "\x00\x3C\x00\x3F\x00\x78\x00\x6D\x00\x6C") {
             if ($pos = strpos($data, "\x00\x3F\x00\x3E")) {
-                $parser = $registry->create('XML_Declaration_Parser', [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16BE', 'UTF-8')]);
+                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16BE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -2009,7 +2009,7 @@ class Misc
         // UTF-16 Little Endian Without BOM
         elseif (substr($data, 0, 10) === "\x3C\x00\x3F\x00\x78\x00\x6D\x00\x6C\x00") {
             if ($pos = strpos($data, "\x3F\x00\x3E\x00")) {
-                $parser = $registry->create('XML_Declaration_Parser', [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16LE', 'UTF-8')]);
+                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16LE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -2019,7 +2019,7 @@ class Misc
         // US-ASCII (or superset)
         elseif (substr($data, 0, 5) === "\x3C\x3F\x78\x6D\x6C") {
             if ($pos = strpos($data, "\x3F\x3E")) {
-                $parser = $registry->create('XML_Declaration_Parser', [substr($data, 5, $pos - 5)]);
+                $parser = $registry->create(XML\Declaration\Parser::class, [substr($data, 5, $pos - 5)]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -43,6 +43,8 @@
 
 namespace SimplePie;
 
+use SimplePie\XML\Declaration\Parser;
+
 /**
  * Miscellaneous utilities
  *
@@ -1979,7 +1981,7 @@ class Misc
         // UTF-32 Big Endian Without BOM
         elseif (substr($data, 0, 20) === "\x00\x00\x00\x3C\x00\x00\x00\x3F\x00\x00\x00\x78\x00\x00\x00\x6D\x00\x00\x00\x6C") {
             if ($pos = strpos($data, "\x00\x00\x00\x3F\x00\x00\x00\x3E")) {
-                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32BE', 'UTF-8')]);
+                $parser = $registry->create(Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32BE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -1989,7 +1991,7 @@ class Misc
         // UTF-32 Little Endian Without BOM
         elseif (substr($data, 0, 20) === "\x3C\x00\x00\x00\x3F\x00\x00\x00\x78\x00\x00\x00\x6D\x00\x00\x00\x6C\x00\x00\x00") {
             if ($pos = strpos($data, "\x3F\x00\x00\x00\x3E\x00\x00\x00")) {
-                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32LE', 'UTF-8')]);
+                $parser = $registry->create(Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 20), 'UTF-32LE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -1999,7 +2001,7 @@ class Misc
         // UTF-16 Big Endian Without BOM
         elseif (substr($data, 0, 10) === "\x00\x3C\x00\x3F\x00\x78\x00\x6D\x00\x6C") {
             if ($pos = strpos($data, "\x00\x3F\x00\x3E")) {
-                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16BE', 'UTF-8')]);
+                $parser = $registry->create(Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16BE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -2009,7 +2011,7 @@ class Misc
         // UTF-16 Little Endian Without BOM
         elseif (substr($data, 0, 10) === "\x3C\x00\x3F\x00\x78\x00\x6D\x00\x6C\x00") {
             if ($pos = strpos($data, "\x3F\x00\x3E\x00")) {
-                $parser = $registry->create(XML\Declaration\Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16LE', 'UTF-8')]);
+                $parser = $registry->create(Parser::class, [Misc::change_encoding(substr($data, 20, $pos - 10), 'UTF-16LE', 'UTF-8')]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }
@@ -2019,7 +2021,7 @@ class Misc
         // US-ASCII (or superset)
         elseif (substr($data, 0, 5) === "\x3C\x3F\x78\x6D\x6C") {
             if ($pos = strpos($data, "\x3F\x3E")) {
-                $parser = $registry->create(XML\Declaration\Parser::class, [substr($data, 5, $pos - 5)]);
+                $parser = $registry->create(Parser::class, [substr($data, 5, $pos - 5)]);
                 if ($parser->parse()) {
                     $encoding[] = $parser->encoding;
                 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -122,7 +122,7 @@ class Parser
         }
 
         if (substr($data, 0, 5) === '<?xml' && strspn(substr($data, 5, 1), "\x09\x0A\x0D\x20") && ($pos = strpos($data, '?>')) !== false) {
-            $declaration = $this->registry->create('XML_Declaration_Parser', [substr($data, 5, $pos - 5)]);
+            $declaration = $this->registry->create(XML\Declaration\Parser::class, [substr($data, 5, $pos - 5)]);
             if ($declaration->parse()) {
                 $data = substr($data, $pos + 2);
                 $data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' ."\n". $this->declare_html_entities() . $data;
@@ -271,7 +271,7 @@ class Parser
         }
 
         if (isset($attribs[\SimplePie\SimplePie::NAMESPACE_XML]['base'])) {
-            $base = $this->registry->call('Misc', 'absolutize_url', [$attribs[\SimplePie\SimplePie::NAMESPACE_XML]['base'], end($this->xml_base)]);
+            $base = $this->registry->call(Misc::class, 'absolutize_url', [$attribs[\SimplePie\SimplePie::NAMESPACE_XML]['base'], end($this->xml_base)]);
             if ($base !== false) {
                 $this->xml_base[] = $base;
                 $this->xml_base_explicit[] = true;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -43,6 +43,8 @@
 
 namespace SimplePie;
 
+use SimplePie\XML\Declaration\Parser as DeclarationParser;
+
 /**
  * Parses XML into something sane
  *
@@ -122,7 +124,7 @@ class Parser
         }
 
         if (substr($data, 0, 5) === '<?xml' && strspn(substr($data, 5, 1), "\x09\x0A\x0D\x20") && ($pos = strpos($data, '?>')) !== false) {
-            $declaration = $this->registry->create(XML\Declaration\Parser::class, [substr($data, 5, $pos - 5)]);
+            $declaration = $this->registry->create(DeclarationParser::class, [substr($data, 5, $pos - 5)]);
             if ($declaration->parse()) {
                 $data = substr($data, $pos + 2);
                 $data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' ."\n". $this->declare_html_entities() . $data;

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -167,7 +167,7 @@ class Registry
         /** @var string */
         $base_class = $this->default[$type];
 
-        if (!@is_subclass_of($class, $base_class)) {
+        if (!is_subclass_of($class, $base_class)) {
             return false;
         }
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -97,7 +97,7 @@ class Registry
      * Legacy classes
      *
      * @see register()
-     * @var array<string, class-string>
+     * @var array<class-string>
      */
     protected $legacy = [];
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -151,7 +151,7 @@ class Registry
     public function register($type, $class, $legacy = false)
     {
         if (array_key_exists($type, $this->legacyTypes)) {
-            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
+            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8.0, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
 
             $type = $this->legacyTypes[$type];
         }
@@ -192,7 +192,7 @@ class Registry
     public function get_class($type)
     {
         if (array_key_exists($type, $this->legacyTypes)) {
-            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
+            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8.0, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
 
             $type = $this->legacyTypes[$type];
         }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -149,6 +149,8 @@ class Registry
     public function register($type, $class, $legacy = false)
     {
         if (array_key_exists($type, $this->legacyTypes)) {
+            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
+
             $type = $this->legacyTypes[$type];
         }
 
@@ -188,6 +190,8 @@ class Registry
     public function get_class($type)
     {
         if (array_key_exists($type, $this->legacyTypes)) {
+            // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
+
             $type = $this->legacyTypes[$type];
         }
 

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -401,7 +401,7 @@ class Sanitize
                             if ($cache->get_data($image_url, false)) {
                                 $img->setAttribute('src', $this->image_handler . $image_url);
                             } else {
-                                $file = $this->registry->create('File', [$img->getAttribute('src'), $this->timeout, 5, ['X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']], $this->useragent, $this->force_fsockopen]);
+                                $file = $this->registry->create(File::class, [$img->getAttribute('src'), $this->timeout, 5, ['X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']], $this->useragent, $this->force_fsockopen]);
                                 $headers = $file->headers;
 
                                 if ($file->success && ($file->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE === 0 || ($file->status_code === 200 || $file->status_code > 206 && $file->status_code < 300))) {
@@ -432,7 +432,7 @@ class Sanitize
             }
 
             if ($type & \SimplePie\SimplePie::CONSTRUCT_IRI) {
-                $absolute = $this->registry->call('Misc', 'absolutize_url', [$data, $base]);
+                $absolute = $this->registry->call(Misc::class, 'absolutize_url', [$data, $base]);
                 if ($absolute !== false) {
                     $data = $absolute;
                 }
@@ -443,7 +443,7 @@ class Sanitize
             }
 
             if ($this->output_encoding !== 'UTF-8') {
-                $data = $this->registry->call('Misc', 'change_encoding', [$data, 'UTF-8', $this->output_encoding]);
+                $data = $this->registry->call(Misc::class, 'change_encoding', [$data, 'UTF-8', $this->output_encoding]);
             }
         }
         return $data;
@@ -481,7 +481,7 @@ class Sanitize
             foreach ($elements as $element) {
                 foreach ($attributes as $attribute) {
                     if ($element->hasAttribute($attribute)) {
-                        $value = $this->registry->call('Misc', 'absolutize_url', [$element->getAttribute($attribute), $this->base]);
+                        $value = $this->registry->call(Misc::class, 'absolutize_url', [$element->getAttribute($attribute), $this->base]);
                         if ($value !== false) {
                             $value = $this->https_url($value);
                             $element->setAttribute($attribute, $value);
@@ -617,7 +617,7 @@ class Sanitize
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);
-            $cache = $this->registry->call('Cache', 'get_handler', [
+            $cache = $this->registry->call(Cache::class, 'get_handler', [
                 $this->cache_location,
                 $image_url,
                 Base::TYPE_IMAGE

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -770,10 +770,10 @@ class SimplePie
         $this->multifeed_url = [];
         if (is_array($url)) {
             foreach ($url as $value) {
-                $this->multifeed_url[] = $this->registry->call('Misc', 'fix_protocol', [$value, 1]);
+                $this->multifeed_url[] = $this->registry->call(Misc::class, 'fix_protocol', [$value, 1]);
             }
         } else {
-            $this->feed_url = $this->registry->call('Misc', 'fix_protocol', [$url, 1]);
+            $this->feed_url = $this->registry->call(Misc::class, 'fix_protocol', [$url, 1]);
             $this->permanent_url = $this->feed_url;
         }
     }
@@ -1030,7 +1030,7 @@ class SimplePie
     public function set_cache_class($class = 'SimplePie\Cache')
     {
         // @trigger_error(sprintf('SimplePie\SimplePie::set_cache_class() is deprecated since SimplePie 1.3.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);
-        return $this->registry->register('Cache', $class, true);
+        return $this->registry->register(Cache::class, $class, true);
     }
 
     /**
@@ -1038,7 +1038,7 @@ class SimplePie
      */
     public function set_locator_class($class = 'SimplePie\Locator')
     {
-        return $this->registry->register('Locator', $class, true);
+        return $this->registry->register(Locator::class, $class, true);
     }
 
     /**
@@ -1046,7 +1046,7 @@ class SimplePie
      */
     public function set_parser_class($class = 'SimplePie\Parser')
     {
-        return $this->registry->register('Parser', $class, true);
+        return $this->registry->register(Parser::class, $class, true);
     }
 
     /**
@@ -1054,7 +1054,7 @@ class SimplePie
      */
     public function set_file_class($class = 'SimplePie\File')
     {
-        return $this->registry->register('File', $class, true);
+        return $this->registry->register(File::class, $class, true);
     }
 
     /**
@@ -1062,7 +1062,7 @@ class SimplePie
      */
     public function set_sanitize_class($class = 'SimplePie\Sanitize')
     {
-        return $this->registry->register('Sanitize', $class, true);
+        return $this->registry->register(Sanitize::class, $class, true);
     }
 
     /**
@@ -1070,7 +1070,7 @@ class SimplePie
      */
     public function set_item_class($class = 'SimplePie\Item')
     {
-        return $this->registry->register('Item', $class, true);
+        return $this->registry->register(Item::class, $class, true);
     }
 
     /**
@@ -1078,7 +1078,7 @@ class SimplePie
      */
     public function set_author_class($class = 'SimplePie\Author')
     {
-        return $this->registry->register('Author', $class, true);
+        return $this->registry->register(Author::class, $class, true);
     }
 
     /**
@@ -1086,7 +1086,7 @@ class SimplePie
      */
     public function set_category_class($class = 'SimplePie\Category')
     {
-        return $this->registry->register('Category', $class, true);
+        return $this->registry->register(Category::class, $class, true);
     }
 
     /**
@@ -1094,7 +1094,7 @@ class SimplePie
      */
     public function set_enclosure_class($class = 'SimplePie\Enclosure')
     {
-        return $this->registry->register('Enclosure', $class, true);
+        return $this->registry->register(Enclosure::class, $class, true);
     }
 
     /**
@@ -1102,7 +1102,7 @@ class SimplePie
      */
     public function set_caption_class($class = 'SimplePie\Caption')
     {
-        return $this->registry->register('Caption', $class, true);
+        return $this->registry->register(Caption::class, $class, true);
     }
 
     /**
@@ -1110,7 +1110,7 @@ class SimplePie
      */
     public function set_copyright_class($class = 'SimplePie\Copyright')
     {
-        return $this->registry->register('Copyright', $class, true);
+        return $this->registry->register(Copyright::class, $class, true);
     }
 
     /**
@@ -1118,7 +1118,7 @@ class SimplePie
      */
     public function set_credit_class($class = 'SimplePie\Credit')
     {
-        return $this->registry->register('Credit', $class, true);
+        return $this->registry->register(Credit::class, $class, true);
     }
 
     /**
@@ -1126,7 +1126,7 @@ class SimplePie
      */
     public function set_rating_class($class = 'SimplePie\Rating')
     {
-        return $this->registry->register('Rating', $class, true);
+        return $this->registry->register(Rating::class, $class, true);
     }
 
     /**
@@ -1134,7 +1134,7 @@ class SimplePie
      */
     public function set_restriction_class($class = 'SimplePie\Restriction')
     {
-        return $this->registry->register('Restriction', $class, true);
+        return $this->registry->register(Restriction::class, $class, true);
     }
 
     /**
@@ -1142,7 +1142,7 @@ class SimplePie
      */
     public function set_content_type_sniffer_class($class = 'SimplePie\Content\Type\Sniffer')
     {
-        return $this->registry->register('Content_Type_Sniffer', $class, true);
+        return $this->registry->register(Content\Type\Sniffer::class, $class, true);
     }
 
     /**
@@ -1150,7 +1150,7 @@ class SimplePie
      */
     public function set_source_class($class = 'SimplePie\Source')
     {
-        return $this->registry->register('Source', $class, true);
+        return $this->registry->register(Source::class, $class, true);
     }
     /**#@-*/
 
@@ -1384,8 +1384,8 @@ class SimplePie
 
         // The default sanitize class gets set in the constructor, check if it has
         // changed.
-        if ($this->registry->get_class('Sanitize') !== 'SimplePie\Sanitize') {
-            $this->sanitize = $this->registry->create('Sanitize');
+        if ($this->registry->get_class(Sanitize::class) !== 'SimplePie\Sanitize') {
+            $this->sanitize = $this->registry->create(Sanitize::class);
         }
         if (method_exists($this->sanitize, 'set_registry')) {
             $this->sanitize->set_registry($this->registry);
@@ -1397,10 +1397,10 @@ class SimplePie
             $this->enable_cache,
             $this->cache_location,
             $this->cache_name_function,
-            $this->registry->get_class('Cache'),
+            $this->registry->get_class(Cache::class),
             $this->cache
         );
-        $this->sanitize->pass_file_data($this->registry->get_class('File'), $this->timeout, $this->useragent, $this->force_fsockopen, $this->curl_options);
+        $this->sanitize->pass_file_data($this->registry->get_class(File::class), $this->timeout, $this->useragent, $this->force_fsockopen, $this->curl_options);
 
         if (!empty($this->multifeed_url)) {
             $i = 0;
@@ -1429,7 +1429,7 @@ class SimplePie
         $cache = false;
 
         if ($this->feed_url !== null) {
-            $parsed_feed_url = $this->registry->call('Misc', 'parse_url', [$this->feed_url]);
+            $parsed_feed_url = $this->registry->call(Misc::class, 'parse_url', [$this->feed_url]);
 
             // Decide whether to enable caching
             if ($this->enable_cache && $parsed_feed_url['scheme'] !== '') {
@@ -1449,7 +1449,7 @@ class SimplePie
         // Empty response check
         if (empty($this->raw_data)) {
             $this->error = "A feed could not be found at `$this->feed_url`. Empty body.";
-            $this->registry->call('Misc', 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
+            $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
             return false;
         }
 
@@ -1470,7 +1470,7 @@ class SimplePie
                 if (isset($headers['content-type']) && preg_match('/;\x20?charset=([^;]*)/i', $headers['content-type'], $charset)) {
                     $encodings[] = strtoupper($charset[1]);
                 }
-                $encodings = array_merge($encodings, $this->registry->call('Misc', 'xml_encoding', [$this->raw_data, &$this->registry]));
+                $encodings = array_merge($encodings, $this->registry->call(Misc::class, 'xml_encoding', [$this->raw_data, &$this->registry]));
                 $encodings[] = 'UTF-8';
             } elseif (in_array($sniffed, $text_types) || substr($sniffed, 0, 5) === 'text/' && substr($sniffed, -4) === '+xml') {
                 if (isset($headers['content-type']) && preg_match('/;\x20?charset=([^;]*)/i', $headers['content-type'], $charset)) {
@@ -1485,7 +1485,7 @@ class SimplePie
         }
 
         // Fallback to XML 1.0 Appendix F.1/UTF-8/ISO-8859-1
-        $encodings = array_merge($encodings, $this->registry->call('Misc', 'xml_encoding', [$this->raw_data, &$this->registry]));
+        $encodings = array_merge($encodings, $this->registry->call(Misc::class, 'xml_encoding', [$this->raw_data, &$this->registry]));
         $encodings[] = 'UTF-8';
         $encodings[] = 'ISO-8859-1';
 
@@ -1495,16 +1495,16 @@ class SimplePie
         // Loop through each possible encoding, till we return something, or run out of possibilities
         foreach ($encodings as $encoding) {
             // Change the encoding to UTF-8 (as we always use UTF-8 internally)
-            if ($utf8_data = $this->registry->call('Misc', 'change_encoding', [$this->raw_data, $encoding, 'UTF-8'])) {
+            if ($utf8_data = $this->registry->call(Misc::class, 'change_encoding', [$this->raw_data, $encoding, 'UTF-8'])) {
                 // Create new parser
-                $parser = $this->registry->create('Parser');
+                $parser = $this->registry->create(Parser::class);
 
                 // If it's parsed fine
                 if ($parser->parse($utf8_data, 'UTF-8', $this->permanent_url)) {
                     $this->data = $parser->get_data();
                     if (!($this->get_type() & ~self::TYPE_NONE)) {
                         $this->error = "A feed could not be found at `$this->feed_url`. This does not appear to be a valid RSS or Atom feed.";
-                        $this->registry->call('Misc', 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
+                        $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
                         return false;
                     }
 
@@ -1546,7 +1546,7 @@ class SimplePie
             }
         }
 
-        $this->registry->call('Misc', 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
+        $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
 
         return false;
     }
@@ -1623,7 +1623,7 @@ class SimplePie
                             $headers['if-none-match'] = $this->data['headers']['etag'];
                         }
 
-                        $file = $this->registry->create('File', [$this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
+                        $file = $this->registry->create(File::class, [$this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
                         $this->status_code = $file->status_code;
 
                         if ($file->success) {
@@ -1665,7 +1665,7 @@ class SimplePie
                 $headers = [
                     'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
                 ];
-                $file = $this->registry->create('File', [$this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
+                $file = $this->registry->create(File::class, [$this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options]);
             }
         }
         $this->status_code = $file->status_code;
@@ -1678,7 +1678,7 @@ class SimplePie
 
         if (!$this->force_feed) {
             // Check if the supplied URL is a feed, if it isn't, look for it.
-            $locate = $this->registry->create('Locator', [&$file, $this->timeout, $this->useragent, $this->max_checked_feeds, $this->force_fsockopen, $this->curl_options]);
+            $locate = $this->registry->create(Locator::class, [&$file, $this->timeout, $this->useragent, $this->max_checked_feeds, $this->force_fsockopen, $this->curl_options]);
 
             if (!$locate->is_feed($file)) {
                 $copyStatusCode = $file->status_code;
@@ -1720,7 +1720,7 @@ class SimplePie
                             // been called that object is untouched
                             unset($file);
                             $this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`";
-                            $this->registry->call('Misc', 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
+                            $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
                             return false;
                         }
                     }
@@ -1729,7 +1729,7 @@ class SimplePie
                     unset($file);
                     // This is usually because DOMDocument doesn't exist
                     $this->error = $e->getMessage();
-                    $this->registry->call('Misc', 'error', [$this->error, E_USER_NOTICE, $e->getFile(), $e->getLine()]);
+                    $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, $e->getFile(), $e->getLine()]);
                     return false;
                 }
 
@@ -1753,7 +1753,7 @@ class SimplePie
         $this->raw_data = $file->body;
         $this->permanent_url = $file->permanent_url;
         $headers = $file->headers;
-        $sniffer = $this->registry->create('Content_Type_Sniffer', [&$file]);
+        $sniffer = $this->registry->create(Content\Type\Sniffer::class, [&$file]);
         $sniffed = $sniffer->get_type();
 
         return [$headers, $sniffed];
@@ -2157,7 +2157,7 @@ class SimplePie
         } catch (\SimplePie\Exception $e) {
             if (!$this->enable_exceptions) {
                 $this->error = $e->getMessage();
-                $this->registry->call('Misc', 'error', [$this->error, E_USER_WARNING, $e->getFile(), $e->getLine()]);
+                $this->registry->call(Misc::class, 'error', [$this->error, E_USER_WARNING, $e->getFile(), $e->getLine()]);
                 return '';
             }
 
@@ -2176,9 +2176,9 @@ class SimplePie
     public function get_title()
     {
         if ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_10, 'title')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_03, 'title')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_RSS_10, 'title')) {
             return $this->sanitize($return[0]['data'], self::CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_RSS_090, 'title')) {
@@ -2236,7 +2236,7 @@ class SimplePie
             if (isset($category['attribs']['']['label'])) {
                 $label = $this->sanitize($category['attribs']['']['label'], self::CONSTRUCT_TEXT);
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, $label]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_RSS_20, 'category') as $category) {
             // This is really the label, but keep this as the term also for BC.
@@ -2247,13 +2247,13 @@ class SimplePie
             } else {
                 $scheme = null;
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, null]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, null]);
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_DC_11, 'subject') as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], self::CONSTRUCT_TEXT), null, null]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], self::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_DC_10, 'subject') as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], self::CONSTRUCT_TEXT), null, null]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], self::CONSTRUCT_TEXT), null, null]);
         }
 
         if (!empty($categories)) {
@@ -2305,7 +2305,7 @@ class SimplePie
                 $email = $this->sanitize($author['child'][self::NAMESPACE_ATOM_10]['email'][0]['data'], self::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         if ($author = $this->get_channel_tags(self::NAMESPACE_ATOM_03, 'author')) {
@@ -2322,17 +2322,17 @@ class SimplePie
                 $email = $this->sanitize($author[0]['child'][self::NAMESPACE_ATOM_03]['email'][0]['data'], self::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_DC_11, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_DC_10, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_ITUNES, 'author') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], self::CONSTRUCT_TEXT), null, null]);
         }
 
         if (!empty($authors)) {
@@ -2384,7 +2384,7 @@ class SimplePie
                 $email = $this->sanitize($contributor['child'][self::NAMESPACE_ATOM_10]['email'][0]['data'], self::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         foreach ((array) $this->get_channel_tags(self::NAMESPACE_ATOM_03, 'contributor') as $contributor) {
@@ -2401,7 +2401,7 @@ class SimplePie
                 $email = $this->sanitize($contributor['child'][self::NAMESPACE_ATOM_03]['email'][0]['data'], self::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
 
@@ -2487,7 +2487,7 @@ class SimplePie
 
             $keys = array_keys($this->data['links']);
             foreach ($keys as $key) {
-                if ($this->registry->call('Misc', 'is_isegment_nz_nc', [$key])) {
+                if ($this->registry->call(Misc::class, 'is_isegment_nz_nc', [$key])) {
                     if (isset($this->data['links'][self::IANA_LINK_RELATIONS_REGISTRY . $key])) {
                         $this->data['links'][self::IANA_LINK_RELATIONS_REGISTRY . $key] = array_merge($this->data['links'][$key], $this->data['links'][self::IANA_LINK_RELATIONS_REGISTRY . $key]);
                         $this->data['links'][$key] =& $this->data['links'][self::IANA_LINK_RELATIONS_REGISTRY . $key];
@@ -2537,9 +2537,9 @@ class SimplePie
     public function get_description()
     {
         if ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_10, 'subtitle')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_03, 'tagline')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_RSS_10, 'description')) {
             return $this->sanitize($return[0]['data'], self::CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_RSS_090, 'description')) {
@@ -2570,9 +2570,9 @@ class SimplePie
     public function get_copyright()
     {
         if ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_10, 'rights')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_ATOM_03, 'copyright')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_RSS_20, 'copyright')) {
             return $this->sanitize($return[0]['data'], self::CONSTRUCT_TEXT);
         } elseif ($return = $this->get_channel_tags(self::NAMESPACE_DC_11, 'rights')) {
@@ -2853,31 +2853,31 @@ class SimplePie
             if ($items = $this->get_feed_tags(self::NAMESPACE_ATOM_10, 'entry')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create('Item', [$this, $items[$key]]);
+                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_ATOM_03, 'entry')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create('Item', [$this, $items[$key]]);
+                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_RSS_10, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create('Item', [$this, $items[$key]]);
+                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_RSS_090, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create('Item', [$this, $items[$key]]);
+                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
                 }
             }
             if ($items = $this->get_channel_tags(self::NAMESPACE_RSS_20, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create('Item', [$this, $items[$key]]);
+                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
                 }
             }
         }
@@ -3061,7 +3061,7 @@ class SimplePie
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);
-            $cache = $this->registry->call('Cache', 'get_handler', [
+            $cache = $this->registry->call(Cache::class, 'get_handler', [
                 $this->cache_location,
                 $this->get_cache_filename($feed_url),
                 Base::TYPE_FEED

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -49,6 +49,7 @@ use SimplePie\Cache\Base;
 use SimplePie\Cache\BaseDataCache;
 use SimplePie\Cache\DataCache;
 use SimplePie\Cache\Psr16;
+use SimplePie\Content\Type\Sniffer;
 
 /**
  * SimplePie
@@ -1007,152 +1008,269 @@ class SimplePie
      *
      * Use this to override SimplePie's default classes
      * @see \SimplePie\Registry
-     * @return \SimplePie\Registry
+     *
+     * @return Registry
      */
     public function &get_registry()
     {
         return $this->registry;
     }
 
-    /**#@+
-     * Useful when you are overloading or extending SimplePie's default classes.
-     *
-     * @deprecated Use {@see get_registry()} instead
-     * @link http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.extends PHP5 extends documentation
-     * @param string $class Name of custom class
-     * @return boolean True on success, false otherwise
-     */
     /**
      * Set which class SimplePie uses for caching
      *
-     * @deprecated Use {@see set_cache()} instead
+     * @deprecated since SimplePie 1.3, use {@see set_cache()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_cache_class($class = 'SimplePie\Cache')
+    public function set_cache_class($class = Cache::class)
     {
-        // @trigger_error(sprintf('SimplePie\SimplePie::set_cache_class() is deprecated since SimplePie 1.3.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Cache::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for auto-discovery
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_locator_class($class = 'SimplePie\Locator')
+    public function set_locator_class($class = Locator::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Locator::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for XML parsing
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_parser_class($class = 'SimplePie\Parser')
+    public function set_parser_class($class = Parser::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Parser::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for remote file fetching
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_file_class($class = 'SimplePie\File')
+    public function set_file_class($class = File::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(File::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for data sanitization
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_sanitize_class($class = 'SimplePie\Sanitize')
+    public function set_sanitize_class($class = Sanitize::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Sanitize::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for handling feed items
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_item_class($class = 'SimplePie\Item')
+    public function set_item_class($class = Item::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Item::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for handling author data
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_author_class($class = 'SimplePie\Author')
+    public function set_author_class($class = Author::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Author::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for handling category data
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_category_class($class = 'SimplePie\Category')
+    public function set_category_class($class = Category::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Category::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for feed enclosures
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_enclosure_class($class = 'SimplePie\Enclosure')
+    public function set_enclosure_class($class = Enclosure::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Enclosure::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for `<media:text>` captions
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_caption_class($class = 'SimplePie\Caption')
+    public function set_caption_class($class = Caption::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Caption::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for `<media:copyright>`
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_copyright_class($class = 'SimplePie\Copyright')
+    public function set_copyright_class($class = Copyright::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Copyright::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for `<media:credit>`
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_credit_class($class = 'SimplePie\Credit')
+    public function set_credit_class($class = Credit::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Credit::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for `<media:rating>`
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_rating_class($class = 'SimplePie\Rating')
+    public function set_rating_class($class = Rating::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Rating::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for `<media:restriction>`
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_restriction_class($class = 'SimplePie\Restriction')
+    public function set_restriction_class($class = Restriction::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Restriction::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses for content-type sniffing
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_content_type_sniffer_class($class = 'SimplePie\Content\Type\Sniffer')
+    public function set_content_type_sniffer_class($class = Sniffer::class)
     {
-        return $this->registry->register(Content\Type\Sniffer::class, $class, true);
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
+        return $this->registry->register(Sniffer::class, $class, true);
     }
 
     /**
      * Set which class SimplePie uses item sources
+     *
+     * @deprecated since SimplePie 1.3, use {@see get_registry()} instead
+     *
+     * @param string $class Name of custom class
+     *
+     * @return boolean True on success, false otherwise
      */
-    public function set_source_class($class = 'SimplePie\Source')
+    public function set_source_class($class = Source::class)
     {
+        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+
         return $this->registry->register(Source::class, $class, true);
     }
-    /**#@-*/
 
     /**
      * Set the user agent string
@@ -1753,7 +1871,7 @@ class SimplePie
         $this->raw_data = $file->body;
         $this->permanent_url = $file->permanent_url;
         $headers = $file->headers;
-        $sniffer = $this->registry->create(Content\Type\Sniffer::class, [&$file]);
+        $sniffer = $this->registry->create(Sniffer::class, [&$file]);
         $sniffed = $sniffer->get_type();
 
         return [$headers, $sniffed];

--- a/src/Source.php
+++ b/src/Source.php
@@ -102,9 +102,9 @@ class Source
     public function get_title()
     {
         if ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'title')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'title')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_10, 'title')) {
             return $this->sanitize($return[0]['data'], \SimplePie\SimplePie::CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_090, 'title')) {
@@ -147,7 +147,7 @@ class Source
             if (isset($category['attribs']['']['label'])) {
                 $label = $this->sanitize($category['attribs']['']['label'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, $label]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, $label]);
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_20, 'category') as $category) {
             // This is really the label, but keep this as the term also for BC.
@@ -158,13 +158,13 @@ class Source
             } else {
                 $scheme = null;
             }
-            $categories[] = $this->registry->create('Category', [$term, $scheme, null]);
+            $categories[] = $this->registry->create(Category::class, [$term, $scheme, null]);
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, 'subject') as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_DC_10, 'subject') as $category) {
-            $categories[] = $this->registry->create('Category', [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $categories[] = $this->registry->create(Category::class, [$this->sanitize($category['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
 
         if (!empty($categories)) {
@@ -201,7 +201,7 @@ class Source
                 $email = $this->sanitize($author['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         if ($author = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'author')) {
@@ -218,17 +218,17 @@ class Source
                 $email = $this->sanitize($author[0]['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_03]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $authors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $authors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_DC_10, 'creator') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ITUNES, 'author') as $author) {
-            $authors[] = $this->registry->create('Author', [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
+            $authors[] = $this->registry->create(Author::class, [$this->sanitize($author['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT), null, null]);
         }
 
         if (!empty($authors)) {
@@ -265,7 +265,7 @@ class Source
                 $email = $this->sanitize($contributor['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $uri !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $uri, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $uri, $email]);
             }
         }
         foreach ((array) $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'contributor') as $contributor) {
@@ -282,7 +282,7 @@ class Source
                 $email = $this->sanitize($contributor['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_03]['email'][0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
             }
             if ($name !== null || $email !== null || $url !== null) {
-                $contributors[] = $this->registry->create('Author', [$name, $url, $email]);
+                $contributors[] = $this->registry->create(Author::class, [$name, $url, $email]);
             }
         }
 
@@ -343,7 +343,7 @@ class Source
 
             $keys = array_keys($this->data['links']);
             foreach ($keys as $key) {
-                if ($this->registry->call('Misc', 'is_isegment_nz_nc', [$key])) {
+                if ($this->registry->call(Misc::class, 'is_isegment_nz_nc', [$key])) {
                     if (isset($this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key])) {
                         $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key] = array_merge($this->data['links'][$key], $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key]);
                         $this->data['links'][$key] =& $this->data['links'][\SimplePie\SimplePie::IANA_LINK_RELATIONS_REGISTRY . $key];
@@ -367,9 +367,9 @@ class Source
     public function get_description()
     {
         if ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'subtitle')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'tagline')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_10, 'description')) {
             return $this->sanitize($return[0]['data'], \SimplePie\SimplePie::CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_090, 'description')) {
@@ -392,9 +392,9 @@ class Source
     public function get_copyright()
     {
         if ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'rights')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_03, 'copyright')) {
-            return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
+            return $this->sanitize($return[0]['data'], $this->registry->call(Misc::class, 'atom_03_construct_type', [$return[0]['attribs']]), $this->get_base($return[0]));
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_RSS_20, 'copyright')) {
             return $this->sanitize($return[0]['data'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
         } elseif ($return = $this->get_source_tags(\SimplePie\SimplePie::NAMESPACE_DC_11, 'rights')) {

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -41,6 +41,8 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
+use SimplePie\Cache;
+use SimplePie\File;
 use SimplePie\Tests\Fixtures\FileMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
@@ -92,7 +94,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
 
         $feed = new SimplePie();
         $feed->set_cache_class('Mock_CacheLegacy');
-        $feed->get_registry()->register('File', FileMock::class);
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         $feed->init();
@@ -103,8 +105,8 @@ class CacheTest extends PHPUnit\Framework\TestCase
         $this->expectException('Exception_Success');
 
         $feed = new SimplePie();
-        $feed->get_registry()->register('Cache', 'Mock_CacheNew');
-        $feed->get_registry()->register('File', FileMock::class);
+        $feed->get_registry()->register(Cache::class, 'Mock_CacheNew');
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         $feed->init();

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -46,7 +46,9 @@ namespace SimplePie\Tests\Integration;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
+use SimplePie\Cache;
 use SimplePie\Cache\Base;
+use SimplePie\File;
 use SimplePie\Misc;
 use SimplePie\SimplePie;
 use SimplePie\Tests\Fixtures\Cache\BaseCacheWithCallbacksMock;
@@ -69,7 +71,7 @@ class CachingTest extends TestCase
         $writtenData = [];
 
         $feed = new SimplePie();
-        $feed->get_registry()->register('File', FileMock::class);
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         switch ($testedCacheClass) {
@@ -126,7 +128,7 @@ class CachingTest extends TestCase
                     return true;
                 });
 
-                $feed->get_registry()->call('Cache', 'register', ['mock', BaseCacheWithCallbacksMock::class]);
+                $feed->get_registry()->call(Cache::class, 'register', ['mock', BaseCacheWithCallbacksMock::class]);
                 $feed->set_cache_location('mock');
                 break;
 

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -43,6 +43,7 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
+use SimplePie\File;
 use SimplePie\Tests\Fixtures\FileMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
@@ -72,7 +73,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
         $locator = new SimplePie_Locator($data, 0, null, false);
 
         $registry = new SimplePie_Registry();
-        $registry->register('File', FileMock::class);
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
@@ -87,7 +88,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
         $locator = new SimplePie_Locator($data, 0, null, false);
 
         $registry = new SimplePie_Registry();
-        $registry->register('File', FileMock::class);
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
@@ -152,7 +153,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
         $locator = new SimplePie_Locator($data, 0, null, false);
 
         $registry = new SimplePie_Registry();
-        $registry->register('File', FileMock::class);
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $expected = [];

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -89,7 +89,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
@@ -104,7 +104,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
@@ -169,7 +169,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
         $locator->set_registry($registry);
 
         $expected = [];

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -44,7 +44,9 @@
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SimplePie\File;
 use SimplePie\Registry;
+use SimplePie\Tests\Fixtures\FileMock;
 
 class RegistryTest extends TestCase
 {
@@ -59,7 +61,7 @@ class RegistryTest extends TestCase
     }
 
     /**
-     * @dataProvider getClassDataProvider
+     * @dataProvider getDefaultClassDataProvider
      */
     public function testGetClassReturnsCorrectClassname(string $type, string $expected)
     {
@@ -68,7 +70,7 @@ class RegistryTest extends TestCase
         $this->assertSame($expected, $registry->get_class($type));
     }
 
-    public function getClassDataProvider(): array
+    public function getDefaultClassDataProvider(): array
     {
         return [
             ['SimplePie\Cache', 'SimplePie\Cache'],
@@ -110,6 +112,28 @@ class RegistryTest extends TestCase
             ['Misc', 'SimplePie\Misc'],
             ['XML_Declaration_Parser', 'SimplePie\XML\Declaration\Parser'],
             ['Parse_Date', 'SimplePie\Parse\Date'],
+        ];
+    }
+
+    /**
+     * @dataProvider getOverridingClassDataProvider
+     */
+    public function testRegisterAllowsOverridingTheDefaultClassname(string $registeredType, string $requestedType, string $classname)
+    {
+        $registry = new Registry();
+
+        $registry->register($registeredType, $classname);
+
+        $this->assertSame($classname, $registry->get_class($requestedType));
+    }
+
+    public function getOverridingClassDataProvider(): array
+    {
+        return [
+            ['File',      'File',      FileMock::class],
+            [File::class, 'File',      FileMock::class],
+            ['File',      File::class, FileMock::class],
+            [File::class, File::class, FileMock::class],
         ];
     }
 }

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -44,16 +44,72 @@
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SimplePie\Registry;
 
 class RegistryTest extends TestCase
 {
     public function testNamespacedClassExists()
     {
-        $this->assertTrue(class_exists('SimplePie\Registry'));
+        $this->assertTrue(class_exists(Registry::class));
     }
 
     public function testClassExists()
     {
         $this->assertTrue(class_exists('SimplePie_Registry'));
+    }
+
+    /**
+     * @dataProvider getClassDataProvider
+     */
+    public function testGetClassReturnsCorrectClassname(string $type, string $expected)
+    {
+        $registry = new Registry();
+
+        $this->assertSame($expected, $registry->get_class($type));
+    }
+
+    public function getClassDataProvider(): array
+    {
+        return [
+            ['SimplePie\Cache', 'SimplePie\Cache'],
+            ['SimplePie\Locator', 'SimplePie\Locator'],
+            ['SimplePie\Parser', 'SimplePie\Parser'],
+            ['SimplePie\File', 'SimplePie\File'],
+            ['SimplePie\Sanitize', 'SimplePie\Sanitize'],
+            ['SimplePie\Item', 'SimplePie\Item'],
+            ['SimplePie\Author', 'SimplePie\Author'],
+            ['SimplePie\Category', 'SimplePie\Category'],
+            ['SimplePie\Enclosure', 'SimplePie\Enclosure'],
+            ['SimplePie\Caption', 'SimplePie\Caption'],
+            ['SimplePie\Copyright', 'SimplePie\Copyright'],
+            ['SimplePie\Credit', 'SimplePie\Credit'],
+            ['SimplePie\Rating', 'SimplePie\Rating'],
+            ['SimplePie\Restriction', 'SimplePie\Restriction'],
+            ['SimplePie\Content\Type\Sniffer', 'SimplePie\Content\Type\Sniffer'],
+            ['SimplePie\Source', 'SimplePie\Source'],
+            ['SimplePie\Misc', 'SimplePie\Misc'],
+            ['SimplePie\XML\Declaration\Parser', 'SimplePie\XML\Declaration\Parser'],
+            ['SimplePie\Parse\Date', 'SimplePie\Parse\Date'],
+            // Legacy type names
+            ['Cache', 'SimplePie\Cache'],
+            ['Locator', 'SimplePie\Locator'],
+            ['Parser', 'SimplePie\Parser'],
+            ['File', 'SimplePie\File'],
+            ['Sanitize', 'SimplePie\Sanitize'],
+            ['Item', 'SimplePie\Item'],
+            ['Author', 'SimplePie\Author'],
+            ['Category', 'SimplePie\Category'],
+            ['Enclosure', 'SimplePie\Enclosure'],
+            ['Caption', 'SimplePie\Caption'],
+            ['Copyright', 'SimplePie\Copyright'],
+            ['Credit', 'SimplePie\Credit'],
+            ['Rating', 'SimplePie\Rating'],
+            ['Restriction', 'SimplePie\Restriction'],
+            ['Content_Type_Sniffer', 'SimplePie\Content\Type\Sniffer'],
+            ['Source', 'SimplePie\Source'],
+            ['Misc', 'SimplePie\Misc'],
+            ['XML_Declaration_Parser', 'SimplePie\XML\Declaration\Parser'],
+            ['Parse_Date', 'SimplePie\Parse\Date'],
+        ];
     }
 }

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -44,8 +44,10 @@
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SimplePie\Cache;
 use SimplePie\File;
 use SimplePie\Registry;
+use SimplePie\Tests\Fixtures\Cache\NewCacheMock;
 use SimplePie\Tests\Fixtures\FileMock;
 
 class RegistryTest extends TestCase
@@ -116,6 +118,8 @@ class RegistryTest extends TestCase
     }
 
     /**
+     * Test register() and get_class() with old and new type names
+     *
      * @dataProvider getOverridingClassDataProvider
      */
     public function testRegisterAllowsOverridingTheDefaultClassname(string $registeredType, string $requestedType, string $classname)
@@ -130,10 +134,14 @@ class RegistryTest extends TestCase
     public function getOverridingClassDataProvider(): array
     {
         return [
-            ['File',      'File',      FileMock::class],
-            [File::class, 'File',      FileMock::class],
-            ['File',      File::class, FileMock::class],
-            [File::class, File::class, FileMock::class],
+            ['File',       'File',       FileMock::class],
+            [File::class,  'File',       FileMock::class],
+            ['File',       File::class,  FileMock::class],
+            [File::class,  File::class,  FileMock::class],
+            ['Cache',      'Cache',      NewCacheMock::class],
+            [Cache::class, 'Cache',      NewCacheMock::class],
+            ['Cache',      Cache::class, NewCacheMock::class],
+            [Cache::class, Cache::class, NewCacheMock::class],
         ];
     }
 }

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -44,6 +44,7 @@
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SimplePie\Misc;
 use SimplePie\Registry;
 use SimplePie\Sanitize;
 
@@ -130,7 +131,7 @@ EOT
         $sanitize = new Sanitize();
 
         $registry = new Registry();
-        $registry->register('Misc', 'SimplePie\Misc');
+        $registry->register(Misc::class, 'SimplePie\Misc');
         $sanitize->set_registry($registry);
 
         $base = 'http://example.com/';

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -255,6 +255,11 @@ class SimplePieTest extends TestCase
 
     public function testLegacyCallOfSetCacheClass()
     {
+        $feed = new SimplePie();
+        $feed->set_cache_class('SimplePie\Tests\Fixtures\Cache\LegacyCacheMock');
+        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $feed->set_feed_url('http://example.com/feed/');
+
         if (version_compare(PHP_VERSION, '8.0', '<')) {
             $this->expectException('SimplePie\Tests\Fixtures\Exception\SuccessException');
         } else {
@@ -263,11 +268,6 @@ class SimplePieTest extends TestCase
             // for the old non-static cache methods.
             $this->expectError();
         }
-
-        $feed = new SimplePie();
-        $feed->set_cache_class('SimplePie\Tests\Fixtures\Cache\LegacyCacheMock');
-        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
-        $feed->set_feed_url('http://example.com/feed/');
 
         $feed->init();
     }

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -45,7 +45,12 @@ namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
+use SimplePie\Cache;
+use SimplePie\File;
 use SimplePie\SimplePie;
+use SimplePie\Tests\Fixtures\Cache\LegacyCacheMock;
+use SimplePie\Tests\Fixtures\Cache\NewCacheMock;
+use SimplePie\Tests\Fixtures\FileMock;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
@@ -60,7 +65,7 @@ class SimplePieTest extends TestCase
 
     public function testClassExists()
     {
-        $this->assertTrue(class_exists('SimplePie'));
+        $this->assertTrue(class_exists(SimplePie::class));
     }
 
     /**
@@ -247,7 +252,7 @@ class SimplePieTest extends TestCase
 
         $feed = new SimplePie();
         $feed->set_cache($psr16);
-        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         $feed->init();
@@ -256,8 +261,8 @@ class SimplePieTest extends TestCase
     public function testLegacyCallOfSetCacheClass()
     {
         $feed = new SimplePie();
-        $feed->set_cache_class('SimplePie\Tests\Fixtures\Cache\LegacyCacheMock');
-        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $feed->set_cache_class(LegacyCacheMock::class);
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         if (version_compare(PHP_VERSION, '8.0', '<')) {
@@ -277,8 +282,8 @@ class SimplePieTest extends TestCase
         $this->expectException('SimplePie\Tests\Fixtures\Exception\SuccessException');
 
         $feed = new SimplePie();
-        $feed->get_registry()->register('Cache', 'SimplePie\Tests\Fixtures\Cache\NewCacheMock');
-        $feed->get_registry()->register('File', 'SimplePie\Tests\Fixtures\FileMock');
+        $feed->get_registry()->register(Cache::class, NewCacheMock::class);
+        $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
         $feed->init();
@@ -287,7 +292,7 @@ class SimplePieTest extends TestCase
     public function testDirectOverrideLegacy()
     {
         $feed = new SimplePie();
-        $feed->get_registry()->register('File', FileWithRedirectMock::class);
+        $feed->get_registry()->register(File::class, FileWithRedirectMock::class);
         $feed->enable_cache(false);
         $feed->set_feed_url('http://example.com/feed/');
 


### PR DESCRIPTION
As discussed with @jtojnar I finalized #737 for using class-strings instead of strings in `Registry` class. #737 can be closed.

It also create legacy replacements to provide BC. In future it should also possible to use an interface as `$type` and provide an implementing class as `$class`.