### PR TITLE
Fix broken phpdoc references

### DIFF
--- a/src/Cache/Base.php
+++ b/src/Cache/Base.php
@@ -83,7 +83,7 @@ interface Base
     /**
      * Save data to the cache
      *
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data);

--- a/src/Cache/DB.php
+++ b/src/Cache/DB.php
@@ -59,7 +59,7 @@ abstract class DB implements Base
      *
      * Converts a given {@see SimplePie} object into data to be stored
      *
-     * @param SimplePie $data
+     * @param \SimplePie\SimplePie $data
      * @return array First item is the serialized data for storage, second item is the unique ID for this item
      */
     protected static function prepare_simplepie_object_for_cache($data)

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -101,7 +101,7 @@ class File implements Base
     /**
      * Save data to the cache
      *
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data)

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -112,7 +112,7 @@ class Memcache implements Base
     /**
      * Save data to the cache
      *
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data)

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -108,7 +108,7 @@ class Memcached implements Base
 
     /**
      * Save data to the cache
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data)

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -63,7 +63,7 @@ class MySQL extends DB
     /**
      * PDO instance
      *
-     * @var PDO
+     * @var \PDO
      */
     protected $mysql;
 
@@ -148,7 +148,7 @@ class MySQL extends DB
     /**
      * Save data to the cache
      *
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data)

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -85,13 +85,6 @@ class Redis implements Base
     protected $name;
 
     /**
-     * Cache Data
-     *
-     * @var type
-     */
-    protected $data;
-
-    /**
      * Create a new cache object
      *
      * @param string $location Location string (from SimplePie::$cache_location)
@@ -135,7 +128,7 @@ class Redis implements Base
     /**
      * Save data to the cache
      *
-     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @param array|\SimplePie\SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
      * @return bool Successfulness
      */
     public function save($data)

--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -660,7 +660,7 @@ class Date
      *
      * @final
      * @access public
-     * @param callback $callback
+     * @param callable $callback
      */
     public function add_callback($callback)
     {


### PR DESCRIPTION
Otherwise ApiGen will complain:

	Missing SimplePie\Parse\callback
	referenced by SimplePie\Parse\Date

	Missing SimplePie\Cache\type
	referenced by SimplePie\Cache\Redis

	Missing SimplePie\Cache\SimplePie
	referenced by SimplePie\Cache\Redis

	Missing SimplePie\Cache\PDO
	referenced by SimplePie\Cache\MySQL
