### PR TITLE
Add phpcs.xml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ indent_style = space
 [*.{yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[*.xml]
+indent_style = tab

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SimplePie">
+	<arg name="extensions" value="php"/>
+	<exclude-pattern>./.git/</exclude-pattern>
+	<exclude-pattern>./compatibility_test/</exclude-pattern>
+	<exclude-pattern>./vendor/</exclude-pattern>
+	<rule ref="PSR12">
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+		<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+		<exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+	</rule>
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="165"/>
+			<property name="absoluteLineLimit" value="400"/>
+		</properties>
+	</rule>
+</ruleset>


### PR DESCRIPTION
(I was tired of seeing red errors everywhere when opening SimplePie)
![image](https://github.com/user-attachments/assets/f5e58b03-eefc-4e9f-9abf-6b959efeae5b)

The current `.php-cs-fixer.dist.php` does not seem to do much when it comes to live feedback, so consider adding a standard configuration file for PHPCS so that it works with the correct code style convention in IDEs
https://github.com/PHPCSStandards/PHP_CodeSniffer
Example of extension for VSCode https://marketplace.visualstudio.com/items?itemName=ValeryanM.vscode-phpsab

With that config, there are still many PSR12 errors, but at least most are gone. By the way, `phpcbf` could automatically fix many of those (for instance missing spaces in string concatenations `$a.'b'`). I can gladly send a PR if there is interest.
