### PR TITLE
Fix CI for PHPStan 1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.8",
         "mf2/mf2": "^0.5.0",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "~1.12.2",
         "phpunit/phpunit": "^8 || ^9 || ^10",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -301,12 +301,10 @@ class IRI
             if ($match[1] === '') {
                 $match['scheme'] = null;
             }
-            if (!isset($match[3]) || $match[3] === '') {
+            if ($match[3] === '') {
                 $match['authority'] = null;
             }
-            if (!isset($match[5])) {
-                $match['path'] = '';
-            }
+            $match['path'] = '';
             if (!isset($match[6]) || $match[6] === '') {
                 $match['query'] = null;
             }

--- a/src/IRI.php
+++ b/src/IRI.php
@@ -304,7 +304,6 @@ class IRI
             if ($match[3] === '') {
                 $match['authority'] = null;
             }
-            $match['path'] = '';
             if (!isset($match[6]) || $match[6] === '') {
                 $match['query'] = null;
             }


### PR DESCRIPTION
CI was broken due to not pinning `composer.lock` AND allowing updates at `1.x.x` level, which may contain breaking changes, e.g. for PHPStan.

```
------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/IRI.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  :304   Offset 3 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string, 4: string, path: string, ...} in isset()
         always exists and is not nullable.
  :307   Offset 5 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}
         in isset() always exists and is not nullable.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
