### PR TITLE
Use more ::class constant instead of class-strings

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -65,10 +65,10 @@ class Cache
      * @var array
      */
     protected static $handlers = [
-        'mysql'     => 'SimplePie\Cache\MySQL',
-        'memcache'  => 'SimplePie\Cache\Memcache',
-        'memcached' => 'SimplePie\Cache\Memcached',
-        'redis'     => 'SimplePie\Cache\Redis'
+        'mysql'     => Cache\MySQL::class,
+        'memcache'  => Cache\Memcache::class,
+        'memcached' => Cache\Memcached::class,
+        'redis'     => Cache\Redis::class,
     ];
 
     /**

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -80,7 +80,7 @@ class Locator implements RegistryAware
         if (class_exists('DOMDocument') && $this->file->body != '') {
             $this->dom = new \DOMDocument();
 
-            set_error_handler(['SimplePie\Misc', 'silence_errors']);
+            set_error_handler([Misc::class, 'silence_errors']);
             try {
                 $this->dom->loadHTML($this->file->body);
             } catch (\Throwable $ex) {

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -131,7 +131,7 @@ class Sanitize implements RegistryAware
         $this->registry = $registry;
     }
 
-    public function pass_cache_data($enable_cache = true, $cache_location = './cache', $cache_name_function = 'md5', $cache_class = 'SimplePie\Cache', DataCache $cache = null)
+    public function pass_cache_data($enable_cache = true, $cache_location = './cache', $cache_name_function = 'md5', $cache_class = Cache::class, DataCache $cache = null)
     {
         if (isset($enable_cache)) {
             $this->enable_cache = (bool) $enable_cache;
@@ -164,7 +164,7 @@ class Sanitize implements RegistryAware
         }
     }
 
-    public function pass_file_data($file_class = 'SimplePie\File', $timeout = 10, $useragent = '', $force_fsockopen = false)
+    public function pass_file_data($file_class = File::class, $timeout = 10, $useragent = '', $force_fsockopen = false)
     {
         if ($timeout) {
             $this->timeout = (string) $timeout;
@@ -363,7 +363,7 @@ class Sanitize implements RegistryAware
 
                 $data = $this->preprocess($data, $type);
 
-                set_error_handler(['SimplePie\Misc', 'silence_errors']);
+                set_error_handler([Misc::class, 'silence_errors']);
                 $document->loadHTML($data);
                 restore_error_handler();
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1539,7 +1539,7 @@ class SimplePie
 
         // The default sanitize class gets set in the constructor, check if it has
         // changed.
-        if ($this->registry->get_class(Sanitize::class) !== 'SimplePie\Sanitize') {
+        if ($this->registry->get_class(Sanitize::class) !== Sanitize::class) {
             $this->sanitize = $this->registry->create(Sanitize::class);
         }
         if (method_exists($this->sanitize, 'set_registry')) {

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -95,7 +95,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
 
         $feed = new SimplePie();
         $this->expectDeprecation();
-        $feed->set_cache_class('Mock_CacheLegacy');
+        $feed->set_cache_class(Mock_CacheLegacy::class);
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
@@ -107,7 +107,7 @@ class CacheTest extends PHPUnit\Framework\TestCase
         $this->expectException('Exception_Success');
 
         $feed = new SimplePie();
-        $feed->get_registry()->register(Cache::class, 'Mock_CacheNew');
+        $feed->get_registry()->register(Cache::class, Mock_CacheNew::class);
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 

--- a/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
+++ b/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
@@ -10,6 +10,6 @@ class MiscWithPublicStaticMethodsMock extends Misc
 {
     public static function __callStatic($name, $args)
     {
-        return call_user_func_array(['SimplePie\Misc', $name], $args);
+        return call_user_func_array([Misc::class, $name], $args);
     }
 }

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -111,7 +111,7 @@ class LocatorTest extends PHPUnit\Framework\TestCase
 
     public function testFailDiscoveryNoDOM()
     {
-        $this->expectException('SimplePie_Exception');
+        $this->expectException(\SimplePie\Exception::class);
 
         $data = new FileMock('http://example.com/feed.xml');
         $data->headers['content-type'] = 'text/html';

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
+use SimplePie\File;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
 
 class SubscribeUrlTest extends PHPUnit\Framework\TestCase
@@ -49,7 +50,7 @@ class SubscribeUrlTest extends PHPUnit\Framework\TestCase
     public function testDirectOverrideLegacy()
     {
         $feed = new SimplePie();
-        $feed->get_registry()->register('File', FileWithRedirectMock::class);
+        $feed->get_registry()->register(File::class, FileWithRedirectMock::class);
         $feed->enable_cache(false);
         $feed->set_feed_url('http://example.com/feed/');
 

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -90,7 +90,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
@@ -105,7 +105,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
@@ -127,7 +127,7 @@ class LocatorTest extends TestCase
 
     public function testFailDiscoveryNoDOM()
     {
-        $this->expectException('SimplePie_Exception');
+        $this->expectException(\SimplePie\Exception::class);
 
         $data = new FileMock('http://example.com/feed.xml');
         $data->headers['content-type'] = 'text/html';
@@ -170,7 +170,7 @@ class LocatorTest extends TestCase
         $locator = new Locator($data, 0, null, false);
 
         $registry = new Registry();
-        $registry->register(File::class, 'SimplePie\Tests\Fixtures\FileMock');
+        $registry->register(File::class, FileMock::class);
         $locator->set_registry($registry);
 
         $expected = [];
@@ -184,7 +184,7 @@ class LocatorTest extends TestCase
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
         $this->assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
-        $this->assertInstanceOf('SimplePie\Tests\Fixtures\FileMock', $feed);
+        $this->assertInstanceOf(FileMock::class, $feed);
         $success = array_filter($expected, [get_class(), 'filter_success']);
 
         $found = array_map([get_class(), 'map_url_file'], $all);

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -51,6 +51,7 @@ use SimplePie\File;
 use SimplePie\SimplePie;
 use SimplePie\Tests\Fixtures\Cache\LegacyCacheMock;
 use SimplePie\Tests\Fixtures\Cache\NewCacheMock;
+use SimplePie\Tests\Fixtures\Exception\SuccessException;
 use SimplePie\Tests\Fixtures\FileMock;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
@@ -268,7 +269,7 @@ class SimplePieTest extends TestCase
         $feed->set_feed_url('http://example.com/feed/');
 
         if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectException('SimplePie\Tests\Fixtures\Exception\SuccessException');
+            $this->expectException(SuccessException::class);
         } else {
             // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
             // This is no longer supported in PHP, so there is just no way to continue to provide BC
@@ -281,7 +282,7 @@ class SimplePieTest extends TestCase
 
     public function testDirectOverrideNew()
     {
-        $this->expectException('SimplePie\Tests\Fixtures\Exception\SuccessException');
+        $this->expectException(SuccessException::class);
 
         $feed = new SimplePie();
         $feed->get_registry()->register(Cache::class, NewCacheMock::class);


### PR DESCRIPTION
This makes it easier for tools to verify that a mentioned class exists.
