### PR TITLE
Locator: add type hints

### DIFF
--- a/src/Locator.php
+++ b/src/Locator.php
@@ -65,6 +65,7 @@ class Locator implements RegistryAware
     public $max_checked_feeds = 10;
     public $force_fsockopen = false;
     public $curl_options = [];
+    /** @var ?\DomDocument */
     public $dom;
     protected $registry;
 
@@ -288,6 +289,7 @@ class Locator implements RegistryAware
         $xpath = new \DOMXpath($this->dom);
         $query = '//a[@rel and @href] | //link[@rel and @href]';
         foreach ($xpath->query($query) as $link) {
+            /** @var \DOMElement $link */
             $href = trim($link->getAttribute('href'));
             $parsed = $this->registry->call(Misc::class, 'parse_url', [$href]);
             if ($parsed['scheme'] === '' ||


### PR DESCRIPTION
Needed for PHPStan level 2 to pass.

`DOMXpath::query` returns `DOMNodeList<DOMNode>` but here the XPath query looks for a or link elements so we can be more specific.
