### PR TITLE
PHP 8.4 | Fix passing E_USER_ERROR to trigger_error() x 3

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -49,7 +49,7 @@ spl_autoload_register(array(new SimplePie_Autoloader(), 'autoload'));
 
 if (!class_exists('SimplePie'))
 {
-	trigger_error('Autoloader not registered properly', E_USER_ERROR);
+	exit('Autoloader not registered properly');
 }
 
 /**

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -142,7 +142,7 @@ class Gzdecode
      */
     public function __set(string $name, $value)
     {
-        trigger_error("Cannot write property $name", E_USER_ERROR);
+        throw new Exception("Cannot write property $name");
     }
 
     /**

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -3297,7 +3297,7 @@ class SimplePie
         $trace = debug_backtrace();
         $file = $trace[0]['file'];
         $line = $trace[0]['line'];
-        trigger_error("Call to undefined method $class::$method() in $file on line $line", E_USER_ERROR);
+        throw new SimplePieException("Call to undefined method $class::$method() in $file on line $line");
     }
 
     /**

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -671,8 +671,7 @@ class SimplePie
     public function __construct()
     {
         if (version_compare(PHP_VERSION, '7.2', '<')) {
-            trigger_error('Please upgrade to PHP 7.2 or newer.');
-            die();
+            exit('Please upgrade to PHP 7.2 or newer.');
         }
 
         $this->set_useragent();


### PR DESCRIPTION
Notes:
* Each change is in a separate commit as each has its own reasoning and decision point.
* For the two calls changed to exceptions, it could be considered to introduce SimplePie native dedicated exceptions. This is a design choice for the maintainers of SimplePie. This PR simply fixes the PHP 8.4 compatibility issue.


---

### PHP 8.4 | Fix passing E_USER_ERROR to trigger_error() [1]

PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

This commit fixes an instance found in the autoloader by changing it to a call to `exit`, which considering it is an error related to the autoloader not being registered seems the most appropriate.

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

### PHP 8.4 | Fix passing E_USER_ERROR to trigger_error() [2]

PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

This commit fixes another instance of this issue. In this case, the call to `trigger_error()` is replaced by throwing a generic `SimplePie\Exception` for the same.

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

### PHP 8.4 | Fix passing E_USER_ERROR to trigger_error() [3]

PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

This commit fixes the last instance of this issue. In this case, the call to `trigger_error()` is also replaced by throwing a generic `SimplePie\Exception` for the same.

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

### QA: replace another call to trigger_error() with exit

... the call to `trigger_error()` would now throw a PHP notice, but with the `die()` after it, with still kill the program anyhow, so we may as well, exit with the error message and remove the `trigger_error()` function call completely.