### PR TITLE
Update to github actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP with latest composer
         uses: shivammathur/setup-php@v2
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install PHP
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
[Starting Summer 2023 all Github actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). We are currently using `actions/checkout@v2`, for which there is an update available. This PR updates to Version 3, so we can get rid of the [warnings under the jobs](https://github.com/simplepie/simplepie/actions/runs/4025417866).

**Changelog** for actions/checkout@v3: https://github.com/actions/checkout/blob/main/CHANGELOG.md

> ## v3.0.0
> Update to node 16 [actions/checkout#689](https://github.com/actions/checkout/pull/689)
