### PR TITLE
[1.8 backport] PHP 8.4 | Fix implicitly nullable parameters

### DIFF
--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -132,7 +132,7 @@ class Sanitize implements RegistryAware
         $this->registry = $registry;
     }
 
-    public function pass_cache_data($enable_cache = true, $cache_location = './cache', $cache_name_function = 'md5', $cache_class = 'SimplePie\Cache', DataCache $cache = null)
+    public function pass_cache_data($enable_cache = true, $cache_location = './cache', $cache_name_function = 'md5', $cache_class = 'SimplePie\Cache', ?DataCache $cache = null)
     {
         if (isset($enable_cache)) {
             $this->enable_cache = (bool) $enable_cache;


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

Includes updating the documentation to match.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
(cherry picked from commit c8c0e4c4f1e938436de2883bed77f2a623a12421)
