### PR TITLE
Fix PHPStan for PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.8",
         "mf2/mf2": "^0.5.0",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.11",
         "phpunit/phpunit": "^8 || ^9 || ^10",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -145,7 +145,7 @@ class Parser implements RegistryAware
                 do {
                     $stream_data = fread($stream, 1048576);
                     // NB: At some point between PHP 7.3 and 7.4, the documented signature for `fread()` has changed
-                    // from returning `string` to returning `string|false`, and in older versions, it used to be `string|null`,
+                    // from returning `string` to returning `string|false`,
                     // hence the falsy check:
                     if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -144,7 +144,7 @@ class Parser implements RegistryAware
                 //Parse by chunks not to use too much memory
                 do {
                     $stream_data = fread($stream, 1048576);
-                    // NB: At some point between PHP 7.3 and 7.4, the documented signature for `fread()` has changed
+                    // NB: At some point between PHP 7.3 and 7.4, the signature for `fread()` has changed
                     // from returning `string` to returning `string|false`, hence the falsy check:
                     if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -146,7 +146,7 @@ class Parser implements RegistryAware
                     $stream_data = fread($stream, 1048576);
                     // NB: At some point between PHP 7.3 and 7.4, the documented signature for `fread()` has changed
                     // from returning `string` to returning `string|false`, and in older versions, it used to be `string|null`,
-                    // hense the falsy check:
+                    // hence the falsy check:
                     if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);
                         $this->error_string = xml_error_string($this->error_code);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -144,6 +144,9 @@ class Parser implements RegistryAware
                 //Parse by chunks not to use too much memory
                 do {
                     $stream_data = fread($stream, 1048576);
+                    // NB: At some point between PHP 7.3 and 7.4, the documented signature for `fread()` has changed
+                    // from returning `string` to returning `string|false`, and in older versions, it used to be `string|null`,
+                    // hense the falsy check:
                     if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);
                         $this->error_string = xml_error_string($this->error_code);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -145,8 +145,7 @@ class Parser implements RegistryAware
                 do {
                     $stream_data = fread($stream, 1048576);
                     // NB: At some point between PHP 7.3 and 7.4, the documented signature for `fread()` has changed
-                    // from returning `string` to returning `string|false`,
-                    // hence the falsy check:
+                    // from returning `string` to returning `string|false`, hence the falsy check:
                     if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);
                         $this->error_string = xml_error_string($this->error_code);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -144,7 +144,7 @@ class Parser implements RegistryAware
                 //Parse by chunks not to use too much memory
                 do {
                     $stream_data = fread($stream, 1048576);
-                    if (!xml_parse($xml, $stream_data === false ? '' : $stream_data, feof($stream))) {
+                    if (!xml_parse($xml, $stream_data == false ? '' : $stream_data, feof($stream))) {
                         $this->error_code = xml_get_error_code($xml);
                         $this->error_string = xml_error_string($this->error_code);
                         $return = false;


### PR DESCRIPTION
The signature of `fread()` has changed from PHP 7.3 to 7.4
