### PR TITLE
SimplePie: Prepare PubSubHubbub for PSR-18 clients

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -319,6 +319,19 @@ class File implements Response
         return $this->parsed_headers[strtolower($name)] ?? [];
     }
 
+    public function with_header(string $name, $value)
+    {
+        $this->maybe_update_headers();
+        $new = clone $this;
+
+        $newHeader = [
+            strtolower($name) => (array) $value,
+        ];
+        $new->set_headers($newHeader + $this->get_headers());
+
+        return $new;
+    }
+
     public function get_header_line(string $name): string
     {
         $this->maybe_update_headers();

--- a/src/HTTP/Psr7Response.php
+++ b/src/HTTP/Psr7Response.php
@@ -69,6 +69,11 @@ final class Psr7Response implements Response
         return $this->response->hasHeader($name);
     }
 
+    public function with_header(string $name, $value)
+    {
+        return new self($this->response->withHeader($name, $value), $this->permanent_url, $this->requested_url);
+    }
+
     public function get_header(string $name): array
     {
         return $this->response->getHeader($name);

--- a/src/HTTP/Psr7Response.php
+++ b/src/HTTP/Psr7Response.php
@@ -58,7 +58,10 @@ final class Psr7Response implements Response
 
     public function get_headers(): array
     {
-        return $this->response->getHeaders();
+        // The filtering is probably redundant but let’s make PHPStan happy.
+        return array_filter($this->response->getHeaders(), function (array $header): bool {
+            return count($header) >= 1;
+        });
     }
 
     public function has_header(string $name): bool

--- a/src/HTTP/RawTextResponse.php
+++ b/src/HTTP/RawTextResponse.php
@@ -28,6 +28,11 @@ final class RawTextResponse implements Response
     private $permanent_url;
 
     /**
+     * @var array<non-empty-array<string>>
+     */
+    private $headers = [];
+
+    /**
      * @var string
      */
     private $requested_url;
@@ -56,22 +61,34 @@ final class RawTextResponse implements Response
 
     public function get_headers(): array
     {
-        return [];
+        return $this->headers;
     }
 
     public function has_header(string $name): bool
     {
-        return false;
+        return isset($this->headers[strtolower($name)]);
     }
 
     public function get_header(string $name): array
     {
-        return [];
+        return isset($this->headers[strtolower($name)]) ? $this->headers[$name] : [];
+    }
+
+    public function with_header(string $name, $value)
+    {
+        $new = clone $this;
+
+        $newHeader = [
+            strtolower($name) => (array) $value,
+        ];
+        $new->headers = $newHeader + $this->headers;
+
+        return $new;
     }
 
     public function get_header_line(string $name): string
     {
-        return '';
+        return isset($this->headers[strtolower($name)]) ? implode(", ", $this->headers[$name]) : '';
     }
 
     public function get_body_content(): string

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -95,7 +95,7 @@ interface Response
      *         }
      *     }
      *
-     * @return string[][] Returns an associative array of the message's headers.
+     * @return array<non-empty-array<string>> Returns an associative array of the message's headers.
      *     Each key MUST be a header name, and each value MUST be an array of
      *     strings for that header.
      */

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -128,6 +128,20 @@ interface Response
     public function get_header(string $name): array;
 
     /**
+     * Return an instance with the provided value replacing the specified header.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new and/or updated header and value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|non-empty-array<string> $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function with_header(string $name, $value);
+
+    /**
      * Retrieves a comma-separated string of the values for a single header.
      *
      * This method returns all of the header values of the given

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -331,7 +331,7 @@ class Locator implements RegistryAware
         }
 
         $xpath = new \DOMXpath($this->dom);
-        $query = '//a[@rel and @href] | //link[@rel and @href]';
+        $query = '//link[@rel and @href]';
         foreach ($xpath->query($query) as $link) {
             /** @var \DOMElement $link */
             $href = trim($link->getAttribute('href'));

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -317,6 +317,8 @@ class Locator implements RegistryAware
     }
 
     /**
+     * Extracts first `link` element with given `rel` attribute inside the `head` element.
+     *
      * @return string|null
      */
     public function get_rel_link(string $rel)
@@ -331,7 +333,7 @@ class Locator implements RegistryAware
         }
 
         $xpath = new \DOMXpath($this->dom);
-        $query = '//link[@rel and @href]';
+        $query = '(//head)[1]/link[@rel and @href]';
         foreach ($xpath->query($query) as $link) {
             /** @var \DOMElement $link */
             $href = trim($link->getAttribute('href'));

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3389,10 +3389,8 @@ class SimplePie
      *
      * There is no way to find PuSH links in the body of a microformats feed,
      * so they are added to the headers when found, to be used later by get_links.
-     * @param string $hub
-     * @param string $self
      */
-    private function store_links(File &$file, string $hub, string $self): void
+    private function store_links(File &$file, string $hub, ?string $self): void
     {
         if (isset($file->headers['link']) && preg_match('/rel=hub/', $file->headers['link'])) {
             return;

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3399,7 +3399,7 @@ class SimplePie
         if ($hub) {
             if (isset($file->headers['link'])) {
                 if ($file->headers['link'] !== '') {
-                    $file->headers['link'] = ', ';
+                    $file->headers['link'] .= ', ';
                 }
             } else {
                 $file->headers['link'] = '';

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2034,9 +2034,7 @@ class SimplePie
                     if ($microformats) {
                         if ($hub = $locate->get_rel_link('hub')) {
                             $self = $locate->get_rel_link('self');
-                            if ($file instanceof File) {
-                                $this->store_links($file, $hub, $self);
-                            }
+                            $file = $this->store_links($file, $hub, $self);
                         }
                         // Push the current file onto all_discovered feeds so the user can
                         // be shown this as one of the options.
@@ -3390,25 +3388,23 @@ class SimplePie
      * There is no way to find PuSH links in the body of a microformats feed,
      * so they are added to the headers when found, to be used later by get_links.
      */
-    private function store_links(File &$file, string $hub, ?string $self): void
+    private function store_links(Response $file, string $hub, ?string $self): Response
     {
-        if (isset($file->headers['link']) && preg_match('/rel=hub/', $file->headers['link'])) {
-            return;
+        $linkHeaderLine = $file->get_header_line('link');
+        if ($linkHeaderLine !== '' && preg_match('/rel=hub/', $linkHeaderLine)) {
+            return $file;
         }
 
         if ($hub) {
-            if (isset($file->headers['link'])) {
-                if ($file->headers['link'] !== '') {
-                    $file->headers['link'] .= ', ';
-                }
-            } else {
-                $file->headers['link'] = '';
+            $linkHeader = $file->get_header('link');
+            $linkHeader[] = '<'.$hub.'>; rel=hub';
+            if ($self && !preg_match('/rel=self/', $linkHeaderLine)) {
+                $linkHeader[] = '<'.$self.'>; rel=self';
             }
-            $file->headers['link'] .= '<'.$hub.'>; rel=hub';
-            if ($self && !preg_match('/rel=self/', $file->headers['link'])) {
-                $file->headers['link'] .= ', <'.$self.'>; rel=self';
-            }
+            $file = $file->with_header('link', $linkHeader);
         }
+
+        return $file;
     }
 
     /**

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3405,7 +3405,7 @@ class SimplePie
                 $file->headers['link'] = '';
             }
             $file->headers['link'] .= '<'.$hub.'>; rel=hub';
-            if ($self) {
+            if ($self && !preg_match('/rel=self/', $file->headers['link'])) {
                 $file->headers['link'] .= ', <'.$self.'>; rel=self';
             }
         }

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -366,6 +366,44 @@ HTML
             'selfUrl' => 'https://example.com/',
         ];
 
+        yield 'hub + self in `a` element (insecure and unsupported)' => [
+            'data' => <<<HTML
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+    <body>
+        <a rel="hub" href="https://pubsubhubbub.appspot.com" />
+        <a rel="self" href="https://example.com" />
+        <div class="h-feed">
+        </div>
+    </body>
+</html>
+HTML
+            ,
+            'hubUrl' => null,
+            'selfUrl' => null,
+        ];
+
+        yield 'hub + self inside `body`' => [
+            'data' => <<<HTML
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+    <body>
+        <link rel="hub" href="https://pubsubhubbub.appspot.com">
+        <link rel="self" href="https://example.com">
+        <div class="h-feed">
+        </div>
+    </body>
+</html>
+HTML
+            ,
+            'hubUrl' => 'https://pubsubhubbub.appspot.com/',
+            'selfUrl' => 'https://example.com/',
+        ];
+
         yield 'self only' => [
             'data' => <<<HTML
 <html>

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -407,6 +407,28 @@ HTML
             ],
             'bogoUrl' => 'https://bogo.test/',
         ];
+
+        yield 'hub + self + self in header' => [
+            'data' => <<<HTML
+<html>
+    <head>
+        <title>Test</title>
+        <link rel="hub" href="https://pubsubhubbub.appspot.com">
+        <link rel="self" href="https://example.com">
+    </head>
+    <body>
+        <div class="h-feed">
+        </div>
+    </body>
+</html>
+HTML
+            ,
+            'hubUrl' => 'https://pubsubhubbub.appspot.com/',
+            'selfUrl' => 'https://example.org/',
+            'headers' => [
+                'Link: <https://example.org/>; rel=self',
+            ],
+        ];
     }
 
     /**
@@ -438,6 +460,7 @@ HTML
 
         $this->assertSame($hubUrl, $feed->get_link(0, 'hub'), 'Link rel=hub does not match');
         $this->assertSame($selfUrl, $feed->get_link(0, 'self'), 'Link rel=self does not match');
+        $this->assertLessThanOrEqual(1, count($feed->get_links('self') ?? []), 'Link rel=self should not be promoted from HTML when it is already present in headers');
         $this->assertSame($bogoUrl, $feed->get_link(0, 'bogo'), 'Link rel=bogo does not match');
     }
 }

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -253,4 +253,57 @@ class SimplePieTest extends TestCase
         $this->assertTrue($simplepie->init());
         $this->assertSame(100, $simplepie->get_item_quantity());
     }
+
+    /**
+     * @return iterable<array{path: string, feedTitle: string, titles: list<string>}>
+     */
+    public static function microformatFeedProvider(): iterable
+    {
+        yield [
+            'path' => dirname(__FILE__, 2) . '/data/microformats/h-feed-simple.html',
+            'feedTitle' => 'Test',
+            'titles' => [
+                'One',
+                'Two',
+                'Three',
+                'Four',
+            ],
+        ];
+
+        yield [
+            'path' => dirname(__FILE__, 2) . '/data/microformats/h-feed-with-comments.html',
+            'feedTitle' => 'Test',
+            'titles' => [
+                'One',
+                'Two',
+                'Three',
+                'Four',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider microformatFeedProvider
+     *
+     * @param list<string> $titles
+     */
+    public function testMicroformatItems(string $path, string $feedTitle, array $titles): void
+    {
+        if (!function_exists('Mf2\parse')) {
+            $this->markTestSkipped('Test requires Mf2 library.');
+        }
+
+        $feed = new SimplePie();
+        $feed->set_raw_data(file_get_contents($path));
+        $feed->enable_cache(false);
+
+        $this->assertTrue($feed->init(), 'Failed fetching feed: ' . $feed->error());
+
+        $this->assertSame($feedTitle, $feed->get_title());
+        $items = $feed->get_items();
+        $this->assertSame(count($titles), count($items), 'Number of items does not match');
+        foreach (array_map(null, $titles, $items) as $i => [$expectedTitle, $item]) {
+            $this->assertSame($expectedTitle, $item->get_title(), "Title of item #$i does not match");
+        }
+    }
 }

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -419,8 +419,7 @@ HTML
 HTML
             ,
             'hubUrl' => null,
-            // We only promote self link when hub is set as well.
-            'selfUrl' => null,
+            'selfUrl' => 'https://example.com/',
         ];
 
         yield 'hub + self + bogo in header' => [
@@ -465,6 +464,28 @@ HTML
             'selfUrl' => 'https://example.org/',
             'headers' => [
                 'Link: <https://example.org/>; rel=self',
+            ],
+        ];
+
+        yield 'hub in header + self' => [
+            'data' => <<<HTML
+<html>
+    <head>
+        <title>Test</title>
+        <link rel="hub" href="https://pubsubhubbub.appspot.com">
+        <link rel="self" href="https://example.com">
+    </head>
+    <body>
+        <div class="h-feed">
+        </div>
+    </body>
+</html>
+HTML
+            ,
+            'hubUrl' => 'https://switchboard.p3k.io/',
+            'selfUrl' => 'https://example.com/',
+            'headers' => [
+                'Link: <https://switchboard.p3k.io/>; rel=hub',
             ],
         ];
     }

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -385,7 +385,7 @@ HTML
             'selfUrl' => null,
         ];
 
-        yield 'hub + self inside `body`' => [
+        yield 'hub + self inside `body (insecure and unsupported)`' => [
             'data' => <<<HTML
 <html>
     <head>
@@ -400,8 +400,8 @@ HTML
 </html>
 HTML
             ,
-            'hubUrl' => 'https://pubsubhubbub.appspot.com/',
-            'selfUrl' => 'https://example.com/',
+            'hubUrl' => null,
+            'selfUrl' => null,
         ];
 
         yield 'self only' => [

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -29,36 +29,7 @@ class ParserTest extends TestCase
     public static function feedProvider(): iterable
     {
         yield [
-            <<<HTML
-<!-- SPDX-FileCopyrightText: 2018 Aaron Parecki -->
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-<!-- SPDX-ArtifactOfProjectName: php-mf2 -->
-<html>
-    <head>
-        <title>Test</title>
-    </head>
-    <body>
-        <div class="h-feed">
-            <a href="/author" class="p-author h-card">Author Name</a>
-            <ul>
-                <li class="h-entry">
-                    <a href="/1" class="u-url p-name">One</a>
-                </li>
-                <li class="h-entry">
-                    <a href="/2" class="u-url p-name">Two</a>
-                </li>
-                <li class="h-entry">
-                    <a href="/3" class="u-url p-name">Three</a>
-                </li>
-                <li class="h-entry">
-                    <a href="/4" class="u-url p-name">Four</a>
-                </li>
-            </ul>
-        </div>
-    </body>
-</html>
-HTML
-            ,
+            file_get_contents(dirname(__FILE__, 2) . '/data/microformats/h-feed-simple.html'),
             'https://example.com',
             [
                 'child' => [
@@ -187,44 +158,7 @@ HTML
         ];
 
         yield [
-            <<<HTML
-<!-- SPDX-FileCopyrightText: 2018 Aaron Parecki -->
-<!-- SPDX-License-Identifier: CC0-1.0 -->
-<!-- SPDX-ArtifactOfProjectName: php-mf2 -->
-<html>
-    <head>
-        <title>Test</title>
-    </head>
-    <body>
-        <div class="h-feed">
-            <a href="/author" class="p-author h-card">Author Name</a>
-            <ul>
-                <li class="h-entry">
-                    <a href="/1" class="u-url p-name">One</a>
-                </li>
-                <li class="h-entry">
-                    <a href="/2" class="u-url p-name">Two</a>
-                    <ul>
-                        <li class="p-comment h-entry"><a href="/a" class="u-url p-name">Comment A</a></li>
-                        <li class="p-comment h-entry"><a href="/b" class="u-url p-name">Comment B</a></li>
-                    </ul>
-                </li>
-                <li class="h-entry">
-                    <a href="/3" class="u-url p-name">Three</a>
-                    <ul>
-                        <li class="h-entry"><a href="/c" class="u-url p-name">Comment C</a></li>
-                        <li class="h-entry"><a href="/d" class="u-url p-name">Comment D</a></li>
-                    </ul>
-                </li>
-                <li class="h-entry">
-                    <a href="/4" class="u-url p-name">Four</a>
-                </li>
-            </ul>
-        </div>
-    </body>
-</html>
-HTML
-            ,
+            file_get_contents(dirname(__FILE__, 2) . '/data/microformats/h-feed-with-comments.html'),
             'https://example.com',
             [
                 'child' => [

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -358,7 +358,7 @@ HTML
      *
      * @param array<string, mixed> $parsedData
      */
-    public function test_get_title(string $feed, string $base, array $parsedData): void
+    public function test_parse(string $feed, string $base, array $parsedData): void
     {
         if (!function_exists('Mf2\parse')) {
             $this->markTestSkipped('Test requires Mf2 library.');

--- a/tests/data/microformats/h-feed-simple.html
+++ b/tests/data/microformats/h-feed-simple.html
@@ -1,0 +1,27 @@
+<!-- SPDX-FileCopyrightText: 2018 Aaron Parecki -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-ArtifactOfProjectName: php-mf2 -->
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+    <body>
+        <div class="h-feed">
+            <a href="/author" class="p-author h-card">Author Name</a>
+            <ul>
+                <li class="h-entry">
+                    <a href="/1" class="u-url p-name">One</a>
+                </li>
+                <li class="h-entry">
+                    <a href="/2" class="u-url p-name">Two</a>
+                </li>
+                <li class="h-entry">
+                    <a href="/3" class="u-url p-name">Three</a>
+                </li>
+                <li class="h-entry">
+                    <a href="/4" class="u-url p-name">Four</a>
+                </li>
+            </ul>
+        </div>
+    </body>
+</html>

--- a/tests/data/microformats/h-feed-with-comments.html
+++ b/tests/data/microformats/h-feed-with-comments.html
@@ -1,0 +1,35 @@
+<!-- SPDX-FileCopyrightText: 2018 Aaron Parecki -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-ArtifactOfProjectName: php-mf2 -->
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+    <body>
+        <div class="h-feed">
+            <a href="/author" class="p-author h-card">Author Name</a>
+            <ul>
+                <li class="h-entry">
+                    <a href="/1" class="u-url p-name">One</a>
+                </li>
+                <li class="h-entry">
+                    <a href="/2" class="u-url p-name">Two</a>
+                    <ul>
+                        <li class="p-comment h-entry"><a href="/a" class="u-url p-name">Comment A</a></li>
+                        <li class="p-comment h-entry"><a href="/b" class="u-url p-name">Comment B</a></li>
+                    </ul>
+                </li>
+                <li class="h-entry">
+                    <a href="/3" class="u-url p-name">Three</a>
+                    <ul>
+                        <li class="h-entry"><a href="/c" class="u-url p-name">Comment C</a></li>
+                        <li class="h-entry"><a href="/d" class="u-url p-name">Comment D</a></li>
+                    </ul>
+                </li>
+                <li class="h-entry">
+                    <a href="/4" class="u-url p-name">Four</a>
+                </li>
+            </ul>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Previously, this only supported `File`, let’s prepare for other `Response` implementations.

Also fixes a bug where it would clear previous links (by setting it to comma instead of appending).
And where it would add redundant `rel=self` link.
