### PR TITLE
Enable test execution with PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ vendor/
 composer.lock
 phpunit.xml
 .php-cs-fixer.cache
-.phpunit.result.cache
+.phpunit.cache/

--- a/build/bootstrap.php
+++ b/build/bootstrap.php
@@ -3,4 +3,3 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/SimplePie.compiled.php';
-require_once dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.8",
         "mf2/mf2": "^0.5.0",
         "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^8 || ^9 || ^10",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/simple-cache": "^1 || ^2 || ^3",
-        "yoast/phpunit-polyfills": "^2"
+        "psr/simple-cache": "^1 || ^2 || ^3"
     },
     "suggest": {
         "ext-curl": "",

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "sort-packages": true
     },
     "scripts": {
+        "coverage": "phpunit --coverage-html=.phpunit.cache/code-coverage",
         "cs": "php-cs-fixer fix --verbose --dry-run --diff",
         "fix": "php-cs-fixer fix --verbose --diff",
         "phpstan": "phpstan analyze --memory-limit 512M",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/simple-cache": "^1 || ^2 || ^3",
-        "yoast/phpunit-polyfills": "^1.0.1"
+        "yoast/phpunit-polyfills": "^2"
     },
     "suggest": {
         "ext-curl": "",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" convertDeprecationsToExceptions="true">
-  <coverage includeUncoveredFiles="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache">
+  <coverage includeUncoveredFiles="true"/>
+  <source>
     <include>
       <directory suffix=".php">library</directory>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
   <testsuites>
     <testsuite name="SimplePie Test Suite">
       <directory>./tests</directory>

--- a/src/File.php
+++ b/src/File.php
@@ -265,10 +265,12 @@ class File implements Response
             }
         } else {
             $this->method = \SimplePie\SimplePie::FILE_SOURCE_LOCAL | \SimplePie\SimplePie::FILE_SOURCE_FILE_GET_CONTENTS;
-            if (empty($url) || !($this->body = trim(file_get_contents($url)))) {
-                $this->error = 'file_get_contents() could not read the file';
+            if (empty($url) || ! is_readable($url) ||  false === $filebody = file_get_contents($url)) {
+                $this->body = '';
+                $this->error = sprintf('file "%s" is not readable', $url);
                 $this->success = false;
             } else {
+                $this->body = trim($filebody);
                 $this->status_code = 200;
             }
         }

--- a/src/HTTP/Psr18Client.php
+++ b/src/HTTP/Psr18Client.php
@@ -144,6 +144,10 @@ final class Psr18Client implements Client
 
     private function requestLocalFile(string $path): Response
     {
+        if (! is_readable($path)) {
+            throw new HttpException(sprintf('file "%s" is not readable', $path));
+        }
+
         try {
             $raw = file_get_contents($path);
         } catch (Throwable $th) {

--- a/tests/BCTest.php
+++ b/tests/BCTest.php
@@ -5,10 +5,12 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  */
-class BCTest extends PHPUnit\Framework\TestCase
+class BCTest extends TestCase
 {
     /**
      * Test class SimplePie_Core exists

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -5,11 +5,11 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
 use SimplePie\Cache;
 use SimplePie\File;
 use SimplePie\Tests\Fixtures\Exception\SuccessException;
 use SimplePie\Tests\Fixtures\FileMock;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class Mock_CacheLegacy extends SimplePie_Cache
 {
@@ -35,10 +35,8 @@ class Mock_CacheNew extends SimplePie_Cache
     }
 }
 
-class CacheTest extends PHPUnit\Framework\TestCase
+class CacheTest extends TestCase
 {
-    use ExpectPHPException;
-
     public function testDirectOverrideLegacy(): void
     {
         if (version_compare(PHP_VERSION, '8.0', '<')) {

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -62,13 +62,13 @@ class CacheTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.',
-                    $errstr,
+                    $errstr
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED,
+            E_USER_DEPRECATED
         );
 
         $feed->set_cache_class(Mock_CacheLegacy::class);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -5,11 +5,17 @@
 
 declare(strict_types=1);
 
+namespace SimplePie\Tests;
+
+use Exception;
 use PHPUnit\Framework\TestCase;
+use SimplePie;
 use SimplePie\Cache;
 use SimplePie\File;
 use SimplePie\Tests\Fixtures\Exception\SuccessException;
 use SimplePie\Tests\Fixtures\FileMock;
+use SimplePie_Cache;
+use TypeError;
 
 class Mock_CacheLegacy extends SimplePie_Cache
 {
@@ -45,11 +51,26 @@ class CacheTest extends TestCase
             // PHP 8.0 will throw a `TypeError` for trying to call a non-static method statically.
             // This is no longer supported in PHP, so there is just no way to continue to provide BC
             // for the old non-static cache methods.
-            $this->expectError();
+            $this->expectException(TypeError::class);
+            $this->expectExceptionMessage('call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method SimplePie\Tests\Mock_CacheLegacy::create() cannot be called statically');
         }
 
         $feed = new SimplePie();
-        $this->expectDeprecation();
+
+        // PHPUnit 10 compatible way to test the deprecation error.
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
         $feed->set_cache_class(Mock_CacheLegacy::class);
         $feed->get_registry()->register(File::class, FileMock::class);
         $feed->set_feed_url('http://example.com/feed/');

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -57,7 +57,7 @@ class CacheTest extends TestCase
 
         $feed = new SimplePie();
 
-        // PHPUnit 10 compatible way to test the deprecation error.
+        // PHPUnit 10 compatible way to test trigger_error().
         set_error_handler(
             function ($errno, $errstr): bool {
                 $this->assertSame(

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -5,10 +5,12 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Encoding tests for SimplePie_Misc::change_encoding() and SimplePie_Misc::encoding()
  */
-class EncodingTest extends PHPUnit\Framework\TestCase
+class EncodingTest extends TestCase
 {
     /* ## UTF-8 methods */
 

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -5,10 +5,12 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * HTTP parsing tests
  */
-class HTTPParserTest extends PHPUnit\Framework\TestCase
+class HTTPParserTest extends TestCase
 {
     /**
      * @return array<array{string, string}>

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -456,16 +456,16 @@ class IRITest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     'Undefined property: SimplePie\IRI::nonexistant_prop',
-                    $errstr,
+                    $errstr
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_NOTICE,
+            E_USER_NOTICE
         );
 
-        $iri->nonexistant_prop;
+        $should_fail = $iri->nonexistant_prop;
     }
 
     public function testBlankHost(): void

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -448,11 +448,24 @@ class IRITest extends TestCase
 
     public function testNonexistantProperty(): void
     {
-        $this->expectNotice();
-
         $iri = new SimplePie_IRI();
         $this->assertFalse(isset($iri->nonexistant_prop));
-        $should_fail = $iri->nonexistant_prop;
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    'Undefined property: SimplePie\IRI::nonexistant_prop',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_NOTICE,
+        );
+
+        $iri->nonexistant_prop;
     }
 
     public function testBlankHost(): void

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -5,15 +5,13 @@
 
 declare(strict_types=1);
 
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * IRI test cases
  */
-class IRITest extends PHPUnit\Framework\TestCase
+class IRITest extends TestCase
 {
-    use ExpectPHPException;
-
     /**
      * @return array<array{string, string}>
      */

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -118,7 +118,7 @@ class CachingTest extends TestCase
     /**
      * @return array<array{string, array<string, mixed>, array<string, mixed>, int}>
      */
-    public function provideSavedCacheData(): array
+    public static function provideSavedCacheData(): array
     {
         $defaultMtime = time();
         $defaultExpirationTime = $defaultMtime + 3600;

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -17,12 +17,9 @@ use SimplePie\Misc;
 use SimplePie\SimplePie;
 use SimplePie\Tests\Fixtures\Cache\BaseCacheWithCallbacksMock;
 use SimplePie\Tests\Fixtures\FileMock;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class CachingTest extends TestCase
 {
-    use ExpectPHPException;
-
     /**
      * @dataProvider provideSavedCacheData
      * @param array<string, mixed> $currentDataCached

--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -20,24 +20,25 @@ use SimplePie\Registry;
 
 class ClientsTest extends TestCase
 {
-    /**
-     * @return array<Client[]>
-     */
-    public function provideHttpClientsForLocalFiles(): iterable
+    public function testFileClientGetContentOfLocalFile(): void
     {
-        yield [new FileClient(new Registry())];
-
-        yield [new Psr18Client(
-            $this->createMock(ClientInterface::class),
-            $this->createMock(RequestFactoryInterface::class),
-            $this->createMock(UriFactoryInterface::class)
-        )];
+        $this->runTestsWithClientGetContentOfLocalFile(
+            new FileClient(new Registry())
+        );
     }
 
-    /**
-     * @dataProvider provideHttpClientsForLocalFiles
-     */
-    public function testClientGetContentOfLocalFile(Client $client): void
+    public function testPrs18ClientGetContentOfLocalFile(): void
+    {
+        $this->runTestsWithClientGetContentOfLocalFile(
+            new Psr18Client(
+                $this->createMock(ClientInterface::class),
+                $this->createMock(RequestFactoryInterface::class),
+                $this->createMock(UriFactoryInterface::class)
+            )
+        );
+    }
+
+    private function runTestsWithClientGetContentOfLocalFile(Client $client): void
     {
         $filepath = dirname(__FILE__, 3) . '/data/feed_rss-2.0.xml';
 
@@ -51,10 +52,25 @@ class ClientsTest extends TestCase
         $this->assertStringStartsWith('<rss version="2.0">', $response->get_body_content());
     }
 
-    /**
-     * @dataProvider provideHttpClientsForLocalFiles
-     */
-    public function testClientThrowsHttpException(Client $client): void
+    public function testFileClientThrowsHttpException(): void
+    {
+        $this->runTestWithClientThrowsHttpException(
+            new FileClient(new Registry())
+        );
+    }
+
+    public function testPsr18ClientThrowsHttpException(): void
+    {
+        $this->runTestWithClientThrowsHttpException(
+            new Psr18Client(
+                $this->createMock(ClientInterface::class),
+                $this->createMock(RequestFactoryInterface::class),
+                $this->createMock(UriFactoryInterface::class)
+            )
+        );
+    }
+
+    private function runTestWithClientThrowsHttpException(Client $client): void
     {
         $filepath = dirname(__FILE__, 3) . '/data/this-file-does-not-exist';
 

--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -75,13 +75,9 @@ class ClientsTest extends TestCase
         $filepath = dirname(__FILE__, 3) . '/data/this-file-does-not-exist';
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionCode(2);
+        $this->expectExceptionCode(0);
 
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectExceptionMessage('file_get_contents('.$filepath.'): failed to open stream: No such file or directory');
-        } else {
-            $this->expectExceptionMessage('file_get_contents('.$filepath.'): Failed to open stream: No such file or directory');
-        }
+        $this->expectExceptionMessage(sprintf('file "%s" is not readable', $filepath));
 
         $client->request(Client::METHOD_GET, $filepath);
     }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -5,10 +5,12 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for SimplePie\Item
  */
-class ItemTest extends PHPUnit\Framework\TestCase
+class ItemTest extends TestCase
 {
     /**
      * Run a test using a sprintf template and data

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -5,17 +5,15 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
 use SimplePie\File;
 use SimplePie\Tests\Fixtures\FileMock;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 /**
  * Tests for autodiscovery
  */
-class LocatorTest extends PHPUnit\Framework\TestCase
+class LocatorTest extends TestCase
 {
-    use ExpectPHPException;
-
     /**
      * @return array<array{string}>
      */

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -33,7 +33,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function sanitizeURLProvider(): array
+    public static function sanitizeURLProvider(): array
     {
         return [
             'simple absolute valid a href, resolved' => [

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -6,7 +6,9 @@
 
 declare(strict_types=1);
 
-class SanitizeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SanitizeTest extends TestCase
 {
     public function testSanitize(): void
     {

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -5,10 +5,11 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
 use SimplePie\File;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
 
-class SubscribeUrlTest extends PHPUnit\Framework\TestCase
+class SubscribeUrlTest extends TestCase
 {
     public function testDirectOverrideLegacy(): void
     {

--- a/tests/Unit/AuthorTest.php
+++ b/tests/Unit/AuthorTest.php
@@ -27,7 +27,7 @@ class AuthorTest extends TestCase
     /**
      * @return array<array{string, ?string}>
      */
-    public function getAuthorNameDataProvider(): array
+    public static function getAuthorNameDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Creator' => [
@@ -505,7 +505,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getContributorNameDataProvider(): array
+    public static function getContributorNameDataProvider(): array
     {
         return [
             'Test Atom 0.3 Name' => [

--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -27,7 +27,7 @@ class CategoryTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function getFeedCategoryLableDataProvider(): array
+    public static function getFeedCategoryLableDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Subject' => [
@@ -395,7 +395,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getItemCategoryLableDataProvider(): array
+    public static function getItemCategoryLableDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Subject' => [

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -43,7 +43,7 @@ class EnclosureTest extends TestCase
     /**
      * @return iterable<array{string, string}>
      */
-    public function getLinkProvider(): iterable
+    public static function getLinkProvider(): iterable
     {
         yield 'Test enclosure get_link urlencoded' => [
             <<<XML
@@ -107,7 +107,7 @@ XML
     /**
      * @return iterable<array{string, int}>
      */
-    public function getEnclosuresProvider(): iterable
+    public static function getEnclosuresProvider(): iterable
     {
         yield 'Test multiple enclosures MRSS' => [
             <<<XML

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -32,7 +32,7 @@ class FileTest extends TestCase
     /**
      * @return array<array{File}>
      */
-    public function getResponseData(): iterable
+    public static function getResponseData(): iterable
     {
         yield [new FileMock('http://example.com/feed')];
     }

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -25,7 +25,7 @@ class ParserTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function chunkedDataProvider(): array
+    public static function chunkedDataProvider(): array
     {
         return [
             [

--- a/tests/Unit/HTTP/Psr7ResponseTest.php
+++ b/tests/Unit/HTTP/Psr7ResponseTest.php
@@ -20,10 +20,7 @@ class Psr7ResponseTest extends TestCase
         $this->assertInstanceOf(Response::class, new Psr7Response($this->createMock(ResponseInterface::class), '', ''));
     }
 
-    /**
-     * @return array<Psr7Response[]>
-     */
-    public function getResponseData(): iterable
+    public function createPsr7Response(): Psr7Response
     {
         $stream = $this->createMock(StreamInterface::class);
         $stream->method('__toString')->willReturn('<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />');
@@ -45,122 +42,111 @@ class Psr7ResponseTest extends TestCase
             ['X-Custom-Header', ''],
         ]);
 
-        yield [new Psr7Response(
+        return new Psr7Response(
             $response,
             'https://example.com',
             'https://example.com/feed.xml'
-        )];
+        );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetPermanentUriReturnsString(Psr7Response $response): void
+    public function testGetPermanentUriReturnsString(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             'https://example.com',
             $response->get_permanent_uri()
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetFinalRequestedUriReturnsString(Psr7Response $response): void
+    public function testGetFinalRequestedUriReturnsString(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             'https://example.com/feed.xml',
             $response->get_final_requested_uri()
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetStatusCodeReturnsInt(Psr7Response $response): void
+    public function testGetStatusCodeReturnsInt(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             200,
             $response->get_status_code()
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetHeadersReturnsArray(Psr7Response $response): void
+    public function testGetHeadersReturnsArray(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             ['content-type' => ['application/atom+xml']],
             $response->get_headers()
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testHasHeadersReturnsTrue(Psr7Response $response): void
+    public function testHasHeadersReturnsTrue(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertTrue($response->has_header('Content-Type'));
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testHasHeadersReturnsFalse(Psr7Response $response): void
+    public function testHasHeadersReturnsFalse(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertFalse($response->has_header('X-Custom-Header'));
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetHeaderReturnsArray(Psr7Response $response): void
+    public function testGetHeaderReturnsArray(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             ['application/atom+xml'],
             $response->get_header('CONTENT-TYPE')
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetHeaderReturnsEmptyArray(Psr7Response $response): void
+    public function testGetHeaderReturnsEmptyArray(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             [],
             $response->get_header('X-Custom-Header')
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetHeaderLineReturnsString(Psr7Response $response): void
+    public function testGetHeaderLineReturnsString(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             'application/atom+xml',
             $response->get_header_line('content-Type')
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetHeaderLineReturnsEmptyString(Psr7Response $response): void
+    public function testGetHeaderLineReturnsEmptyString(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             '',
             $response->get_header_line('X-Custom-Header')
         );
     }
 
-    /**
-     * @dataProvider getResponseData
-     */
-    public function testGetBodyContentReturnsString(Psr7Response $response): void
+    public function testGetBodyContentReturnsString(): void
     {
+        $response = $this->createPsr7Response();
+
         $this->assertSame(
             '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />',
             $response->get_body_content()

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -9,12 +9,9 @@ namespace SimplePie\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SimplePie\IRI;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class IRITest extends TestCase
 {
-    use ExpectPHPException;
-
     public function testNamespacedClassExists(): void
     {
         $this->assertTrue(class_exists('SimplePie\IRI'));

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -466,16 +466,16 @@ class IRITest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     'Undefined property: SimplePie\IRI::nonexistant_prop',
-                    $errstr,
+                    $errstr
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_NOTICE,
+            E_USER_NOTICE
         );
 
-        $iri->nonexistant_prop;
+        $should_fail = $iri->nonexistant_prop;
     }
 
     public function testBlankHost(): void

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -25,7 +25,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function rfc3986DataProvider(): array
+    public static function rfc3986DataProvider(): array
     {
         return [
             // Normal
@@ -107,7 +107,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string, string}>
      */
-    public function SpDataProvider(): array
+    public static function SpDataProvider(): array
     {
         return [
             ['http://a/b/c/d', 'f%0o', 'http://a/b/c/f%250o'],
@@ -151,7 +151,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function queryDataProvider(): array
+    public static function queryDataProvider(): array
     {
         return [
             ['a=b&c=d', 'http://example.com/?a=b&c=d'],
@@ -185,7 +185,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string, string}>
      */
-    public function absolutizeDataProvider(): array
+    public static function absolutizeDataProvider(): array
     {
         return [
             ['http://example.com/', 'foo/111:bar', 'http://example.com/foo/111:bar'],
@@ -215,7 +215,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function normalizationDataProvider(): array
+    public static function normalizationDataProvider(): array
     {
         return [
             ['example://a/b/c/%7Bfoo%7D', 'example://a/b/c/%7Bfoo%7D'],
@@ -320,7 +320,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function uriDataProvider(): array
+    public static function uriDataProvider(): array
     {
         return [
             ['http://example.com/%C3%A9cole', 'http://example.com/%C3%A9cole'],
@@ -341,7 +341,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function equivalenceDataProvider(): array
+    public static function equivalenceDataProvider(): array
     {
         return [
             ['http://É.com', 'http://%C3%89.com'],
@@ -361,7 +361,7 @@ class IRITest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function notEquivalenceDataProvider(): array
+    public static function notEquivalenceDataProvider(): array
     {
         return [
             ['http://example.com/foo/bar', 'http://example.com/foo%2Fbar'],

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -458,11 +458,24 @@ class IRITest extends TestCase
 
     public function testNonexistantProperty(): void
     {
-        $this->expectNotice();
-
         $iri = new IRI();
         $this->assertFalse(isset($iri->nonexistant_prop));
-        $should_fail = $iri->nonexistant_prop;
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    'Undefined property: SimplePie\IRI::nonexistant_prop',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_NOTICE,
+        );
+
+        $iri->nonexistant_prop;
     }
 
     public function testBlankHost(): void

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -26,7 +26,7 @@ class ItemTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function getContentDataProvider(): array
+    public static function getContentDataProvider(): array
     {
         return [
             'Test Atom 0.3 Content' => [
@@ -665,7 +665,7 @@ EOT
     /**
      * @return array<string, array{string, int|null}>
      */
-    public function getDateDataProvider(): array
+    public static function getDateDataProvider(): array
     {
         return [
             'Test Atom 0.3 Created' => [
@@ -1340,7 +1340,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getDescriptionDataProvider(): array
+    public static function getDescriptionDataProvider(): array
     {
         return [
             'Test Atom 0.3 Content' => [
@@ -1978,7 +1978,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getIdDataProvider(): array
+    public static function getIdDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Identifier' => [
@@ -2382,7 +2382,7 @@ EOT
     /**
      * @return array<array{string, float}>
      */
-    public function getLatitudeDataProvider(): array
+    public static function getLatitudeDataProvider(): array
     {
         return [
             'Test Atom 0.3 Geo Lat' => [
@@ -2609,7 +2609,7 @@ EOT
     /**
      * @return array<array{string, float}>
      */
-    public function getLongitudeDataProvider(): array
+    public static function getLongitudeDataProvider(): array
     {
         return [
             'Test Atom 0.3 Geo Long' => [
@@ -2836,7 +2836,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getPermalinkDataProvider(): array
+    public static function getPermalinkDataProvider(): array
     {
         return [
             'Test Atom 0.3 Enclosure' => [
@@ -3317,7 +3317,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getBaseProvider(): array
+    public static function getBaseProvider(): array
     {
         return [
             'Test item get_base xml:base' => [
@@ -3395,7 +3395,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getTitleDataProvider(): array
+    public static function getTitleDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Title' => [
@@ -4836,7 +4836,7 @@ EOT
     /**
      * @return iterable<array{string, string}>
      */
-    public function getThumbnailProvider(): iterable
+    public static function getThumbnailProvider(): iterable
     {
         yield 'Test thumbnail link sanitized' => [
             <<<XML

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -31,7 +31,7 @@ class LocatorTest extends TestCase
     /**
      * @return array<array{string}>
      */
-    public function feedmimetypes(): array
+    public static function feedmimetypes(): array
     {
         return [
             ['application/rss+xml'],
@@ -113,7 +113,7 @@ class LocatorTest extends TestCase
      *
      * @return iterable<array{File}>
      */
-    public function firefoxTestDataProvider(): iterable
+    public static function firefoxTestDataProvider(): iterable
     {
         $data = new File(dirname(__DIR__) . '/data/fftests.html');
         $data->headers = ['content-type' => 'text/html'];

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -15,12 +15,9 @@ use SimplePie\Locator;
 use SimplePie\Registry;
 use SimplePie\SimplePie;
 use SimplePie\Tests\Fixtures\FileMock;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class LocatorTest extends TestCase
 {
-    use ExpectPHPException;
-
     public function testNamespacedClassExists(): void
     {
         $this->assertTrue(class_exists('SimplePie\Locator'));

--- a/tests/Unit/MiscTest.php
+++ b/tests/Unit/MiscTest.php
@@ -43,7 +43,7 @@ class MiscTest extends TestCase
      *
      * @return array<array{string, string, string}>
      */
-    public function utf8DataProvider(): array
+    public static function utf8DataProvider(): array
     {
         return [
             ['A', 'A', 'ASCII'],
@@ -75,7 +75,7 @@ class MiscTest extends TestCase
      *
      * @return array<array{string, string, string}>
      */
-    public function utf8MbstringDataProvider(): array
+    public static function utf8MbstringDataProvider(): array
     {
         return [
             ["\xa1\xc4", "\xe2\x88\x9e", 'EUC-KR'],
@@ -103,7 +103,7 @@ class MiscTest extends TestCase
      *
      * @return array<array{string, string, string}>
      */
-    public function utf8IconvDataProvider(): array
+    public static function utf8IconvDataProvider(): array
     {
         return [
             ["\xfe\xff\x22\x1e", "\xe2\x88\x9e", 'UTF-16'],
@@ -131,7 +131,7 @@ class MiscTest extends TestCase
      *
      * @return array<array{string, string, string}>
      */
-    public function utf8IntlDataProvider(): array
+    public static function utf8IntlDataProvider(): array
     {
         return [
             ["\xfe\xff\x22\x1e", "\xe2\x88\x9e", 'UTF-16'],
@@ -159,7 +159,7 @@ class MiscTest extends TestCase
     /**
      * @return array<array{string, string, string}>
      */
-    public function utf16DataProvider(): array
+    public static function utf16DataProvider(): array
     {
         return [
             ["\x22\x1e", "\x22\x1e", 'UTF-16BE'],
@@ -193,7 +193,7 @@ class MiscTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function absolutizeUrlRFC3986DataProvider(): array
+    public static function absolutizeUrlRFC3986DataProvider(): array
     {
         // The tests enclosed within come from RFC 3986 section 5.4
         // and all share the same base URL
@@ -387,7 +387,7 @@ class MiscTest extends TestCase
     /**
      * @return array<array{string, string, string}>
      */
-    public function absolutizeUrlBugsDataProvider(): array
+    public static function absolutizeUrlBugsDataProvider(): array
     {
         return [
             'bug 274.0' => [
@@ -492,7 +492,7 @@ class MiscTest extends TestCase
     /**
      * @return array<array{string, int|false}>
      */
-    public function parseDateDataProvider(): array
+    public static function parseDateDataProvider(): array
     {
         return [
             // The tests enclosed within come from RFC 3339 section 5.8

--- a/tests/Unit/Parse/DateTest.php
+++ b/tests/Unit/Parse/DateTest.php
@@ -25,7 +25,7 @@ class DateTest extends TestCase
     /**
      * @return iterable<array{string, int}>
      */
-    public function w3cDtfDatesProvider(): iterable
+    public static function w3cDtfDatesProvider(): iterable
     {
         // The examples enclosed within come from the W3C Date and Time Formats note
         // https://www.w3.org/TR/NOTE-datetime

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -26,7 +26,7 @@ class ParserTest extends TestCase
     /**
      * @return iterable<array{string, string, array<string, mixed>}>
      */
-    public function feedProvider(): iterable
+    public static function feedProvider(): iterable
     {
         yield [
             <<<HTML

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -42,7 +42,7 @@ class RegistryTest extends TestCase
     /**
      * @return array<array{string, class-string}>
      */
-    public function getDefaultClassDataProvider(): array
+    public static function getDefaultClassDataProvider(): array
     {
         return [
             ['SimplePie\Cache', 'SimplePie\Cache'],
@@ -104,7 +104,7 @@ class RegistryTest extends TestCase
     /**
      * @return array<array{string, string, string}>
      */
-    public function getOverridingClassDataProvider(): array
+    public static function getOverridingClassDataProvider(): array
     {
         return [
             ['File',       'File',       FileMock::class],

--- a/tests/Unit/RestrictionTest.php
+++ b/tests/Unit/RestrictionTest.php
@@ -28,7 +28,7 @@ class RestrictionTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function getRelationshipDataProvider(): array
+    public static function getRelationshipDataProvider(): array
     {
         return [
             'iTunesRSS Channel Block Test RSS 2.0' => [

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -47,7 +47,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function sanitizeURLDataProvider(): array
+    public static function sanitizeURLDataProvider(): array
     {
         return [
             'simple absolute valid a href, resolved' => [

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -17,12 +17,9 @@ use SimplePie\Tests\Fixtures\Cache\NewCacheMock;
 use SimplePie\Tests\Fixtures\Exception\SuccessException;
 use SimplePie\Tests\Fixtures\FileMock;
 use SimplePie\Tests\Fixtures\FileWithRedirectMock;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class SimplePieTest extends TestCase
 {
-    use ExpectPHPException;
-
     public function testNamespacedClassExists(): void
     {
         $this->assertTrue(class_exists('SimplePie\SimplePie'));

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -270,7 +270,7 @@ class SimplePieTest extends TestCase
     /**
      * @return array<array{string, string}>
      */
-    public function getCopyrightDataProvider(): array
+    public static function getCopyrightDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0' => [
@@ -583,7 +583,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getDescriptionDataProvider(): array
+    public static function getDescriptionDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Description' => [
@@ -994,7 +994,7 @@ EOT
     /**
      * @return array<array{string, int|null}>
      */
-    public function getImageHeightDataProvider(): array
+    public static function getImageHeightDataProvider(): array
     {
         return [
             'Test Atom 1.0 Icon Default' => [
@@ -1291,7 +1291,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getImageLinkDataProvider(): array
+    public static function getImageLinkDataProvider(): array
     {
         return [
             'Test RSS 0.90 Link' => [
@@ -1388,7 +1388,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getImageTitleDataProvider(): array
+    public static function getImageTitleDataProvider(): array
     {
         return [
             'Test RSS 0.90 DC 1.0 Title' => [
@@ -1635,7 +1635,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getImageUrlDataProvider(): array
+    public static function getImageUrlDataProvider(): array
     {
         return [
             'Test Atom 1.0 Icon' => [
@@ -1884,7 +1884,7 @@ EOT
     /**
      * @return array<array{string, int|null}>
      */
-    public function getImageWidthDataProvider(): array
+    public static function getImageWidthDataProvider(): array
     {
         return [
             'Test Atom 1.0 Icon Default' => [
@@ -2186,7 +2186,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getLanguageDataProvider(): array
+    public static function getLanguageDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Language' => [
@@ -2441,7 +2441,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getLinkDataProvider(): array
+    public static function getLinkDataProvider(): array
     {
         return [
             'Test Atom 0.3 Link' => [
@@ -2709,7 +2709,7 @@ EOT
     /**
      * @return array<array{string, string}>
      */
-    public function getTitleDataProvider(): array
+    public static function getTitleDataProvider(): array
     {
         return [
             'Test Atom 0.3 DC 1.0 Title' => [

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -232,13 +232,13 @@ class SimplePieTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.',
-                    $errstr,
+                    $errstr
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED,
+            E_USER_DEPRECATED
         );
 
         $feed->set_cache_class(LegacyCacheMock::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,4 +6,3 @@ declare(strict_types=1);
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 require_once dirname(__DIR__) . '/autoloader.php';
-require_once dirname(__DIR__) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';


### PR DESCRIPTION
This PR allows us to run the tests with PHPUnit 10. The tests use `phpunit/phpunit` directly and obsolete the usage of `yoast/phpunit-polyfills`.

This PR adds a check with `is_readable()` for reading local files and should solve the discussion from https://github.com/simplepie/simplepie/pull/826#discussion_r1142162502.

refs #822