### PR TITLE
Remove strict_types declaration

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,8 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         'void_return' => false,
         '@PHPUnit84Migration:risky' => true,
+        'declare_strict_types' => false,
     ])
+    ->setRiskyAllowed(true)
     ->setFinder($finder)
 ;

--- a/build/bootstrap.php
+++ b/build/bootstrap.php
@@ -1,6 +1,4 @@
 <?php
 
-declare(strict_types=1);
-
 require_once dirname(__DIR__) . '/SimplePie.compiled.php';
 require_once dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';

--- a/build/charset.php
+++ b/build/charset.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 require_once '../autoloader.php';
 
 function normalize_character_set($charset)

--- a/build/compile.php
+++ b/build/compile.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 // Set up our constants
 define('SP_PATH', dirname(__FILE__, 2));
 define('COMPILED', SP_PATH . DIRECTORY_SEPARATOR . 'SimplePie.compiled.php');

--- a/library/SimplePie.php
+++ b/library/SimplePie.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Author.php
+++ b/library/SimplePie/Author.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache.php
+++ b/library/SimplePie/Cache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Base.php
+++ b/library/SimplePie/Cache/Base.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/DB.php
+++ b/library/SimplePie/Cache/DB.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/File.php
+++ b/library/SimplePie/Cache/File.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Memcache.php
+++ b/library/SimplePie/Cache/Memcache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Memcached.php
+++ b/library/SimplePie/Cache/Memcached.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/MySQL.php
+++ b/library/SimplePie/Cache/MySQL.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Cache/Redis.php
+++ b/library/SimplePie/Cache/Redis.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * SimplePie Redis Cache Extension
  *

--- a/library/SimplePie/Caption.php
+++ b/library/SimplePie/Caption.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Category.php
+++ b/library/SimplePie/Category.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Content/Type/Sniffer.php
+++ b/library/SimplePie/Content/Type/Sniffer.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Copyright.php
+++ b/library/SimplePie/Copyright.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Core.php
+++ b/library/SimplePie/Core.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Credit.php
+++ b/library/SimplePie/Credit.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Decode/HTML/Entities.php
+++ b/library/SimplePie/Decode/HTML/Entities.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Enclosure.php
+++ b/library/SimplePie/Enclosure.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Exception.php
+++ b/library/SimplePie/Exception.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/File.php
+++ b/library/SimplePie/File.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/HTTP/Parser.php
+++ b/library/SimplePie/HTTP/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/IRI.php
+++ b/library/SimplePie/IRI.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Item.php
+++ b/library/SimplePie/Item.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Locator.php
+++ b/library/SimplePie/Locator.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Misc.php
+++ b/library/SimplePie/Misc.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Net/IPv6.php
+++ b/library/SimplePie/Net/IPv6.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Parse/Date.php
+++ b/library/SimplePie/Parse/Date.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Parser.php
+++ b/library/SimplePie/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Rating.php
+++ b/library/SimplePie/Rating.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Registry.php
+++ b/library/SimplePie/Registry.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Restriction.php
+++ b/library/SimplePie/Restriction.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Sanitize.php
+++ b/library/SimplePie/Sanitize.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/Source.php
+++ b/library/SimplePie/Source.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/XML/Declaration/Parser.php
+++ b/library/SimplePie/XML/Declaration/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/library/SimplePie/gzdecode.php
+++ b/library/SimplePie/gzdecode.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Author.php
+++ b/src/Author.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Base.php
+++ b/src/Cache/Base.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/DB.php
+++ b/src/Cache/DB.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/DataCache.php
+++ b/src/Cache/DataCache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/MySQL.php
+++ b/src/Cache/MySQL.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Psr16.php
+++ b/src/Cache/Psr16.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Cache/Redis.php
+++ b/src/Cache/Redis.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Caption.php
+++ b/src/Caption.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Category.php
+++ b/src/Category.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Content/Type/Sniffer.php
+++ b/src/Content/Type/Sniffer.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Copyright.php
+++ b/src/Copyright.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Credit.php
+++ b/src/Credit.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/File.php
+++ b/src/File.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Item.php
+++ b/src/Item.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Net/IPv6.php
+++ b/src/Net/IPv6.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Rating.php
+++ b/src/Rating.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/RegistryAware.php
+++ b/src/RegistryAware.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Restriction.php
+++ b/src/Restriction.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/Source.php
+++ b/src/Source.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/src/XML/Declaration/Parser.php
+++ b/src/XML/Declaration/Parser.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/BCTest.php
+++ b/tests/BCTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  *

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  *

--- a/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
+++ b/tests/Fixtures/Cache/BaseCacheWithCallbacksMock.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Fixtures/Cache/LegacyCacheMock.php
+++ b/tests/Fixtures/Cache/LegacyCacheMock.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures\Cache;
 
 use Exception;

--- a/tests/Fixtures/Cache/NewCacheMock.php
+++ b/tests/Fixtures/Cache/NewCacheMock.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures\Cache;
 
 use Exception;

--- a/tests/Fixtures/Exception/SuccessException.php
+++ b/tests/Fixtures/Exception/SuccessException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures\Exception;
 
 use Exception;

--- a/tests/Fixtures/FileMock.php
+++ b/tests/Fixtures/FileMock.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures;
 
 use SimplePie\File;

--- a/tests/Fixtures/FileWithRedirectMock.php
+++ b/tests/Fixtures/FileWithRedirectMock.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures;
 
 /**

--- a/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
+++ b/tests/Fixtures/MiscWithPublicStaticMethodsMock.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace SimplePie\Tests\Fixtures;
 
 use SimplePie\Misc;

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * HTTP parsing tests
  *

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * IRI test cases
  *

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Tests for SimplePie_Item
  *

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * Tests for autodiscovery
  *

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -170,9 +170,9 @@ class LocatorTest extends PHPUnit\Framework\TestCase
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
         $this->assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
         $this->assertInstanceOf(FileMock::class, $feed);
-        $success = array_filter($expected, [get_class(), 'filter_success']);
+        $success = array_filter($expected, [get_class($this), 'filter_success']);
 
-        $found = array_map([get_class(), 'map_url_file'], $all);
+        $found = array_map([get_class($this), 'map_url_file'], $all);
         $this->assertSame($success, $found);
     }
 

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/AuthorTest.php
+++ b/tests/Unit/AuthorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/BaseDataCacheTest.php
+++ b/tests/Unit/Cache/BaseDataCacheTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/BaseTest.php
+++ b/tests/Unit/Cache/BaseTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/DBTest.php
+++ b/tests/Unit/Cache/DBTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/FileTest.php
+++ b/tests/Unit/Cache/FileTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MemcacheTest.php
+++ b/tests/Unit/Cache/MemcacheTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MemcachedTest.php
+++ b/tests/Unit/Cache/MemcachedTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/MySQLTest.php
+++ b/tests/Unit/Cache/MySQLTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Cache/RedisTest.php
+++ b/tests/Unit/Cache/RedisTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CaptionTest.php
+++ b/tests/Unit/CaptionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Content/Type/SnifferTest.php
+++ b/tests/Unit/Content/Type/SnifferTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CopyrightTest.php
+++ b/tests/Unit/CopyrightTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/CreditTest.php
+++ b/tests/Unit/CreditTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/GzdecodeTest.php
+++ b/tests/Unit/GzdecodeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -186,9 +186,9 @@ class LocatorTest extends TestCase
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
         $this->assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
         $this->assertInstanceOf('SimplePie\Tests\Fixtures\FileMock', $feed);
-        $success = array_filter($expected, [get_class(), 'filter_success']);
+        $success = array_filter($expected, [get_class($this), 'filter_success']);
 
-        $found = array_map([get_class(), 'map_url_file'], $all);
+        $found = array_map([get_class($this), 'map_url_file'], $all);
         $this->assertSame($success, $found);
     }
 

--- a/tests/Unit/MiscTest.php
+++ b/tests/Unit/MiscTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Net/IPv6Test.php
+++ b/tests/Unit/Net/IPv6Test.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/Parse/DateTest.php
+++ b/tests/Unit/Parse/DateTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RatingTest.php
+++ b/tests/Unit/RatingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/RestrictionTest.php
+++ b/tests/Unit/RestrictionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/Unit/XML/Declaration/ParserTest.php
+++ b/tests/Unit/XML/Declaration/ParserTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * SimplePie
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 // require the composer autoload.php file
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 


### PR DESCRIPTION
The code base is not ready for it yet.

Reverts efe70f4dd8c1eab286b6dadefa1d4e6e0b000a98
Partially reverts 93fe4599bb6757de7d1f558c044c49125959426f and some other commits

Fixes: https://github.com/simplepie/simplepie/issues/810
Fixes: https://github.com/simplepie/simplepie/issues/831
Fixes: https://github.com/simplepie/simplepie/issues/801
Fixes: https://github.com/simplepie/simplepie/issues/802
