### PR TITLE
tests/CacheTest: Use existing SuccessException fixture

### DIFF
--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -44,15 +44,9 @@ declare(strict_types=1);
 
 use SimplePie\Cache;
 use SimplePie\File;
+use SimplePie\Tests\Fixtures\Exception\SuccessException;
 use SimplePie\Tests\Fixtures\FileMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
-
-/**
- * This is a dirty, dirty hack
- */
-class Exception_Success extends Exception
-{
-}
 
 class Mock_CacheLegacy extends SimplePie_Cache
 {
@@ -62,7 +56,7 @@ class Mock_CacheLegacy extends SimplePie_Cache
     }
     public function create($location, $filename, $extension)
     {
-        throw new Exception_Success('Correct function called');
+        throw new SuccessException('Correct function called');
     }
 }
 
@@ -70,7 +64,7 @@ class Mock_CacheNew extends SimplePie_Cache
 {
     public static function get_handler($location, $filename, $extension)
     {
-        throw new Exception_Success('Correct function called');
+        throw new SuccessException('Correct function called');
     }
     public function create($location, $filename, $extension)
     {
@@ -85,7 +79,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
     public function testDirectOverrideLegacy()
     {
         if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectException('Exception_Success');
+            $this->expectException(SuccessException::class);
         } else {
             // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
             // This is no longer supported in PHP, so there is just no way to continue to provide BC
@@ -104,7 +98,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
 
     public function testDirectOverrideNew()
     {
-        $this->expectException('Exception_Success');
+        $this->expectException(SuccessException::class);
 
         $feed = new SimplePie();
         $feed->get_registry()->register(Cache::class, 'Mock_CacheNew');


### PR DESCRIPTION
Having multiple classes in a single file goes against PSR-1 and we already have SuccessException defined separately.
