### PR TITLE
No URL Decode for enclosure links

### DIFF
--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -606,7 +606,7 @@ class Enclosure
     public function get_link()
     {
         if ($this->link !== null) {
-            return urldecode($this->link);
+            return $this->link;
         }
 
         return null;

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -98,7 +98,8 @@ class EnclosureTest extends TestCase
         </item>
     </channel>
 </rss>
-EOT,
+EOT
+            ,
                 'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
             ],
             'Test enclosure get_link urldecoded' => [
@@ -118,7 +119,8 @@ EOT,
         </item>
     </channel>
 </rss>
-EOT,
+EOT
+            ,
                 'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
             ],
         ];

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -83,7 +83,7 @@ class EnclosureTest extends TestCase
         return [
             'Test enclosure get_link urlencoded' => [
 <<<EOT
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
 	<channel>
 		<title>Test enclosure link 1</title>
 		<description>Test enclosure link 1</description>
@@ -103,7 +103,7 @@ EOT,
             ],
             'Test enclosure get_link urldecoded' => [
 <<<EOT
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
     <channel>
         <title>Test enclosure link 2</title>
         <description>Test enclosure link 2</description>

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -80,49 +80,48 @@ class EnclosureTest extends TestCase
 
     public function getLinkProvider()
     {
-        return [
-            'Test enclosure get_link urlencoded' => [
-<<<EOT
-<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
-    <channel>
-        <title>Test enclosure link 1</title>
-        <description>Test enclosure link 1</description>
-        <link>http://example.net/tests/</link>
-        <item>
-            <title>Test enclosure link 1.1</title>
-            <description>Test enclosure link 1.1</description>
-            <guid>http://example.net/tests/#1.1</guid>
-            <link>http://example.net/tests/#1.1</link>
-            <media:content url="http://example.net/link?a=%22b%22&amp;c=%3Cd%3E" medium="image">
-            </media:content>
-        </item>
-    </channel>
-</rss>
-EOT
+        yield 'Test enclosure get_link urlencoded' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test enclosure link 1</title>
+                    <description>Test enclosure link 1</description>
+                    <link>http://example.net/tests/</link>
+                    <item>
+                        <title>Test enclosure link 1.1</title>
+                        <description>Test enclosure link 1.1</description>
+                        <guid>http://example.net/tests/#1.1</guid>
+                        <link>http://example.net/tests/#1.1</link>
+                        <media:content url="http://example.net/link?a=%22b%22&amp;c=%3Cd%3E" medium="image">
+                        </media:content>
+                    </item>
+                </channel>
+            </rss>
+XML
             ,
-                'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
-            ],
-            'Test enclosure get_link urldecoded' => [
-<<<EOT
-<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
-    <channel>
-        <title>Test enclosure link 2</title>
-        <description>Test enclosure link 2</description>
-        <link>http://example.net/tests/</link>
-        <item>
-            <title>Test enclosure link 2.1</title>
-            <description>Test enclosure link 2.1</description>
-            <guid>http://example.net/tests/#2.1</guid>
-            <link>http://example.net/tests/#2.1</link>
-            <media:content url="http://example.net/link?a=&quot;b&quot;&amp;c=&lt;d&gt;" medium="image">
-            </media:content>
-        </item>
-    </channel>
-</rss>
-EOT
+            'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
+        ];
+
+        yield 'Test enclosure get_link urldecoded' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test enclosure link 2</title>
+                    <description>Test enclosure link 2</description>
+                    <link>http://example.net/tests/</link>
+                    <item>
+                        <title>Test enclosure link 2.1</title>
+                        <description>Test enclosure link 2.1</description>
+                        <guid>http://example.net/tests/#2.1</guid>
+                        <link>http://example.net/tests/#2.1</link>
+                        <media:content url="http://example.net/link?a=&quot;b&quot;&amp;c=&lt;d&gt;" medium="image">
+                        </media:content>
+                    </item>
+                </channel>
+            </rss>
+XML
             ,
-                'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
-            ],
+            'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
         ];
     }
 }

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -84,19 +84,19 @@ class EnclosureTest extends TestCase
             'Test enclosure get_link urlencoded' => [
 <<<EOT
 <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
-	<channel>
-		<title>Test enclosure link 1</title>
-		<description>Test enclosure link 1</description>
-		<link>http://example.net/tests/</link>
-		<item>
-			<title>Test enclosure link 1.1</title>
-			<description>Test enclosure link 1.1</description>
-			<guid>http://example.net/tests/#1.1</guid>
-			<link>http://example.net/tests/#1.1</link>
-			<media:content url="http://example.net/link?a=%22b%22&amp;c=%3Cd%3E" medium="image">
-			</media:content>
-		</item>
-	</channel>
+    <channel>
+        <title>Test enclosure link 1</title>
+        <description>Test enclosure link 1</description>
+        <link>http://example.net/tests/</link>
+        <item>
+            <title>Test enclosure link 1.1</title>
+            <description>Test enclosure link 1.1</description>
+            <guid>http://example.net/tests/#1.1</guid>
+            <link>http://example.net/tests/#1.1</link>
+            <media:content url="http://example.net/link?a=%22b%22&amp;c=%3Cd%3E" medium="image">
+            </media:content>
+        </item>
+    </channel>
 </rss>
 EOT,
                 'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -46,6 +46,8 @@ declare(strict_types=1);
 namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SimplePie\Enclosure;
+use SimplePie\SimplePie;
 
 class EnclosureTest extends TestCase
 {
@@ -57,5 +59,68 @@ class EnclosureTest extends TestCase
     public function testClassExists()
     {
         $this->assertTrue(class_exists('SimplePie_Enclosure'));
+    }
+
+    /**
+     * @dataProvider getLinkProvider
+     */
+    public function test_get_link($data, $expected)
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data($data);
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        $enclosure = $item->get_enclosure(0);
+
+        $this->assertInstanceOf(Enclosure::class, $enclosure);
+        $this->assertSame($expected, $enclosure->get_link());
+    }
+
+    public function getLinkProvider()
+    {
+        return [
+            'Test enclosure get_link urlencoded' => [
+<<<EOT
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+	<channel>
+		<title>Test enclosure link 1</title>
+		<description>Test enclosure link 1</description>
+		<link>http://example.net/tests/</link>
+		<item>
+			<title>Test enclosure link 1.1</title>
+			<description>Test enclosure link 1.1</description>
+			<guid>http://example.net/tests/#1.1</guid>
+			<link>http://example.net/tests/#1.1</link>
+			<media:content url="http://example.net/link?a=%22b%22&amp;c=%3Cd%3E" medium="image">
+			</media:content>
+		</item>
+	</channel>
+</rss>
+EOT,
+                'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
+            ],
+            'Test enclosure get_link urldecoded' => [
+<<<EOT
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <title>Test enclosure link 2</title>
+        <description>Test enclosure link 2</description>
+        <link>http://example.net/tests/</link>
+        <item>
+            <title>Test enclosure link 2.1</title>
+            <description>Test enclosure link 2.1</description>
+            <guid>http://example.net/tests/#2.1</guid>
+            <link>http://example.net/tests/#2.1</link>
+            <media:content url="http://example.net/link?a=&quot;b&quot;&amp;c=&lt;d&gt;" medium="image">
+            </media:content>
+        </item>
+    </channel>
+</rss>
+EOT,
+                'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Having an `urldecode` returns some potentially invalid URLs for enclosures, while SimplePie does not do that for other returned URLs.

Seems to be a similar error than https://github.com/simplepie/simplepie/commit/efb1d8e34c39276fb88fff0dcff01c673bec7e18

This line was introduced in https://github.com/simplepie/simplepie/commit/4bbd7eacfb6940d06899fa74a08754389ddd98de

Downstream PR https://github.com/FreshRSS/FreshRSS/pull/4944

P.S. There are a few other bugs related to enclosure links, and I will try to address some of them in distinct PRs.