### PR TITLE
Add type hints in all classes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,6 +13,7 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
         'void_return' => false,
+        'phpdoc_to_param_type' => true,
         '@PHPUnit84Migration:risky' => true,
     ])
     ->setFinder($finder)

--- a/library/SimplePie/Decode/HTML/Entities.php
+++ b/library/SimplePie/Decode/HTML/Entities.php
@@ -84,7 +84,7 @@ class SimplePie_Decode_HTML_Entities
      * @access public
      * @param string $data Input data
      */
-    public function __construct($data)
+    public function __construct(string $data)
     {
         $this->data = $data;
     }
@@ -128,7 +128,7 @@ class SimplePie_Decode_HTML_Entities
      * @param string $chars Characters to consume
      * @return mixed A series of characters that match the range, or false
      */
-    public function consume_range($chars)
+    public function consume_range(string $chars)
     {
         if ($len = strspn($this->data, $chars, $this->position)) {
             $data = substr($this->data, $this->position, $len);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-    backupGlobals="false"
-    bootstrap="tests/bootstrap.php"
-    convertDeprecationsToExceptions="true"
-    colors="true"
-    >
-    <testsuites>
-        <testsuite name="SimplePie Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">library</directory>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">library</directory>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="SimplePie Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" convertDeprecationsToExceptions="true">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">library</directory>

--- a/src/Author.php
+++ b/src/Author.php
@@ -88,7 +88,7 @@ class Author
      * @param string $link
      * @param string $email
      */
-    public function __construct($name = null, $link = null, $email = null)
+    public function __construct(string $name = null, string $link = null, string $email = null)
     {
         $this->name = $name;
         $this->link = $link;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -89,7 +89,7 @@ class Cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $extension 'spi' or 'spc'
      * @return Base Type of object depends on scheme of `$location`
      */
-    public static function get_handler($location, $filename, $extension)
+    public static function get_handler(string $location, string $filename, $extension)
     {
         $type = explode(':', $location, 2);
         $type = $type[0];
@@ -119,7 +119,7 @@ class Cache
      * @param string $type DSN type to register for
      * @param class-string<Base> $class Name of handler class. Must implement Base
      */
-    public static function register($type, $class)
+    public static function register(string $type, $class)
     {
         self::$handlers[$type] = $class;
     }
@@ -130,7 +130,7 @@ class Cache
      * @param string $url
      * @return array
      */
-    public static function parse_URL($url)
+    public static function parse_URL(string $url)
     {
         $params = parse_url($url);
         $params['extras'] = [];

--- a/src/Cache/Base.php
+++ b/src/Cache/Base.php
@@ -78,7 +78,7 @@ interface Base
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type);
+    public function __construct(string $location, string $name, $type);
 
     /**
      * Save data to the cache

--- a/src/Cache/CallableNameFilter.php
+++ b/src/Cache/CallableNameFilter.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/DB.php
+++ b/src/Cache/DB.php
@@ -62,7 +62,7 @@ abstract class DB implements Base
      * @param \SimplePie\SimplePie $data
      * @return array First item is the serialized data for storage, second item is the unique ID for this item
      */
-    protected static function prepare_simplepie_object_for_cache($data)
+    protected static function prepare_simplepie_object_for_cache(\SimplePie\SimplePie $data)
     {
         $items = $data->get_items();
         $items_by_id = [];

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -90,7 +90,7 @@ class File implements Base
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type)
+    public function __construct(string $location, string $name, $type)
     {
         $this->location = $location;
         $this->filename = $name;

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -91,7 +91,7 @@ class Memcache implements Base
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type)
+    public function __construct(string $location, string $name, $type)
     {
         $this->options = [
             'host' => '127.0.0.1',

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -88,7 +88,7 @@ class Memcached implements Base
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type)
+    public function __construct(string $location, string $name, $type)
     {
         $this->options = [
             'host'   => '127.0.0.1',

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -167,7 +167,7 @@ class Memcached implements Base
      * Set the last modified time and data to NativeMemcached
      * @return bool Success status
      */
-    private function setData($data)
+    private function setData($data): bool
     {
         if ($data !== false) {
             $this->cache->set($this->name . '_mtime', time(), (int)$this->options['extras']['timeout']);

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -88,7 +88,7 @@ class MySQL extends DB
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type)
+    public function __construct(string $location, string $name, $type)
     {
         $this->options = [
             'user' => null,

--- a/src/Cache/NameFilter.php
+++ b/src/Cache/NameFilter.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -89,9 +89,9 @@ class Redis implements Base
      *
      * @param string $location Location string (from SimplePie::$cache_location)
      * @param string $name Unique ID for the cache
-     * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     * @param Base::TYPE_FEED|Base::TYPE_IMAGE|array|null $options Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $options = null)
+    public function __construct(string $location, string $name, $options = null)
     {
         //$this->cache = \flow\simple\cache\Redis::getRedisClientInstance();
         $parsed = \SimplePie\Cache::parse_URL($location);

--- a/src/Category.php
+++ b/src/Category.php
@@ -100,7 +100,7 @@ class Category
      * @param string|null $label
      * @param string|null $type
      */
-    public function __construct($term = null, $scheme = null, $label = null, $type = null)
+    public function __construct(?string $term = null, ?string $scheme = null, ?string $label = null, ?string $type = null)
     {
         $this->term = $term;
         $this->scheme = $scheme;
@@ -145,7 +145,7 @@ class Category
      * @param bool $strict
      * @return string|null
      */
-    public function get_label($strict = false)
+    public function get_label(bool $strict = false)
     {
         if ($this->label === null && $strict !== true) {
             return $this->get_term();

--- a/src/Content/Type/Sniffer.php
+++ b/src/Content/Type/Sniffer.php
@@ -45,6 +45,8 @@ declare(strict_types=1);
 
 namespace SimplePie\Content\Type;
 
+use SimplePie\File;
+
 /**
  * Content-type sniffing
  *
@@ -71,9 +73,9 @@ class Sniffer
     /**
      * Create an instance of the class with the input file
      *
-     * @param Sniffer $file Input file
+     * @param File $file Input file
      */
-    public function __construct($file)
+    public function __construct(File $file)
     {
         $this->file = $file;
     }

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -294,7 +294,7 @@ class Enclosure
      * @param int $key
      * @return \SimplePie\Caption|null
      */
-    public function get_caption($key = 0)
+    public function get_caption(int $key = 0)
     {
         $captions = $this->get_captions();
         if (isset($captions[$key])) {
@@ -324,7 +324,7 @@ class Enclosure
      * @param int $key
      * @return \SimplePie\Category|null
      */
-    public function get_category($key = 0)
+    public function get_category(int $key = 0)
     {
         $categories = $this->get_categories();
         if (isset($categories[$key])) {
@@ -382,7 +382,7 @@ class Enclosure
      * @param int $key
      * @return \SimplePie\Credit|null
      */
-    public function get_credit($key = 0)
+    public function get_credit(int $key = 0)
     {
         $credits = $this->get_credits();
         if (isset($credits[$key])) {
@@ -426,7 +426,7 @@ class Enclosure
      * @param bool $convert Convert seconds into hh:mm:ss
      * @return string|int|null 'hh:mm:ss' string if `$convert` was specified, otherwise integer (or null if none found)
      */
-    public function get_duration($convert = false)
+    public function get_duration(bool $convert = false)
     {
         if ($this->duration !== null) {
             if ($convert) {
@@ -501,7 +501,7 @@ class Enclosure
      * @param int $key
      * @return string|null Hash as per `media:hash`, prefixed with "$algo:"
      */
-    public function get_hash($key = 0)
+    public function get_hash(int $key = 0)
     {
         $hashes = $this->get_hashes();
         if (isset($hashes[$key])) {
@@ -560,7 +560,7 @@ class Enclosure
      * @param int $key
      * @return string|null
      */
-    public function get_keyword($key = 0)
+    public function get_keyword(int $key = 0)
     {
         $keywords = $this->get_keywords();
         if (isset($keywords[$key])) {
@@ -648,7 +648,7 @@ class Enclosure
      * @param int $key
      * @return \SimplePie\Rating|null
      */
-    public function get_rating($key = 0)
+    public function get_rating(int $key = 0)
     {
         $ratings = $this->get_ratings();
         if (isset($ratings[$key])) {
@@ -678,7 +678,7 @@ class Enclosure
      * @param int $key
      * @return \SimplePie\Restriction|null
      */
-    public function get_restriction($key = 0)
+    public function get_restriction(int $key = 0)
     {
         $restrictions = $this->get_restrictions();
         if (isset($restrictions[$key])) {
@@ -737,7 +737,7 @@ class Enclosure
      * @param int $key
      * @return string|null Thumbnail URL
      */
-    public function get_thumbnail($key = 0)
+    public function get_thumbnail(int $key = 0)
     {
         $thumbnails = $this->get_thumbnails();
         if (isset($thumbnails[$key])) {
@@ -862,7 +862,7 @@ class Enclosure
      * @param bool $native Use `<embed>`
      * @return string HTML string to output
      */
-    public function embed($options = '', $native = false)
+    public function embed($options = '', bool $native = false)
     {
         // Set up defaults
         $audio = '';
@@ -1047,7 +1047,7 @@ class Enclosure
      * @param bool $find_handler Internal use only, use {@see get_handler()} instead
      * @return string MIME type
      */
-    public function get_real_type($find_handler = false)
+    public function get_real_type(bool $find_handler = false)
     {
         // Mime-types by handler.
         $types_flash = ['application/x-shockwave-flash', 'application/futuresplash']; // Flash
@@ -1115,7 +1115,7 @@ class Enclosure
                     $type = 'audio/x-ms-wma';
                     break;
 
-                // Video mime-types
+                    // Video mime-types
                 case '3gp':
                 case '3gpp':
                     $type = 'video/3gpp';
@@ -1178,7 +1178,7 @@ class Enclosure
                     $type = 'video/x-ms-wvx';
                     break;
 
-                // Flash mime-types
+                    // Flash mime-types
                 case 'spl':
                     $type = 'application/futuresplash';
                     break;

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -1115,9 +1115,9 @@ class Enclosure
                     $type = 'audio/x-ms-wma';
                     break;
 
-                    // Video mime-types
                 case '3gp':
                 case '3gpp':
+                    // Video mime-types
                     $type = 'video/3gpp';
                     break;
 
@@ -1178,8 +1178,8 @@ class Enclosure
                     $type = 'video/x-ms-wvx';
                     break;
 
-                    // Flash mime-types
                 case 'spl':
+                    // Flash mime-types
                     $type = 'application/futuresplash';
                     break;
 

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -180,7 +180,7 @@ class Gzdecode
      * @param string $name
      * @param mixed $value
      */
-    public function __set($name, $value)
+    public function __set(string $name, $value)
     {
         trigger_error("Cannot write property $name", E_USER_ERROR);
     }
@@ -190,7 +190,7 @@ class Gzdecode
      *
      * @param string $data
      */
-    public function __construct($data)
+    public function __construct(string $data)
     {
         $this->compressed_data = $data;
         $this->compressed_size = strlen($data);

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -163,7 +163,7 @@ class Parser
      *
      * @param string $data Input data
      */
-    public function __construct($data)
+    public function __construct(string $data)
     {
         $this->data = $data;
         $this->data_length = strlen($this->data);
@@ -490,7 +490,7 @@ class Parser
      *
      * @return string
      */
-    public static function prepareHeaders($headers, $count = 1)
+    public static function prepareHeaders(string $headers, int $count = 1)
     {
         $data = explode("\r\n\r\n", $headers, $count);
         $data = array_pop($data);

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -149,7 +149,7 @@ class IRI
      * @param string $name Property name
      * @param mixed $value Property value
      */
-    public function __set($name, $value)
+    public function __set(string $name, $value)
     {
         if (method_exists($this, 'set_' . $name)) {
             call_user_func([$this, 'set_' . $name], $value);
@@ -171,7 +171,7 @@ class IRI
      * @param string $name Property name
      * @return mixed
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         // isset() returns false for null, we don't want to do that
         // Also why we use array_key_exists below instead of isset()
@@ -214,7 +214,7 @@ class IRI
      * @param string $name Property name
      * @return bool
      */
-    public function __isset($name)
+    public function __isset(string $name)
     {
         return method_exists($this, 'get_' . $name) || isset($this->$name);
     }
@@ -224,7 +224,7 @@ class IRI
      *
      * @param string $name Property name
      */
-    public function __unset($name)
+    public function __unset(string $name)
     {
         if (method_exists($this, 'set_' . $name)) {
             call_user_func([$this, 'set_' . $name], '');
@@ -236,7 +236,7 @@ class IRI
      *
      * @param string $iri
      */
-    public function __construct($iri = null)
+    public function __construct(string $iri = null)
     {
         $this->set_iri($iri);
     }
@@ -324,7 +324,7 @@ class IRI
      * @param string $iri
      * @return array
      */
-    protected function parse_iri($iri)
+    protected function parse_iri(string $iri)
     {
         $iri = trim($iri, "\x20\x09\x0A\x0C\x0D");
         if (preg_match('/^((?P<scheme>[^:\/?#]+):)?(\/\/(?P<authority>[^\/?#]*))?(?P<path>[^?#]*)(\?(?P<query>[^#]*))?(#(?P<fragment>.*))?$/', $iri, $match)) {
@@ -356,7 +356,7 @@ class IRI
      * @param string $input
      * @return string
      */
-    protected function remove_dot_segments($input)
+    protected function remove_dot_segments(string $input)
     {
         $output = '';
         while (strpos($input, './') !== false || strpos($input, '/.') !== false || $input === '.' || $input === '..') {
@@ -405,7 +405,7 @@ class IRI
      * @param bool $iprivate Allow iprivate
      * @return string
      */
-    protected function replace_invalid_with_pct_encoding($string, $extra_chars, $iprivate = false)
+    protected function replace_invalid_with_pct_encoding(string $string, string $extra_chars, bool $iprivate = false)
     {
         // Normalize as many pct-encoded sections as possible
         $string = preg_replace_callback('/(?:%[A-Fa-f0-9]{2})+/', [$this, 'remove_iunreserved_percent_encoded'], $string);
@@ -529,7 +529,7 @@ class IRI
      * @param array $match PCRE match
      * @return string Replacement
      */
-    protected function remove_iunreserved_percent_encoded($match)
+    protected function remove_iunreserved_percent_encoded(array $match)
     {
         // As we just have valid percent encoded sequences we can just explode
         // and ignore the first member of the returned array (an empty string).
@@ -709,10 +709,10 @@ class IRI
      * Set the entire IRI. Returns true on success, false on failure (if there
      * are any invalid characters).
      *
-     * @param string $iri
+     * @param string|null $iri
      * @return bool
      */
-    public function set_iri($iri, $clear_cache = false)
+    public function set_iri(?string $iri, $clear_cache = false)
     {
         static $cache;
         if ($clear_cache) {
@@ -769,10 +769,10 @@ class IRI
      * Set the scheme. Returns true on success, false on failure (if there are
      * any invalid characters).
      *
-     * @param string $scheme
+     * @param string|null $scheme
      * @return bool
      */
-    public function set_scheme($scheme)
+    public function set_scheme(?string $scheme)
     {
         if ($scheme === null) {
             $this->scheme = null;
@@ -789,10 +789,10 @@ class IRI
      * Set the authority. Returns true on success, false on failure (if there are
      * any invalid characters).
      *
-     * @param string $authority
+     * @param string|null $authority
      * @return bool
      */
-    public function set_authority($authority, $clear_cache = false)
+    public function set_authority(?string $authority, $clear_cache = false)
     {
         static $cache;
         if ($clear_cache) {
@@ -852,10 +852,10 @@ class IRI
     /**
      * Set the iuserinfo.
      *
-     * @param string $iuserinfo
+     * @param string|null $iuserinfo
      * @return bool
      */
-    public function set_userinfo($iuserinfo)
+    public function set_userinfo(?string $iuserinfo)
     {
         if ($iuserinfo === null) {
             $this->iuserinfo = null;
@@ -871,10 +871,10 @@ class IRI
      * Set the ihost. Returns true on success, false on failure (if there are
      * any invalid characters).
      *
-     * @param string $ihost
+     * @param string|null $ihost
      * @return bool
      */
-    public function set_host($ihost)
+    public function set_host(?string $ihost)
     {
         if ($ihost === null) {
             $this->ihost = null;
@@ -915,7 +915,7 @@ class IRI
      * Set the port. Returns true on success, false on failure (if there are
      * any invalid characters).
      *
-     * @param string $port
+     * @param string|int|null $port
      * @return bool
      */
     public function set_port($port)
@@ -936,10 +936,10 @@ class IRI
     /**
      * Set the ipath.
      *
-     * @param string $ipath
+     * @param string|null $ipath
      * @return bool
      */
-    public function set_path($ipath, $clear_cache = false)
+    public function set_path(?string $ipath, $clear_cache = false)
     {
         static $cache;
         if ($clear_cache) {
@@ -969,10 +969,10 @@ class IRI
     /**
      * Set the iquery.
      *
-     * @param string $iquery
+     * @param string|null $iquery
      * @return bool
      */
-    public function set_query($iquery)
+    public function set_query(?string $iquery)
     {
         if ($iquery === null) {
             $this->iquery = null;
@@ -986,10 +986,10 @@ class IRI
     /**
      * Set the ifragment.
      *
-     * @param string $ifragment
+     * @param string|null $ifragment
      * @return bool
      */
-    public function set_fragment($ifragment)
+    public function set_fragment(?string $ifragment)
     {
         if ($ifragment === null) {
             $this->ifragment = null;

--- a/src/Item.php
+++ b/src/Item.php
@@ -676,7 +676,6 @@ class Item implements RegistryAware
             }
         }
         if ($this->data['date']) {
-            $date_format = (string) $date_format;
             switch ($date_format) {
                 case '':
                     return $this->sanitize($this->data['date']['raw'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
@@ -718,7 +717,6 @@ class Item implements RegistryAware
             }
         }
         if ($this->data['updated']) {
-            $date_format = (string) $date_format;
             switch ($date_format) {
                 case '':
                     return $this->sanitize($this->data['updated']['raw'], \SimplePie\SimplePie::CONSTRUCT_TEXT);

--- a/src/Item.php
+++ b/src/Item.php
@@ -905,7 +905,7 @@ class Item implements RegistryAware
      * @param int $key The enclosure that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Enclosure|null
      */
-    public function get_enclosure(int $key = 0, $prefer = null)
+    public function get_enclosure(int $key = 0)
     {
         $enclosures = $this->get_enclosures();
         if (isset($enclosures[$key])) {

--- a/src/Item.php
+++ b/src/Item.php
@@ -90,7 +90,7 @@ class Item implements RegistryAware
      * @param \SimplePie\SimplePie $feed Parent feed
      * @param array $data Raw data
      */
-    public function __construct($feed, $data)
+    public function __construct(\SimplePie\SimplePie $feed, array $data)
     {
         $this->feed = $feed;
         $this->data = $data;
@@ -143,7 +143,7 @@ class Item implements RegistryAware
      * @param string $tag Tag name
      * @return array
      */
-    public function get_item_tags($namespace, $tag)
+    public function get_item_tags(string $namespace, string $tag)
     {
         if (isset($this->data['child'][$namespace][$tag])) {
             return $this->data['child'][$namespace][$tag];
@@ -159,7 +159,7 @@ class Item implements RegistryAware
      * @param array $element
      * @return string
      */
-    public function get_base($element = [])
+    public function get_base(array $element = [])
     {
         if (!empty($element['xml_base_explicit']) && isset($element['xml_base'])) {
             return $element['xml_base'];
@@ -178,10 +178,10 @@ class Item implements RegistryAware
      * @see \SimplePie\SimplePie::sanitize()
      * @param string $data Data to sanitize
      * @param int $type One of the \SimplePie\SimplePie::CONSTRUCT_* constants
-     * @param string $base Base URL to resolve URLs against
+     * @param string|null $base Base URL to resolve URLs against
      * @return string Sanitized data
      */
-    public function sanitize($data, $type, $base = '')
+    public function sanitize(string $data, int $type, ?string $base = '')
     {
         return $this->feed->sanitize($data, $type, $base);
     }
@@ -214,7 +214,7 @@ class Item implements RegistryAware
      * @param string|false $fn User-supplied function to generate an hash
      * @return string|null
      */
-    public function get_id($hash = false, $fn = 'md5')
+    public function get_id(bool $hash = false, $fn = 'md5')
     {
         if (!$hash) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'id')) {
@@ -290,7 +290,7 @@ class Item implements RegistryAware
      * @param boolean $description_only Should we avoid falling back to the content?
      * @return string|null
      */
-    public function get_description($description_only = false)
+    public function get_description(bool $description_only = false)
     {
         if (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'summary')) &&
             ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_10_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
@@ -340,7 +340,7 @@ class Item implements RegistryAware
      * @param boolean $content_only Should we avoid falling back to the description?
      * @return string|null
      */
-    public function get_content($content_only = false)
+    public function get_content(bool $content_only = false)
     {
         if (($tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'content')) &&
             ($return = $this->sanitize($tags[0]['data'], $this->registry->call(Misc::class, 'atom_10_content_construct_type', [$tags[0]['attribs']]), $this->get_base($tags[0])))) {
@@ -391,7 +391,7 @@ class Item implements RegistryAware
      * @param int $key The category that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Category|null
      */
-    public function get_category($key = 0)
+    public function get_category(int $key = 0)
     {
         $categories = $this->get_categories();
         if (isset($categories[$key])) {
@@ -463,7 +463,7 @@ class Item implements RegistryAware
      * @param int $key The author that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Author|null
      */
-    public function get_author($key = 0)
+    public function get_author(int $key = 0)
     {
         $authors = $this->get_authors();
         if (isset($authors[$key])) {
@@ -480,7 +480,7 @@ class Item implements RegistryAware
      * @param int $key The contrbutor that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Author|null
      */
-    public function get_contributor($key = 0)
+    public function get_contributor(int $key = 0)
     {
         $contributors = $this->get_contributors();
         if (isset($contributors[$key])) {
@@ -647,7 +647,7 @@ class Item implements RegistryAware
      * @param string $date_format Supports any PHP date format from {@see http://php.net/date} (empty for the raw data)
      * @return int|string|null
      */
-    public function get_date($date_format = 'j F Y, g:i a')
+    public function get_date(string $date_format = 'j F Y, g:i a')
     {
         if (!isset($this->data['date'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'published')) {
@@ -703,7 +703,7 @@ class Item implements RegistryAware
      * @param string $date_format Supports any PHP date format from {@see http://php.net/date} (empty for the raw data)
      * @return int|string|null
      */
-    public function get_updated_date($date_format = 'j F Y, g:i a')
+    public function get_updated_date(string $date_format = 'j F Y, g:i a')
     {
         if (!isset($this->data['updated'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_ATOM_10, 'updated')) {
@@ -747,7 +747,7 @@ class Item implements RegistryAware
      * @param string $date_format Supports any PHP date format from {@see http://php.net/strftime} (empty for the raw data)
      * @return int|string|null
      */
-    public function get_local_date($date_format = '%c')
+    public function get_local_date(string $date_format = '%c')
     {
         if (!$date_format) {
             return $this->sanitize($this->get_date(''), \SimplePie\SimplePie::CONSTRUCT_TEXT);
@@ -765,7 +765,7 @@ class Item implements RegistryAware
      * @param string $date_format Supports any PHP date format from {@see http://php.net/date}
      * @return int|string|null
      */
-    public function get_gmdate($date_format = 'j F Y, g:i a')
+    public function get_gmdate(string $date_format = 'j F Y, g:i a')
     {
         $date = $this->get_date('U');
         if ($date === null) {
@@ -782,7 +782,7 @@ class Item implements RegistryAware
      * @param string $date_format Supports any PHP date format from {@see http://php.net/date}
      * @return int|string|null
      */
-    public function get_updated_gmdate($date_format = 'j F Y, g:i a')
+    public function get_updated_gmdate(string $date_format = 'j F Y, g:i a')
     {
         $date = $this->get_updated_date('U');
         if ($date === null) {
@@ -823,7 +823,7 @@ class Item implements RegistryAware
      * @param string $rel The relationship of the link to return
      * @return string|null Link URL
      */
-    public function get_link($key = 0, $rel = 'alternate')
+    public function get_link(int $key = 0, string $rel = 'alternate')
     {
         $links = $this->get_links($rel);
         if ($links && $links[$key] !== null) {
@@ -842,7 +842,7 @@ class Item implements RegistryAware
      * @param string $rel The relationship of links to return
      * @return array|null Links found for the item (strings)
      */
-    public function get_links($rel = 'alternate')
+    public function get_links(string $rel = 'alternate')
     {
         if (!isset($this->data['links'])) {
             $this->data['links'] = [];
@@ -905,7 +905,7 @@ class Item implements RegistryAware
      * @param int $key The enclosure that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Enclosure|null
      */
-    public function get_enclosure($key = 0, $prefer = null)
+    public function get_enclosure(int $key = 0, $prefer = null)
     {
         $enclosures = $this->get_enclosures();
         if (isset($enclosures[$key])) {

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1749,7 +1749,7 @@ class Misc
      * @param string $string Data to strip comments from
      * @return string Comment stripped string
      */
-    public static function uncomment_rfc822($string)
+    public static function uncomment_rfc822(string $string)
     {
         $string = (string) $string;
         $position = 0;
@@ -1906,7 +1906,6 @@ class Misc
      */
     public static function codepoint_to_utf8(int $codepoint)
     {
-        $codepoint = (int) $codepoint;
         if ($codepoint < 0) {
             return false;
         } elseif ($codepoint <= 0x7f) {

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -98,7 +98,7 @@ class Misc
      * @param string $string HTML document
      * @return array
      */
-    public static function get_element($realname, $string)
+    public static function get_element(string $realname, string $string)
     {
         // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.3, use "DOMDocument" instead.'), \E_USER_DEPRECATED);
 
@@ -265,7 +265,7 @@ class Misc
      * @param string $string Windows-1252 encoded string
      * @return string UTF-8 encoded string
      */
-    public static function windows_1252_to_utf8($string)
+    public static function windows_1252_to_utf8(string $string)
     {
         static $convert_table = ["\x80" => "\xE2\x82\xAC", "\x81" => "\xEF\xBF\xBD", "\x82" => "\xE2\x80\x9A", "\x83" => "\xC6\x92", "\x84" => "\xE2\x80\x9E", "\x85" => "\xE2\x80\xA6", "\x86" => "\xE2\x80\xA0", "\x87" => "\xE2\x80\xA1", "\x88" => "\xCB\x86", "\x89" => "\xE2\x80\xB0", "\x8A" => "\xC5\xA0", "\x8B" => "\xE2\x80\xB9", "\x8C" => "\xC5\x92", "\x8D" => "\xEF\xBF\xBD", "\x8E" => "\xC5\xBD", "\x8F" => "\xEF\xBF\xBD", "\x90" => "\xEF\xBF\xBD", "\x91" => "\xE2\x80\x98", "\x92" => "\xE2\x80\x99", "\x93" => "\xE2\x80\x9C", "\x94" => "\xE2\x80\x9D", "\x95" => "\xE2\x80\xA2", "\x96" => "\xE2\x80\x93", "\x97" => "\xE2\x80\x94", "\x98" => "\xCB\x9C", "\x99" => "\xE2\x84\xA2", "\x9A" => "\xC5\xA1", "\x9B" => "\xE2\x80\xBA", "\x9C" => "\xC5\x93", "\x9D" => "\xEF\xBF\xBD", "\x9E" => "\xC5\xBE", "\x9F" => "\xC5\xB8", "\xA0" => "\xC2\xA0", "\xA1" => "\xC2\xA1", "\xA2" => "\xC2\xA2", "\xA3" => "\xC2\xA3", "\xA4" => "\xC2\xA4", "\xA5" => "\xC2\xA5", "\xA6" => "\xC2\xA6", "\xA7" => "\xC2\xA7", "\xA8" => "\xC2\xA8", "\xA9" => "\xC2\xA9", "\xAA" => "\xC2\xAA", "\xAB" => "\xC2\xAB", "\xAC" => "\xC2\xAC", "\xAD" => "\xC2\xAD", "\xAE" => "\xC2\xAE", "\xAF" => "\xC2\xAF", "\xB0" => "\xC2\xB0", "\xB1" => "\xC2\xB1", "\xB2" => "\xC2\xB2", "\xB3" => "\xC2\xB3", "\xB4" => "\xC2\xB4", "\xB5" => "\xC2\xB5", "\xB6" => "\xC2\xB6", "\xB7" => "\xC2\xB7", "\xB8" => "\xC2\xB8", "\xB9" => "\xC2\xB9", "\xBA" => "\xC2\xBA", "\xBB" => "\xC2\xBB", "\xBC" => "\xC2\xBC", "\xBD" => "\xC2\xBD", "\xBE" => "\xC2\xBE", "\xBF" => "\xC2\xBF", "\xC0" => "\xC3\x80", "\xC1" => "\xC3\x81", "\xC2" => "\xC3\x82", "\xC3" => "\xC3\x83", "\xC4" => "\xC3\x84", "\xC5" => "\xC3\x85", "\xC6" => "\xC3\x86", "\xC7" => "\xC3\x87", "\xC8" => "\xC3\x88", "\xC9" => "\xC3\x89", "\xCA" => "\xC3\x8A", "\xCB" => "\xC3\x8B", "\xCC" => "\xC3\x8C", "\xCD" => "\xC3\x8D", "\xCE" => "\xC3\x8E", "\xCF" => "\xC3\x8F", "\xD0" => "\xC3\x90", "\xD1" => "\xC3\x91", "\xD2" => "\xC3\x92", "\xD3" => "\xC3\x93", "\xD4" => "\xC3\x94", "\xD5" => "\xC3\x95", "\xD6" => "\xC3\x96", "\xD7" => "\xC3\x97", "\xD8" => "\xC3\x98", "\xD9" => "\xC3\x99", "\xDA" => "\xC3\x9A", "\xDB" => "\xC3\x9B", "\xDC" => "\xC3\x9C", "\xDD" => "\xC3\x9D", "\xDE" => "\xC3\x9E", "\xDF" => "\xC3\x9F", "\xE0" => "\xC3\xA0", "\xE1" => "\xC3\xA1", "\xE2" => "\xC3\xA2", "\xE3" => "\xC3\xA3", "\xE4" => "\xC3\xA4", "\xE5" => "\xC3\xA5", "\xE6" => "\xC3\xA6", "\xE7" => "\xC3\xA7", "\xE8" => "\xC3\xA8", "\xE9" => "\xC3\xA9", "\xEA" => "\xC3\xAA", "\xEB" => "\xC3\xAB", "\xEC" => "\xC3\xAC", "\xED" => "\xC3\xAD", "\xEE" => "\xC3\xAE", "\xEF" => "\xC3\xAF", "\xF0" => "\xC3\xB0", "\xF1" => "\xC3\xB1", "\xF2" => "\xC3\xB2", "\xF3" => "\xC3\xB3", "\xF4" => "\xC3\xB4", "\xF5" => "\xC3\xB5", "\xF6" => "\xC3\xB6", "\xF7" => "\xC3\xB7", "\xF8" => "\xC3\xB8", "\xF9" => "\xC3\xB9", "\xFA" => "\xC3\xBA", "\xFB" => "\xC3\xBB", "\xFC" => "\xC3\xBC", "\xFD" => "\xC3\xBD", "\xFE" => "\xC3\xBE", "\xFF" => "\xC3\xBF"];
 
@@ -280,7 +280,7 @@ class Misc
      * @param string $output Encoding you want
      * @return string|boolean False if we can't convert it
      */
-    public static function change_encoding($data, $input, $output)
+    public static function change_encoding(string $data, string $input, string $output)
     {
         $input = Misc::encoding($input);
         $output = Misc::encoding($output);
@@ -360,7 +360,7 @@ class Misc
      * @param string $output
      * @return string|false
      */
-    protected static function change_encoding_uconverter($data, $input, $output)
+    protected static function change_encoding_uconverter(string $data, string $input, string $output)
     {
         return @\UConverter::transcode($data, $output, $input);
     }
@@ -376,7 +376,7 @@ class Misc
      * @param string $charset Character set to standardise
      * @return string Standardised name
      */
-    public static function encoding($charset)
+    public static function encoding(string $charset)
     {
         // Normalization from UTS #22
         switch (strtolower(preg_replace('/(?:[^a-zA-Z0-9]+|([^0-9])0+)/', '\1', $charset))) {
@@ -1708,7 +1708,7 @@ class Misc
      * @param string $data Data to strip comments from
      * @return string Comment stripped string
      */
-    public static function strip_comments($data)
+    public static function strip_comments(string $data)
     {
         $output = '';
         while (($start = strpos($data, '<!--')) !== false) {
@@ -1735,7 +1735,7 @@ class Misc
      * @param string $data Input data
      * @return string Output data
      */
-    public static function entities_decode($data)
+    public static function entities_decode(string $data)
     {
         // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.3, use "DOMDocument" instead.'), \E_USER_DEPRECATED);
 
@@ -1746,7 +1746,7 @@ class Misc
     /**
      * Remove RFC822 comments
      *
-     * @param string $data Data to strip comments from
+     * @param string $string Data to strip comments from
      * @return string Comment stripped string
      */
     public static function uncomment_rfc822($string)
@@ -1904,7 +1904,7 @@ class Misc
      * @param int $codepoint Unicode codepoint
      * @return string UTF-8 character
      */
-    public static function codepoint_to_utf8($codepoint)
+    public static function codepoint_to_utf8(int $codepoint)
     {
         $codepoint = (int) $codepoint;
         if ($codepoint < 0) {
@@ -1933,7 +1933,7 @@ class Misc
      * @param string $str The input string.
      * @return array
      */
-    public static function parse_str($str)
+    public static function parse_str(string $str)
     {
         $return = [];
         $str = explode('&', $str);
@@ -1958,7 +1958,7 @@ class Misc
      * @param \SimplePie\Registry $registry Class registry
      * @return array Possible encodings
      */
-    public static function xml_encoding($data, $registry)
+    public static function xml_encoding(string $data, \SimplePie\Registry $registry)
     {
         // UTF-32 Big Endian BOM
         if (substr($data, 0, 4) === "\x00\x00\xFE\xFF") {
@@ -2171,7 +2171,7 @@ END;
      * @param string $url the URL to sanitize.
      * @return string the same URL without HTTP credentials.
      */
-    public static function url_remove_credentials($url)
+    public static function url_remove_credentials(string $url)
     {
         return preg_replace('#^(https?://)[^/:@]+:[^/:@]+@#i', '$1', $url);
     }

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1751,7 +1751,6 @@ class Misc
      */
     public static function uncomment_rfc822(string $string)
     {
-        $string = (string) $string;
         $position = 0;
         $length = strlen($string);
         $depth = 0;

--- a/src/Net/IPv6.php
+++ b/src/Net/IPv6.php
@@ -176,7 +176,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return array [0] contains the IPv6 represented part, and [1] the IPv4 represented part
      */
-    private static function split_v6_v4(string $ip)
+    private static function split_v6_v4(string $ip): array
     {
         if (strpos($ip, '.') !== false) {
             $pos = strrpos($ip, ':');

--- a/src/Net/IPv6.php
+++ b/src/Net/IPv6.php
@@ -78,7 +78,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return string The uncompressed IPv6 address
      */
-    public static function uncompress($ip)
+    public static function uncompress(string $ip)
     {
         $c1 = -1;
         $c2 = -1;
@@ -134,7 +134,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return string The compressed IPv6 address
      */
-    public static function compress($ip)
+    public static function compress(string $ip)
     {
         // Prepare the IP to be compressed
         $ip = self::uncompress($ip);
@@ -176,7 +176,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return array [0] contains the IPv6 represented part, and [1] the IPv4 represented part
      */
-    private static function split_v6_v4($ip)
+    private static function split_v6_v4(string $ip)
     {
         if (strpos($ip, '.') !== false) {
             $pos = strrpos($ip, ':');
@@ -196,7 +196,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return bool true if $ip is a valid IPv6 address
      */
-    public static function check_ipv6($ip)
+    public static function check_ipv6(string $ip)
     {
         $ip = self::uncompress($ip);
         [$ipv6, $ipv4] = self::split_v6_v4($ip);
@@ -249,7 +249,7 @@ class IPv6
      * @param string $ip An IPv6 address
      * @return bool true if $ip is a valid IPv6 address
      */
-    public static function checkIPv6($ip)
+    public static function checkIPv6(string $ip)
     {
         return self::check_ipv6($ip);
     }

--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -638,7 +638,7 @@ class Date
      * @param string $date Date to parse
      * @return int Timestamp corresponding to date string, or false on failure
      */
-    public function parse($date)
+    public function parse(string $date)
     {
         foreach ($this->user as $method) {
             if (($returned = call_user_func($method, $date)) !== false) {
@@ -662,7 +662,7 @@ class Date
      * @access public
      * @param callable $callback
      */
-    public function add_callback($callback)
+    public function add_callback(callable $callback)
     {
         if (is_callable($callback)) {
             $this->user[] = $callback;

--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -664,11 +664,7 @@ class Date
      */
     public function add_callback(callable $callback)
     {
-        if (is_callable($callback)) {
-            $this->user[] = $callback;
-        } else {
-            trigger_error('User-supplied function must be a valid callback', E_USER_WARNING);
-        }
+        $this->user[] = $callback;
     }
 
     /**
@@ -750,12 +746,11 @@ PCRE;
      * Remove RFC822 comments
      *
      * @access protected
-     * @param string $data Data to strip comments from
+     * @param string $string Data to strip comments from
      * @return string Comment stripped string
      */
-    public function remove_rfc2822_comments($string)
+    public function remove_rfc2822_comments(string $string)
     {
-        $string = (string) $string;
         $position = 0;
         $length = strlen($string);
         $depth = 0;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -376,7 +376,7 @@ class Parser implements RegistryAware
         return $cache[$string];
     }
 
-    private function parse_hcard($data, $category = false)
+    private function parse_hcard($data, $category = false): string
     {
         $name = '';
         $link = '';
@@ -400,7 +400,10 @@ class Parser implements RegistryAware
         return $data['value'] ?? '';
     }
 
-    private function parse_microformats(&$data, $url)
+    /**
+     * @return true
+     */
+    private function parse_microformats(&$data, $url): bool
     {
         $feed_title = '';
         $feed_author = null;
@@ -621,7 +624,7 @@ class Parser implements RegistryAware
         return true;
     }
 
-    private function declare_html_entities()
+    private function declare_html_entities(): string
     {
         // This is required because the RSS specification says that entity-encoded
         // html is allowed, but the xml specification says they must be declared.

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -148,7 +148,7 @@ class Registry
      * @param bool $legacy Whether to enable legacy support for this class
      * @return bool Successfulness
      */
-    public function register($type, $class, $legacy = false)
+    public function register(string $type, $class, bool $legacy = false)
     {
         if (array_key_exists($type, $this->legacyTypes)) {
             // trigger_error(sprintf('"%s"(): Using argument #1 ($type) with value "%s" is deprecated since SimplePie 1.8.0, use class-string "%s" instead.', __METHOD__, $type, $this->legacyTypes[$type]), \E_USER_DEPRECATED);
@@ -218,7 +218,7 @@ class Registry
      * @param array $parameters Parameters to pass to the constructor
      * @return T Instance of class
      */
-    public function &create($type, $parameters = [])
+    public function &create($type, array $parameters = [])
     {
         $class = $this->get_class($type);
 
@@ -246,7 +246,7 @@ class Registry
      * @param array $parameters
      * @return mixed
      */
-    public function &call($type, $method, $parameters = [])
+    public function &call($type, string $method, array $parameters = [])
     {
         $class = $this->get_class($type);
 

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -637,7 +637,7 @@ class Sanitize implements RegistryAware
      *
      * @return DataCache
      */
-    private function get_cache(string $image_url = '')
+    private function get_cache(string $image_url = ''): DataCache
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -259,7 +259,7 @@ class Sanitize implements RegistryAware
      * @since 1.0
      * @param array|null $element_attribute Element/attribute key/value pairs, null for default
      */
-    public function set_url_replacements($element_attribute = null)
+    public function set_url_replacements(?array $element_attribute = null)
     {
         if ($element_attribute === null) {
             $element_attribute = [
@@ -637,7 +637,7 @@ class Sanitize implements RegistryAware
      *
      * @return DataCache
      */
-    private function get_cache($image_url = '')
+    private function get_cache(string $image_url = '')
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1368,7 +1368,10 @@ class SimplePie
         $this->sanitize->remove_div($enable);
     }
 
-    public function strip_htmltags(string $tags = '', $encode = null)
+    /**
+     * @param string|false $tags Set a list of tags to strip, or set emtpy string to use default tags or false, to strip nothing.
+     */
+    public function strip_htmltags($tags = '', $encode = null)
     {
         if ($tags === '') {
             $tags = $this->strip_htmltags;

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -798,7 +798,7 @@ class SimplePie
      * @param \SimplePie\File &$file
      * @return bool True on success, false on failure
      */
-    public function set_file(&$file)
+    public function set_file(\SimplePie\File &$file)
     {
         if ($file instanceof \SimplePie\File) {
             $this->feed_url = $file->url;
@@ -882,7 +882,7 @@ class SimplePie
     /**
      * Set a PSR-16 implementation as cache
      *
-     * @param CacheInterface $psr16cache The PSR-16 cache implementation
+     * @param CacheInterface $cache The PSR-16 cache implementation
      *
      * @return void
      */
@@ -1459,7 +1459,7 @@ class SimplePie
     /**
      * Set the list of domains for which to force HTTPS.
      * @see \SimplePie\Sanitize::set_https_domains()
-     * @param array List of HTTPS domains. Example array('biz', 'example.com', 'example.org', 'www.example.net').
+     * @param array $domains List of HTTPS domains. Example array('biz', 'example.com', 'example.org', 'www.example.net').
      */
     public function set_https_domains(array $domains = [])
     {
@@ -1474,7 +1474,7 @@ class SimplePie
      * @param string|false $page Web-accessible path to the handler_image.php file.
      * @param string $qs The query string that the value should be passed to.
      */
-    public function set_image_handler($page = false, $qs = 'i')
+    public function set_image_handler($page = false, string $qs = 'i')
     {
         if ($page !== false) {
             $this->sanitize->set_image_handler($page . '?' . $qs . '=');
@@ -3087,7 +3087,7 @@ class SimplePie
      * @param array $args Arguments to the method
      * @return mixed
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         if (strpos($method, 'subscribe_') === 0) {
             trigger_error('subscribe_*() has been deprecated since SimplePie 1.3, implement the callback yourself', \E_USER_DEPRECATED);
@@ -3207,7 +3207,7 @@ class SimplePie
      *
      * @return DataCache
      */
-    private function get_cache($feed_url = ''): DataCache
+    private function get_cache(string $feed_url = ''): DataCache
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -759,9 +759,9 @@ class SimplePie
      * @since 1.1
      * @param bool $enable Force the given data/URL to be treated as a feed
      */
-    public function force_feed($enable = false)
+    public function force_feed(bool $enable = false)
     {
-        $this->force_feed = (bool) $enable;
+        $this->force_feed = $enable;
     }
 
     /**
@@ -822,7 +822,7 @@ class SimplePie
      * @param string $data RSS or Atom data as a string.
      * @see set_feed_url()
      */
-    public function set_raw_data($data)
+    public function set_raw_data(string $data)
     {
         $this->raw_data = $data;
     }
@@ -836,7 +836,7 @@ class SimplePie
      * @since 1.0 Beta 3
      * @param int $timeout The maximum number of seconds to spend waiting to retrieve a feed.
      */
-    public function set_timeout($timeout = 10)
+    public function set_timeout(int $timeout = 10)
     {
         $this->timeout = (int) $timeout;
     }
@@ -860,9 +860,9 @@ class SimplePie
      * @since 1.0 Beta 3
      * @param bool $enable Force fsockopen() to be used
      */
-    public function force_fsockopen($enable = false)
+    public function force_fsockopen(bool $enable = false)
     {
-        $this->force_fsockopen = (bool) $enable;
+        $this->force_fsockopen = $enable;
     }
 
     /**
@@ -874,9 +874,9 @@ class SimplePie
      * @since 1.0 Preview Release
      * @param bool $enable Enable caching
      */
-    public function enable_cache($enable = true)
+    public function enable_cache(bool $enable = true)
     {
-        $this->enable_cache = (bool) $enable;
+        $this->enable_cache = $enable;
     }
 
     /**
@@ -903,10 +903,10 @@ class SimplePie
      *
      * @param bool $enable Force use of cache on fail.
      */
-    public function force_cache_fallback($enable = false)
+    public function force_cache_fallback(bool $enable = false)
     {
         // @trigger_error(sprintf('SimplePie\SimplePie::force_cache_fallback() is deprecated since SimplePie 1.8.0, expired cache will not be used anymore.'), \E_USER_DEPRECATED);
-        $this->force_cache_fallback = (bool) $enable;
+        $this->force_cache_fallback = $enable;
     }
 
     /**
@@ -915,9 +915,9 @@ class SimplePie
      *
      * @param int $seconds The feed content cache duration
      */
-    public function set_cache_duration($seconds = 3600)
+    public function set_cache_duration(int $seconds = 3600)
     {
-        $this->cache_duration = (int) $seconds;
+        $this->cache_duration = $seconds;
     }
 
     /**
@@ -926,9 +926,9 @@ class SimplePie
      *
      * @param int $seconds The autodiscovered feed URL cache duration.
      */
-    public function set_autodiscovery_cache_duration($seconds = 604800)
+    public function set_autodiscovery_cache_duration(int $seconds = 604800)
     {
-        $this->autodiscovery_cache_duration = (int) $seconds;
+        $this->autodiscovery_cache_duration = $seconds;
     }
 
     /**
@@ -938,10 +938,10 @@ class SimplePie
      *
      * @param string $location The file system location.
      */
-    public function set_cache_location($location = './cache')
+    public function set_cache_location(string $location = './cache')
     {
         // @trigger_error(sprintf('SimplePie\SimplePie::set_cache_location() is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()" instead.'), \E_USER_DEPRECATED);
-        $this->cache_location = (string) $location;
+        $this->cache_location = $location;
     }
 
     /**
@@ -950,7 +950,7 @@ class SimplePie
      * @param string $url The URL of the feed to be cached.
      * @return string A filename (i.e. hash, without path and without extension).
      */
-    public function get_cache_filename($url)
+    public function get_cache_filename(string $url)
     {
         // Append custom parameters to the URL to avoid cache pollution in case of multiple calls with different parameters.
         $url .= $this->force_feed ? '#force_feed' : '';
@@ -979,9 +979,9 @@ class SimplePie
      *
      * @param bool $enable Sort as reverse chronological order.
      */
-    public function enable_order_by_date($enable = true)
+    public function enable_order_by_date(bool $enable = true)
     {
-        $this->order_by_date = (bool) $enable;
+        $this->order_by_date = $enable;
     }
 
     /**
@@ -990,7 +990,7 @@ class SimplePie
      * This overrides the encoding reported by the feed, however it will fall
      * back to the normal encoding detection if the override fails
      *
-     * @param string $encoding Character encoding
+     * @param string|false $encoding Character encoding
      */
     public function set_input_encoding($encoding = false)
     {
@@ -1011,11 +1011,11 @@ class SimplePie
      * @see \SimplePie\SimplePie::LOCATOR_REMOTE_EXTENSION
      * @see \SimplePie\SimplePie::LOCATOR_REMOTE_BODY
      * @see \SimplePie\SimplePie::LOCATOR_ALL
-     * @param int $level Feed Autodiscovery Level (level can be a combination of the above constants, see bitwise OR operator)
+     * @param self::LOCATOR_* $level Feed Autodiscovery Level (level can be a combination of the above constants, see bitwise OR operator)
      */
-    public function set_autodiscovery_level($level = self::LOCATOR_ALL)
+    public function set_autodiscovery_level(int $level = self::LOCATOR_ALL)
     {
-        $this->autodiscovery = (int) $level;
+        $this->autodiscovery = $level;
     }
 
     /**
@@ -1040,9 +1040,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_cache_class($class = Cache::class)
+    public function set_cache_class(string $class = Cache::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Cache::class, $class, true);
     }
@@ -1056,9 +1056,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_locator_class($class = Locator::class)
+    public function set_locator_class(string $class = Locator::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Locator::class, $class, true);
     }
@@ -1072,9 +1072,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_parser_class($class = Parser::class)
+    public function set_parser_class(string $class = Parser::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Parser::class, $class, true);
     }
@@ -1088,9 +1088,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_file_class($class = File::class)
+    public function set_file_class(string $class = File::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(File::class, $class, true);
     }
@@ -1104,9 +1104,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_sanitize_class($class = Sanitize::class)
+    public function set_sanitize_class(string $class = Sanitize::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Sanitize::class, $class, true);
     }
@@ -1120,9 +1120,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_item_class($class = Item::class)
+    public function set_item_class(string $class = Item::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Item::class, $class, true);
     }
@@ -1136,9 +1136,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_author_class($class = Author::class)
+    public function set_author_class(string $class = Author::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Author::class, $class, true);
     }
@@ -1152,9 +1152,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_category_class($class = Category::class)
+    public function set_category_class(string $class = Category::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Category::class, $class, true);
     }
@@ -1168,9 +1168,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_enclosure_class($class = Enclosure::class)
+    public function set_enclosure_class(string $class = Enclosure::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Enclosure::class, $class, true);
     }
@@ -1184,9 +1184,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_caption_class($class = Caption::class)
+    public function set_caption_class(string $class = Caption::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Caption::class, $class, true);
     }
@@ -1200,9 +1200,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_copyright_class($class = Copyright::class)
+    public function set_copyright_class(string $class = Copyright::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Copyright::class, $class, true);
     }
@@ -1216,9 +1216,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_credit_class($class = Credit::class)
+    public function set_credit_class(string $class = Credit::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Credit::class, $class, true);
     }
@@ -1232,9 +1232,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_rating_class($class = Rating::class)
+    public function set_rating_class(string $class = Rating::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Rating::class, $class, true);
     }
@@ -1248,9 +1248,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_restriction_class($class = Restriction::class)
+    public function set_restriction_class(string $class = Restriction::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Restriction::class, $class, true);
     }
@@ -1264,9 +1264,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_content_type_sniffer_class($class = Sniffer::class)
+    public function set_content_type_sniffer_class(string $class = Sniffer::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Sniffer::class, $class, true);
     }
@@ -1280,9 +1280,9 @@ class SimplePie
      *
      * @return boolean True on success, false otherwise
      */
-    public function set_source_class($class = Source::class)
+    public function set_source_class(string $class = Source::class)
     {
-        // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
+        trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::get_registry()" instead.', __METHOD__), \E_USER_DEPRECATED);
 
         return $this->registry->register(Source::class, $class, true);
     }
@@ -1292,7 +1292,7 @@ class SimplePie
      *
      * @param string $ua New user agent string.
      */
-    public function set_useragent($ua = null)
+    public function set_useragent(?string $ua = null)
     {
         if ($ua === null) {
             $ua = \SimplePie\Misc::get_default_useragent();
@@ -1339,7 +1339,7 @@ class SimplePie
      *
      * @param bool $set Whether to set them or not
      */
-    public function set_stupidly_fast($set = false)
+    public function set_stupidly_fast(bool $set = false)
     {
         if ($set) {
             $this->enable_order_by_date(false);
@@ -1358,9 +1358,9 @@ class SimplePie
      *
      * @param int $max Maximum number of feeds to check
      */
-    public function set_max_checked_feeds($max = 10)
+    public function set_max_checked_feeds(int $max = 10)
     {
-        $this->max_checked_feeds = (int) $max;
+        $this->max_checked_feeds = $max;
     }
 
     public function remove_div($enable = true)
@@ -1368,7 +1368,7 @@ class SimplePie
         $this->sanitize->remove_div($enable);
     }
 
-    public function strip_htmltags($tags = '', $encode = null)
+    public function strip_htmltags(string $tags = '', $encode = null)
     {
         if ($tags === '') {
             $tags = $this->strip_htmltags;
@@ -1430,7 +1430,7 @@ class SimplePie
      *
      * @param string $encoding
      */
-    public function set_output_encoding($encoding = 'UTF-8')
+    public function set_output_encoding(string $encoding = 'UTF-8')
     {
         $this->sanitize->set_output_encoding($encoding);
     }
@@ -1451,7 +1451,7 @@ class SimplePie
      * @since 1.0
      * @param array|null $element_attribute Element/attribute key/value pairs, null for default
      */
-    public function set_url_replacements($element_attribute = null)
+    public function set_url_replacements(?array $element_attribute = null)
     {
         $this->sanitize->set_url_replacements($element_attribute);
     }
@@ -1461,7 +1461,7 @@ class SimplePie
      * @see \SimplePie\Sanitize::set_https_domains()
      * @param array List of HTTPS domains. Example array('biz', 'example.com', 'example.org', 'www.example.net').
      */
-    public function set_https_domains($domains = [])
+    public function set_https_domains(array $domains = [])
     {
         if (is_array($domains)) {
             $this->sanitize->set_https_domains($domains);
@@ -1471,7 +1471,7 @@ class SimplePie
     /**
      * Set the handler to enable the display of cached images.
      *
-     * @param string $page Web-accessible path to the handler_image.php file.
+     * @param string|false $page Web-accessible path to the handler_image.php file.
      * @param string $qs The query string that the value should be passed to.
      */
     public function set_image_handler($page = false, $qs = 'i')
@@ -1486,11 +1486,11 @@ class SimplePie
     /**
      * Set the limit for items returned per-feed with multifeeds
      *
-     * @param integer $limit The maximum number of items to return.
+     * @param int $limit The maximum number of items to return.
      */
-    public function set_item_limit($limit = 0)
+    public function set_item_limit(int $limit = 0)
     {
-        $this->item_limit = (int) $limit;
+        $this->item_limit = $limit;
     }
 
     /**
@@ -1498,7 +1498,7 @@ class SimplePie
      *
      * @param boolean $enable Should we throw exceptions, or use the old-style error property?
      */
-    public function enable_exceptions($enable = true)
+    public function enable_exceptions(bool $enable = true)
     {
         $this->enable_exceptions = $enable;
     }
@@ -1973,7 +1973,7 @@ class SimplePie
      *
      * @param string $mime MIME type to serve the page as
      */
-    public function handle_content_type($mime = 'text/html')
+    public function handle_content_type(string $mime = 'text/html')
     {
         if (!headers_sent()) {
             $header = "Content-type: $mime;";
@@ -2095,7 +2095,7 @@ class SimplePie
      * iff it is a 301 redirection
      * @return string|null
      */
-    public function subscribe_url($permanent = false)
+    public function subscribe_url(bool $permanent = false)
     {
         if ($permanent) {
             if ($this->permanent_url !== null) {
@@ -2155,7 +2155,7 @@ class SimplePie
      * @param string $tag Tag name
      * @return array
      */
-    public function get_feed_tags($namespace, $tag)
+    public function get_feed_tags(string $namespace, string $tag)
     {
         $type = $this->get_type();
         if ($type & self::TYPE_ATOM_10) {
@@ -2195,7 +2195,7 @@ class SimplePie
      * @param string $tag Tag name
      * @return array
      */
-    public function get_channel_tags($namespace, $tag)
+    public function get_channel_tags(string $namespace, string $tag)
     {
         $type = $this->get_type();
         if ($type & self::TYPE_ATOM_ALL) {
@@ -2241,7 +2241,7 @@ class SimplePie
      * @param string $tag Tag name
      * @return array
      */
-    public function get_image_tags($namespace, $tag)
+    public function get_image_tags(string $namespace, string $tag)
     {
         $type = $this->get_type();
         if ($type & self::TYPE_RSS_10) {
@@ -2280,7 +2280,7 @@ class SimplePie
      * @param array $element
      * @return string
      */
-    public function get_base($element = [])
+    public function get_base(array $element = [])
     {
         if (!empty($element['xml_base_explicit']) && isset($element['xml_base'])) {
             return $element['xml_base'];
@@ -2301,7 +2301,7 @@ class SimplePie
      * @param string $base Base URL to resolve URLs against
      * @return string Sanitized data
      */
-    public function sanitize($data, $type, $base = '')
+    public function sanitize(string $data, int $type, ?string $base = '')
     {
         try {
             return $this->sanitize->sanitize($data, $type, $base);
@@ -2352,7 +2352,7 @@ class SimplePie
      * @param int $key The category that you want to return. Remember that arrays begin with 0, not 1
      * @return \SimplePie\Category|null
      */
-    public function get_category($key = 0)
+    public function get_category(int $key = 0)
     {
         $categories = $this->get_categories();
         if (isset($categories[$key])) {
@@ -2421,7 +2421,7 @@ class SimplePie
      * @param int $key The author that you want to return. Remember that arrays begin with 0, not 1
      * @return \SimplePie\Author|null
      */
-    public function get_author($key = 0)
+    public function get_author(int $key = 0)
     {
         $authors = $this->get_authors();
         if (isset($authors[$key])) {
@@ -2500,7 +2500,7 @@ class SimplePie
      * @param int $key The contrbutor that you want to return. Remember that arrays begin with 0, not 1
      * @return \SimplePie\Author|null
      */
-    public function get_contributor($key = 0)
+    public function get_contributor(int $key = 0)
     {
         $contributors = $this->get_contributors();
         if (isset($contributors[$key])) {
@@ -2571,7 +2571,7 @@ class SimplePie
      * @param string $rel The relationship of the link to return
      * @return string|null Link URL
      */
-    public function get_link($key = 0, $rel = 'alternate')
+    public function get_link(int $key = 0, string $rel = 'alternate')
     {
         $links = $this->get_links($rel);
         if (isset($links[$key])) {
@@ -2606,7 +2606,7 @@ class SimplePie
      * @param string $rel The relationship of links to return
      * @return array|null Links found for the feed (strings)
      */
-    public function get_links($rel = 'alternate')
+    public function get_links(string $rel = 'alternate')
     {
         if (!isset($this->data['links'])) {
             $this->data['links'] = [];
@@ -2944,15 +2944,14 @@ class SimplePie
      * @param int $max Maximum value to return. 0 for no limit
      * @return int Number of items in the feed
      */
-    public function get_item_quantity($max = 0)
+    public function get_item_quantity(int $max = 0)
     {
-        $max = (int) $max;
         $qty = count($this->get_items());
         if ($max === 0) {
             return $qty;
         }
 
-        return ($qty > $max) ? $max : $qty;
+        return min($qty, $max);
     }
 
     /**
@@ -2967,7 +2966,7 @@ class SimplePie
      * @param int $key The item that you want to return. Remember that arrays begin with 0, not 1
      * @return \SimplePie\Item|null
      */
-    public function get_item($key = 0)
+    public function get_item(int $key = 0)
     {
         $items = $this->get_items();
         if (isset($items[$key])) {
@@ -2990,7 +2989,7 @@ class SimplePie
      * @param int $end Number of items to return. 0 for all items after `$start`
      * @return \SimplePie\Item[]|null List of {@see \SimplePie\Item} objects
      */
-    public function get_items($start = 0, $end = 0)
+    public function get_items(int $start = 0, int $end = 0)
     {
         if (!isset($this->data['items'])) {
             if (!empty($this->multifeed_objects)) {
@@ -3061,7 +3060,7 @@ class SimplePie
      */
     public function set_favicon_handler($page = false, $qs = 'i')
     {
-        trigger_error('Favicon handling has been removed, please use your own handling', \E_USER_DEPRECATED);
+        trigger_error('Favicon handling has been removed since SimplePie 1.3, please use your own handling', \E_USER_DEPRECATED);
         return false;
     }
 
@@ -3072,7 +3071,7 @@ class SimplePie
      */
     public function get_favicon()
     {
-        trigger_error('Favicon handling has been removed, please use your own handling', \E_USER_DEPRECATED);
+        trigger_error('Favicon handling has been removed since SimplePie 1.3, please use your own handling', \E_USER_DEPRECATED);
 
         if (($url = $this->get_link()) !== null) {
             return 'https://www.google.com/s2/favicons?domain=' . urlencode($url);
@@ -3091,11 +3090,11 @@ class SimplePie
     public function __call($method, $args)
     {
         if (strpos($method, 'subscribe_') === 0) {
-            trigger_error('subscribe_*() has been deprecated, implement the callback yourself', \E_USER_DEPRECATED);
+            trigger_error('subscribe_*() has been deprecated since SimplePie 1.3, implement the callback yourself', \E_USER_DEPRECATED);
             return '';
         }
         if ($method === 'enable_xml_dump') {
-            trigger_error('enable_xml_dump() has been deprecated, use get_raw_data() instead', \E_USER_DEPRECATED);
+            trigger_error('enable_xml_dump() has been deprecated since SimplePie 1.3, use get_raw_data() instead', \E_USER_DEPRECATED);
             return false;
         }
 
@@ -3110,11 +3109,11 @@ class SimplePie
      * Sorting callback for items
      *
      * @access private
-     * @param SimplePie $a
-     * @param SimplePie $b
+     * @param Item $a
+     * @param Item $b
      * @return boolean
      */
-    public static function sort_items($a, $b)
+    public static function sort_items(Item $a, Item $b)
     {
         $a_date = $a->get_date('U');
         $b_date = $b->get_date('U');
@@ -3144,7 +3143,7 @@ class SimplePie
      * @param int $limit Maximum number of items per feed
      * @return array
      */
-    public static function merge_items($urls, $start = 0, $end = 0, $limit = 0)
+    public static function merge_items(array $urls, int $start = 0, int $end = 0, int $limit = 0)
     {
         if (is_array($urls) && sizeof($urls) > 0) {
             $items = [];
@@ -3178,7 +3177,7 @@ class SimplePie
      * @param string $hub
      * @param string $self
      */
-    private function store_links(&$file, $hub, $self)
+    private function store_links(File &$file, string $hub, string $self): void
     {
         if (isset($file->headers['link']['hub']) ||
               (isset($file->headers['link']) &&
@@ -3208,7 +3207,7 @@ class SimplePie
      *
      * @return DataCache
      */
-    private function get_cache($feed_url = '')
+    private function get_cache($feed_url = ''): DataCache
     {
         if ($this->cache === null) {
             // @trigger_error(sprintf('Not providing as PSR-16 cache implementation is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache()".'), \E_USER_DEPRECATED);

--- a/src/XML/Declaration/Parser.php
+++ b/src/XML/Declaration/Parser.php
@@ -139,7 +139,7 @@ class Parser
      * @access public
      * @param string $data Input data
      */
-    public function __construct($data)
+    public function __construct(string $data)
     {
         $this->data = $data;
         $this->data_length = strlen($this->data);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -95,6 +95,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
         }
 
         $feed = new SimplePie();
+        $this->expectDeprecation();
         $feed->set_cache_class('Mock_CacheLegacy');
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');

--- a/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
+++ b/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
@@ -122,7 +122,7 @@ class BaseCacheWithCallbacksMock implements Base
      * @param string $name Unique ID for the cache
      * @param Base::TYPE_FEED|Base::TYPE_IMAGE $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
      */
-    public function __construct($location, $name, $type)
+    public function __construct(string $location, string $name, $type)
     {
         if (static::$constructCallback !== null) {
             $callback = static::$constructCallback;

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -52,7 +52,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
      *
      * @param string $template
      */
-    protected function checkFromTemplate($template, $data)
+    protected function checkFromTemplate(string $template, $data)
     {
         if (!is_array($data)) {
             $data = [$data];

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -75,7 +75,7 @@ class SimplePieTest extends TestCase
      *
      * @param string $template
      */
-    private function createFeedWithTemplate(string $template, $data)
+    private function createFeedWithTemplate(string $template, $data): SimplePie
     {
         if (!is_array($data)) {
             $data = [$data];

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -75,7 +75,7 @@ class SimplePieTest extends TestCase
      *
      * @param string $template
      */
-    private function createFeedWithTemplate($template, $data)
+    private function createFeedWithTemplate(string $template, $data)
     {
         if (!is_array($data)) {
             $data = [$data];

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -263,6 +263,7 @@ class SimplePieTest extends TestCase
     public function testLegacyCallOfSetCacheClass()
     {
         $feed = new SimplePie();
+        $this->expectDeprecation();
         $feed->set_cache_class(LegacyCacheMock::class);
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');


### PR DESCRIPTION
This PR adds type hints to all methods in the `SimplePie` class where the arguments are documented. Thanks to type widening in PHP 7.2 this is not a breaking change.

There are also many methods where the parameters are not documented. This places should be be documented, but for BC they should trigger a deprecation warning, if a parameter has to be casted. The type declaration could be added in SimplePie 2.0.0 with a breaking change.

This will fix #773.