### PR TITLE
Check Date parser extensions using reflection

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -639,7 +639,7 @@ class Item implements RegistryAware
 
             if (!empty($this->data['date']['raw'])) {
                 $parser = $this->registry->call(Parse\Date::class, 'get');
-                $this->data['date']['parsed'] = $parser->parse($this->data['date']['raw']) ?: null;
+                $this->data['date']['parsed'] = $parser->parse($this->data['date']['raw']);
             } else {
                 $this->data['date'] = null;
             }

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1730,7 +1730,7 @@ class Misc
     }
 
     /**
-     * @return int|bool
+     * @return ?int
      */
     public static function parse_date(string $dt)
     {


### PR DESCRIPTION
We cannot statically ensure date parser extension points are properly typed so let’s check that dynamically using reflection.
Alternately, we could create a PHPStan extension but that would add complexity and an at that point, we would probably want to abandon extending using inheritance altogether.

This is a BC break:

- `date_` methods now have `?int` return type hint (previously, they only had PHPDoc `int|false`).
  - This will only be an issue if a user extends the class and overrides one of the built-in methods.
- All `date_` methods must have proscribed type signature.
- `Parser\Date` properties were made private (previously the visibility was only hinted by `@access`).
  - Since we store just method names in those properties, we cannot add a type hint that would limit them to proper callables. We can only check them in methods for manipulating the properties.
  - Fortunately, there should be little need for users to manipulate the properties directly, as the class automatically discovers all suitably named methods.

TODO: Maybe revert the return type hint BC break in case someone overrides those methods. And we only changed error value from `false` to `null` to allow putting it into return type hint on older PHP versions that do not support type unions so that could go back too.
