### PR TITLE
Fix cache_expiration_time

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1937,6 +1937,7 @@ class SimplePie
                             // Set raw_data to false here too, to signify that the cache
                             // is still valid.
                             $this->raw_data = false;
+                            $this->data['cache_expiration_time'] = $this->cache_duration + time();
                             $cache->set_data($cacheKey, $this->data, $this->cache_duration);
 
                             return true;

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1901,7 +1901,7 @@ class SimplePie
                     $this->data = [];
                 }
                 // Check if the cache has been updated
-                elseif (isset($this->data['cache_expiration_time']) && $this->data['cache_expiration_time'] > time()) {
+                elseif (empty($this->data['cache_expiration_time']) || $this->data['cache_expiration_time'] < time()) {
                     // Want to know if we tried to send last-modified and/or etag headers
                     // when requesting this file. (Note that it's up to the file to
                     // support this, but we don't always send the headers either.)
@@ -1925,6 +1925,7 @@ class SimplePie
                             $this->status_code = 0;
 
                             if ($this->force_cache_fallback) {
+                                $this->data['cache_expiration_time'] = $this->cache_duration + time();
                                 $cache->set_data($cacheKey, $this->data, $this->cache_duration);
 
                                 return true;

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1900,7 +1900,7 @@ class SimplePie
                     $this->data = [];
                 }
                 // Check if the cache has been updated
-                elseif (empty($this->data['cache_expiration_time']) || $this->data['cache_expiration_time'] < time()) {
+                elseif (!isset($this->data['cache_expiration_time']) || $this->data['cache_expiration_time'] < time()) {
                     // Want to know if we tried to send last-modified and/or etag headers
                     // when requesting this file. (Note that it's up to the file to
                     // support this, but we don't always send the headers either.)

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -120,7 +120,7 @@ class CachingTest extends TestCase
      */
     public static function provideSavedCacheData(): array
     {
-        $defaultMtime = time();
+        $defaultMtime = time() - 1; // -1 to account for tests running within the same second
         $defaultExpirationTime = $defaultMtime + 3600;
 
         $expectDefaultDataWritten = [
@@ -246,10 +246,10 @@ class CachingTest extends TestCase
             [CacheInterface::class, $currentlyCachedDataWithNonFeedUrl,     $expectDataWithNewFeedUrl, $defaultMtime],
             // Check if the cache has been updated
             [Base::class,           $currentlyCachedDataIsUpdated,          $expectDefaultDataWritten, $defaultMtime],
-            [CacheInterface::class, $currentlyCachedDataIsUpdated,          $expectDefaultDataWritten, $defaultMtime],
+            [CacheInterface::class, $currentlyCachedDataIsUpdated,          $expectNoDataWritten,      $defaultMtime],
             // If the cache is still valid, just return true
             [Base::class,           $currentlyCachedDataIsValid,            $expectDefaultDataWritten, $defaultMtime],
-            [CacheInterface::class, $currentlyCachedDataIsValid,            $expectNoDataWritten,      $defaultMtime],
+            [CacheInterface::class, $currentlyCachedDataIsValid,            $expectDefaultDataWritten, $defaultMtime],
         ];
     }
 }


### PR DESCRIPTION
Fix cache handling logic and associated tests. 
fix https://github.com/simplepie/simplepie/issues/830 ([BUG] Cache constantly updating).
Note: the default cache implementation (legacy file cache) is still broken for allowing HTTP 304.
Replaces https://github.com/simplepie/simplepie/pull/846
