### PR TITLE
tests: Do not use magic method for testing protected methods

### DIFF
--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -157,8 +157,18 @@ class EncodingTest extends PHPUnit\Framework\TestCase
 
 class Mock_Misc extends SimplePie_Misc
 {
-    public static function __callStatic($name, $args)
+    public static function change_encoding_mbstring($data, $input, $output)
     {
-        return call_user_func_array(['SimplePie_Misc', $name], $args);
+        return parent::change_encoding_mbstring($data, $input, $output);
+    }
+
+    public static function change_encoding_iconv($data, $input, $output)
+    {
+        return parent::change_encoding_iconv($data, $input, $output);
+    }
+
+    public static function change_encoding_uconverter(string $data, string $input, string $output)
+    {
+        return parent::change_encoding_uconverter($data, $input, $output);
     }
 }

--- a/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
+++ b/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
@@ -8,8 +8,18 @@ use SimplePie\Misc;
 
 class MiscWithPublicStaticMethodsMock extends Misc
 {
-    public static function __callStatic($name, $args)
+    public static function change_encoding_mbstring($data, $input, $output)
     {
-        return call_user_func_array([Misc::class, $name], $args);
+        return parent::change_encoding_mbstring($data, $input, $output);
+    }
+
+    public static function change_encoding_iconv($data, $input, $output)
+    {
+        return parent::change_encoding_iconv($data, $input, $output);
+    }
+
+    public static function change_encoding_uconverter(string $data, string $input, string $output)
+    {
+        return parent::change_encoding_uconverter($data, $input, $output);
     }
 }


### PR DESCRIPTION
PHPStan will not know about those and complain:

    Call to protected static method change_encoding_mbstring() of class SimplePie\Misc.
    Call to protected static method change_encoding_iconv() of class SimplePie\Misc.
    Call to protected static method change_encoding_uconverter() of class SimplePie\Misc.

We could use `@method` PHPDoc annotation but at this point explicit methods are not that much longer.
