### PR TITLE
ci: Add PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php:
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
 
     name: "PHP: ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code
@@ -63,12 +71,12 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.3)"
-        if: ${{ matrix.php < '8.3' }}
+      - name: "Install Composer dependencies (PHP < 8.4)"
+        if: ${{ matrix.php < '8.4' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: "Install Composer dependencies (PHP 8.3)"
-        if: ${{ matrix.php >= '8.3' }}
+      - name: "Install Composer dependencies (PHP 8.4)"
+        if: ${{ matrix.php >= '8.4' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs


### PR DESCRIPTION
PHP 8.4 is in beta, with final version scheduled for November so it is time to start testing it.

Add it to CI matrix, allowing failures for now. Do not allow failures for PHP 8.3 since that has been stable for ages.
