### PR TITLE
Item: Accept Sanitize object

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -41,6 +41,11 @@ class Item implements RegistryAware
     protected $registry;
 
     /**
+     * @var Sanitize|null
+     */
+    private $sanitize = null;
+
+    /**
      * Create a new item object
      *
      * This is usually used by {@see \SimplePie\SimplePie::get_items} and
@@ -2223,7 +2228,7 @@ class Item implements RegistryAware
                     $width = null;
 
                     $url = $this->sanitize($enclosure['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_base($enclosure));
-                    $url = $this->feed->sanitize->https_url($url);
+                    $url = $this->get_sanitize()->https_url($url);
                     if (isset($enclosure['attribs']['']['type'])) {
                         $type = $this->sanitize($enclosure['attribs']['']['type'], \SimplePie\SimplePie::CONSTRUCT_TEXT);
                     }
@@ -2311,6 +2316,18 @@ class Item implements RegistryAware
         }
 
         return null;
+    }
+
+    public function set_sanitize(Sanitize $sanitize): void {
+        $this->sanitize = $sanitize;
+    }
+
+    protected function get_sanitize(): Sanitize {
+        if ($this->sanitize === null) {
+            $this->sanitize = new Sanitize();
+        }
+
+        return $this->sanitize;
     }
 }
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3078,6 +3078,7 @@ class SimplePie
      */
     private function make_item(array $data): Item {
         $item = $this->registry->create(Item::class, [$this, $data]);
+        $item->set_sanitize($this->sanitize);
 
         return $item;
     }

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2971,31 +2971,31 @@ class SimplePie
             if ($items = $this->get_feed_tags(self::NAMESPACE_ATOM_10, 'entry')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
+                    $this->data['items'][] = $this->make_item($items[$key]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_ATOM_03, 'entry')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
+                    $this->data['items'][] = $this->make_item($items[$key]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_RSS_10, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
+                    $this->data['items'][] = $this->make_item($items[$key]);
                 }
             }
             if ($items = $this->get_feed_tags(self::NAMESPACE_RSS_090, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
+                    $this->data['items'][] = $this->make_item($items[$key]);
                 }
             }
             if ($items = $this->get_channel_tags(self::NAMESPACE_RSS_20, 'item')) {
                 $keys = array_keys($items);
                 foreach ($keys as $key) {
-                    $this->data['items'][] = $this->registry->create(Item::class, [$this, $items[$key]]);
+                    $this->data['items'][] = $this->make_item($items[$key]);
                 }
             }
         }
@@ -3071,6 +3071,15 @@ class SimplePie
         $file = $trace[0]['file'];
         $line = $trace[0]['line'];
         trigger_error("Call to undefined method $class::$method() in $file on line $line", E_USER_ERROR);
+    }
+
+    /**
+     * Item factory
+     */
+    private function make_item(array $data): Item {
+        $item = $this->registry->create(Item::class, [$this, $data]);
+
+        return $item;
     }
 
     /**


### PR DESCRIPTION
`SimplePie::$sanitize` is a private member so we should not access it.
It only works because the visibility is currently described using PHPDoc annotation.
