### PR TITLE
ci: Fix php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,7 +14,6 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         'no_alias_functions' => true,
         'void_return' => false,
-        'phpdoc_to_param_type' => true,
         '@PHPUnit84Migration:risky' => true,
     ])
     ->setRiskyAllowed(true)

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3355,7 +3355,7 @@ class SimplePie
                 if ($arg instanceof SimplePie) {
                     $items = array_merge($items, $arg->get_items(0, $limit));
 
-                // @phpstan-ignore-next-line Enforce PHPDoc type.
+                    // @phpstan-ignore-next-line Enforce PHPDoc type.
                 } else {
                     trigger_error('Arguments must be SimplePie objects', E_USER_WARNING);
                 }


### PR DESCRIPTION
phpdoc_to_param_type would add union and mixed types, which are not supported by our target PHP version.
