### PR TITLE
refactor: drop call to xml_set_object()

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -133,7 +133,6 @@ class Parser implements RegistryAware
             $xml = xml_parser_create_ns($this->encoding, $this->separator);
             xml_parser_set_option($xml, XML_OPTION_SKIP_WHITE, 1);
             xml_parser_set_option($xml, XML_OPTION_CASE_FOLDING, 0);
-            xml_set_object($xml, $this);
             xml_set_character_data_handler($xml, [$this, 'cdata']);
             xml_set_element_handler($xml, [$this, 'tag_open'], [$this, 'tag_close']);
 


### PR DESCRIPTION
The xml_set_X_handler() functions already pass in standard callables.

Related to https://github.com/php/php-src/pull/12340