### PR TITLE
Sanitize: Support passing curl_options

### DIFF
--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -49,6 +49,12 @@ class Sanitize implements RegistryAware
     public $useragent = '';
     public $force_fsockopen = false;
     public $replace_url_attributes = null;
+    /**
+     * @var array<mixed> Custom curl options
+     * @see SimplePie::set_curl_options()
+     */
+    private $curl_options = [];
+
     public $registry;
 
     /**
@@ -127,7 +133,7 @@ class Sanitize implements RegistryAware
         }
     }
 
-    public function pass_file_data($file_class = File::class, $timeout = 10, $useragent = '', $force_fsockopen = false)
+    public function pass_file_data($file_class = File::class, $timeout = 10, $useragent = '', $force_fsockopen = false, array $curl_options = [])
     {
         if ($timeout) {
             $this->timeout = (string) $timeout;
@@ -140,6 +146,8 @@ class Sanitize implements RegistryAware
         if ($force_fsockopen) {
             $this->force_fsockopen = (string) $force_fsockopen;
         }
+
+        $this->curl_options = $curl_options;
     }
 
     public function strip_htmltags($tags = ['base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style'])
@@ -386,7 +394,7 @@ class Sanitize implements RegistryAware
                             if ($cache->get_data($image_url, false)) {
                                 $img->setAttribute('src', $this->image_handler . $image_url);
                             } else {
-                                $file = $this->registry->create(File::class, [$img->getAttribute('src'), $this->timeout, 5, ['X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']], $this->useragent, $this->force_fsockopen]);
+                                $file = $this->registry->create(File::class, [$img->getAttribute('src'), $this->timeout, 5, ['X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']], $this->useragent, $this->force_fsockopen, $this->curl_options]);
                                 $headers = $file->headers;
 
                                 if ($file->success && ($file->method & \SimplePie\SimplePie::FILE_SOURCE_REMOTE === 0 || ($file->status_code === 200 || $file->status_code > 206 && $file->status_code < 300))) {


### PR DESCRIPTION
As pointed out by PHPStan, it did not expect them:

    Method SimplePie\Sanitize::pass_file_data() invoked with 5 parameters, 0-4 required

This has been broken since the support for passing curl options was introduced in https://github.com/simplepie/simplepie/commit/51f9f08c402d325e92a72f7568dd261c4cc329bf
