### PR TITLE
tests: Skip cases incompatible with PHP 8

### DIFF
--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -41,14 +41,14 @@ class CacheTest extends PHPUnit\Framework\TestCase
 
     public function testDirectOverrideLegacy()
     {
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectException(SuccessException::class);
-        } else {
+        if (version_compare(PHP_VERSION, '8.0', '>=')) {
             // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
             // This is no longer supported in PHP, so there is just no way to continue to provide BC
             // for the old non-static cache methods.
-            $this->expectError();
+            $this->markTestSkipped('Using legacy cache class is not compatible with PHP 8.');
         }
+
+        $this->expectException(SuccessException::class);
 
         $feed = new SimplePie();
         $this->expectDeprecation();

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -225,20 +225,20 @@ class SimplePieTest extends TestCase
 
     public function testLegacyCallOfSetCacheClass()
     {
+        if (version_compare(PHP_VERSION, '8.0', '>=')) {
+            // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
+            // This is no longer supported in PHP, so there is just no way to continue to provide BC
+            // for the old non-static cache methods.
+            $this->markTestSkipped('Using legacy cache class is not compatible with PHP 8.');
+        }
+
         $feed = new SimplePie();
         $this->expectDeprecation();
         $feed->set_cache_class(LegacyCacheMock::class);
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');
 
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectException(SuccessException::class);
-        } else {
-            // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
-            // This is no longer supported in PHP, so there is just no way to continue to provide BC
-            // for the old non-static cache methods.
-            $this->expectError();
-        }
+        $this->expectException(SuccessException::class);
 
         $feed->init();
     }


### PR DESCRIPTION
instead of running them and expecting an error.

Arguably, it is semantically cleaner to avoid testing a behaviour that is defined by PHP itself rather than anything SimplePie is doing.

As a bonus, it gets rid of the following warning:

    Expecting E_ERROR and E_USER_ERROR is deprecated and will no longer be possible in PHPUnit 10.
