### PR TITLE
Sanitize thumbnail URL

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -370,7 +370,13 @@ class Item implements RegistryAware
     {
         if (!isset($this->data['thumbnail'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'thumbnail')) {
-                $this->data['thumbnail'] = $return[0]['attribs'][''];
+                $thumbnail = $return[0]['attribs'][''];
+                if (empty($thumbnail['url'])) {
+                    $this->data['thumbnail'] = null;
+                } else {
+                    $thumbnail['url'] = $this->sanitize($thumbnail['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_base($return[0]));
+                    $this->data['thumbnail'] = $thumbnail;
+                }
             } else {
                 $this->data['thumbnail'] = null;
             }

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -4828,4 +4828,45 @@ EOT
 
         $this->assertSame($expected, $item->get_title());
     }
+
+    /**
+     * @dataProvider getThumbnailProvider
+     */
+    public function test_get_thumbnail($data, $expected)
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data($data);
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        $thumbnail = $item->get_thumbnail();
+        $this->assertSame($expected, $thumbnail['url']);
+    }
+
+    public function getThumbnailProvider()
+    {
+        return [
+            'Test thumbnail link sanitized' => [
+<<<EOT
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <title>Test thumbnail link 1</title>
+        <description>Test thumbnail link 1</description>
+        <link>http://example.org/tests/</link>
+        <item>
+            <title>Test thumbnail link 1.1</title>
+            <description>Test thumbnail link 1.1</description>
+            <guid>http://example.net/tests/#1.1</guid>
+            <link>http://example.net/tests/#1.1</link>
+            <media:thumbnail url="/link?a=&quot;b&quot;&amp;c=&lt;d&gt;" />
+        </item>
+    </channel>
+</rss>
+EOT
+            ,
+                'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Add missing sanitize and absolute_url on thumbnail URL.

SimplePie normally sanitizes all URLs, but the thumbnail URL was not processed.

Related to https://github.com/simplepie/simplepie/pull/768

Downstream PR https://github.com/FreshRSS/FreshRSS/pull/4944
