### PR TITLE
tests/CacheTest: Do not use trigger_error to ensure method not called

### DIFF
--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -15,7 +15,7 @@ class Mock_CacheLegacy extends SimplePie_Cache
 {
     public static function get_handler($location, $filename, $extension)
     {
-        trigger_error('Legacy cache class should not have get_handler() called');
+        throw new Exception('Legacy cache class should not have get_handler() called');
     }
     public function create($location, $filename, $extension)
     {
@@ -31,7 +31,7 @@ class Mock_CacheNew extends SimplePie_Cache
     }
     public function create($location, $filename, $extension)
     {
-        trigger_error('New cache class should not have create() called');
+        throw new Exception('New cache class should not have create() called');
     }
 }
 


### PR DESCRIPTION
PHPStan would complain:

    Method Mock_CacheLegacy::get_handler() should return SimplePie\Cache\Base but return statement is missing.

Let’s throw an exception to properly terminate the method body.
