### PR TITLE
SimplePie: Deprecate multifeed support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/simplepie/simplepie/compare/1.8.0...master)
 
+### Deprecated
+
+- Passing multiple URLs to `SimplePie\SimplePie::set_feed_url()` is deprecated. You can create separate `SimplePie` instance per feed and then use `SimplePie::merge_items()` to get a single list of items. ([#795](https://github.com/simplepie/simplepie/pull/795))
+
 ## [1.8.0](https://github.com/simplepie/simplepie/compare/1.7.0...1.8.0) - 2023-01-20
 
 ### Added

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -772,18 +772,19 @@ class SimplePie
      * website you want to try to use auto-discovery on. This takes priority
      * over any set raw data.
      *
-     * You can set multiple feeds to mash together by passing an array instead
+     * Deprecated since 1.9.0: You can set multiple feeds to mash together by passing an array instead
      * of a string for the $url. Remember that with each additional feed comes
      * additional processing and resources.
      *
      * @since 1.0 Preview Release
      * @see set_raw_data()
-     * @param string|array $url This is the URL (or array of URLs) that you want to parse.
+     * @param string|array $url This is the URL (or (deprecated) array of URLs) that you want to parse.
      */
     public function set_feed_url($url)
     {
         $this->multifeed_url = [];
         if (is_array($url)) {
+            trigger_error('Fetching multiple feeds with single SimplePie instance is deprecated since SimplePie 1.9.0, create one SimplePie instance per feed and use SimplePie::merge_items to get a single list of items.', \E_USER_DEPRECATED);
             foreach ($url as $value) {
                 $this->multifeed_url[] = $this->registry->call(Misc::class, 'fix_protocol', [$value, 1]);
             }


### PR DESCRIPTION
Multifeed support makes error handling confusing (sometimes `SimplePie::get_error()` returns string and other times an array).
And that will only get worse once we start throwing exceptions.

Additionally, it is ugly on conceptual level (single responsibility principle).
