### PR TITLE
Move code style check into own Github Actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
   test-compiled:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2']
+
+    name: "Test single-file build | PHP ${{ matrix.php }}"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -86,7 +93,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
           tools: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,36 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-code-style:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2']
+
+    name: "Check code style | PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP with latest composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+          coverage: none
+          tools: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: "Install Composer dependencies"
+        uses: "ramsey/composer-install@v2"
+
+      - name: "Check coding style"
+        run: composer cs
+
   test:
     runs-on: ubuntu-latest
 
@@ -42,10 +72,6 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
-
-      - name: "Check coding style"
-        if: ${{ matrix.php == '8.2' }}
-        run: composer cs
 
       - name: Run unit tests
         run: composer test


### PR DESCRIPTION
This PR will move the code style check in CI (introduced with #825) to a separate job. The reason for this is that it is confusing when the tests fail only for a specific PHP version, see https://github.com/simplepie/simplepie/actions/runs/5021614275 as an example.

With this PR the code style check is done in a separate job, so an error "only" in the code style can be visually detected as not serious.

This PR also runs the tests for the single-file build under PHP 8.2 and indicates this in the job name.