### PR TITLE
Gzdecode: Deprecate our gzip implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use `idn_to_ascii` function instead of `idna_convert` library (requires `intl` extension or a [polyfill](https://github.com/symfony/polyfill-intl-idn)) by @jtojnar in [#785](https://github.com/simplepie/simplepie/pull/785)
+- Use native `gzdecode` function instead of internal PHP implementation by @jtojnar in [#882](https://github.com/simplepie/simplepie/pull/882)
 
 ### Removed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The method `SimplePie\SimplePie::set_file()` is deprecated, use `SimplePie\SimplePie::set_http_client()` or `SimplePie\SimplePie::set_raw_data()` instead
 - The method `SimplePie\Sanitize::pass_file_data()` is deprecated, use `SimplePie\Sanitize::set_http_client()` instead
 - Passing multiple URLs to `SimplePie\SimplePie::set_feed_url()` is deprecated. You can create separate `SimplePie` instance per feed and then use `SimplePie::merge_items()` to get a single list of items. ([#795](https://github.com/simplepie/simplepie/pull/795))
+- The `SimplePie\Gzdecode` class is deprecated. You can use native [`gzdecode`](https://www.php.net/manual/en/function.gzdecode.php) function by @jtojnar in [#882](https://github.com/simplepie/simplepie/pull/882)
 
 ## [1.8.0](https://github.com/simplepie/simplepie/compare/1.7.0...1.8.0) - 2023-01-20
 

--- a/src/File.php
+++ b/src/File.php
@@ -228,12 +228,11 @@ class File implements Response
                                 switch (strtolower(trim($contentEncodingHeader, "\x09\x0A\x0D\x20"))) {
                                     case 'gzip':
                                     case 'x-gzip':
-                                        $decoder = new \SimplePie\Gzdecode($this->body);
-                                        if (!$decoder->parse()) {
+                                        if (($decompressed = gzdecode($this->body)) === false) {
                                             $this->error = 'Unable to decode HTTP "gzip" stream';
                                             $this->success = false;
                                         } else {
-                                            $this->body = trim($decoder->data);
+                                            $this->body = trim($decompressed);
                                         }
                                         break;
 
@@ -242,7 +241,7 @@ class File implements Response
                                             $this->body = $decompressed;
                                         } elseif (($decompressed = gzuncompress($this->body)) !== false) {
                                             $this->body = $decompressed;
-                                        } elseif (function_exists('gzdecode') && ($decompressed = gzdecode($this->body)) !== false) {
+                                        } elseif (($decompressed = gzdecode($this->body)) !== false) {
                                             $this->body = $decompressed;
                                         } else {
                                             $this->error = 'Unable to decode HTTP "deflate" stream';

--- a/src/Gzdecode.php
+++ b/src/Gzdecode.php
@@ -11,6 +11,8 @@ namespace SimplePie;
  * Decode 'gzip' encoded HTTP data
  *
  * @link http://www.gzip.org/format.txt
+ * @link https://www.php.net/manual/en/function.gzdecode.php
+ * @deprecated since SimplePie 1.9.0, use `gzdecode` function instead.
  */
 class Gzdecode
 {


### PR DESCRIPTION
PHP supports it natively since 5.4.

acaaa76ed6ca095cd6cf236cc1bef03cc3a41578 also started to use it, presumably to fix sites that were incorrectly declaring `deflate` method when they were using `gzip`.

And since we require PHP 7.2, and the zlib extension is already mandatory for the `gzinflate` and `gzuncompress` functions, let’s also remove the `funcion_exists` check.