### PR TITLE
Cache/Psr16: work around invalid @throws annotation on PHP 7

### DIFF
--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -9,6 +9,7 @@ namespace SimplePie\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
+use Throwable;
 
 /**
  * Caches data into a PSR-16 cache implementation
@@ -47,7 +48,7 @@ final class Psr16 implements DataCache
      *
      * @return array|mixed The value of the item from the cache, or $default in case of cache miss.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException&Throwable
      *   MUST be thrown if the $key string is not a legal value.
      */
     public function get_data(string $key, $default = null)
@@ -77,7 +78,7 @@ final class Psr16 implements DataCache
      *
      * @return bool True on success and false on failure.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException&Throwable
      *   MUST be thrown if the $key string is not a legal value.
      */
     public function set_data(string $key, array $value, ?int $ttl = null): bool
@@ -97,7 +98,7 @@ final class Psr16 implements DataCache
      *
      * @return bool True if the item was successfully removed. False if there was an error.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException&Throwable
      *   MUST be thrown if the $key string is not a legal value.
      */
     public function delete_data(string $key): bool


### PR DESCRIPTION
Because we support `psr/simple-cache` 1.0, which gets installed on PHP 7, and `Psr\SimpleCache\InvalidArgumentException` interface does not extend `Throwable` in that version, PHPStan would complain:

    PHPDoc tag @throws with type Psr\SimpleCache\InvalidArgumentException is not subtype of Throwable

Let’s declare we actually throw a `Throwable` using an intersection type.

