### PR TITLE
IRI: Simplify parse_iri()

### DIFF
--- a/src/IRI.php
+++ b/src/IRI.php
@@ -297,19 +297,10 @@ class IRI
     protected function parse_iri(string $iri)
     {
         $iri = trim($iri, "\x20\x09\x0A\x0C\x0D");
-        if (preg_match('/^((?P<scheme>[^:\/?#]+):)?(\/\/(?P<authority>[^\/?#]*))?(?P<path>[^?#]*)(\?(?P<query>[^#]*))?(#(?P<fragment>.*))?$/', $iri, $match)) {
-            if ($match[1] === '') {
-                $match['scheme'] = null;
-            }
-            if ($match[3] === '') {
-                $match['authority'] = null;
-            }
-            if (!isset($match[6]) || $match[6] === '') {
-                $match['query'] = null;
-            }
-            if (!isset($match[8]) || $match[8] === '') {
-                $match['fragment'] = null;
-            }
+        if (preg_match('/^(?:(?P<scheme>[^:\/?#]+):)?(:?\/\/(?P<authority>[^\/?#]*))?(?P<path>[^?#]*)(?:\?(?P<query>[^#]*))?(?:#(?P<fragment>.*))?$/', $iri, $match, \PREG_UNMATCHED_AS_NULL)) {
+            // TODO: Remove once we require PHP ≥ 7.4.
+            $match['query'] = $match['query'] ?? null;
+            $match['fragment'] = $match['fragment'] ?? null;
             return $match;
         }
 


### PR DESCRIPTION
When a regex contains a capture group within another capture group followed by `?`,
and the outer group is not matched, the resulting matched text for both groups will be an empty string. (1)
Or, if there are no further matched capture groups, the indices for the groups will be simply omitted from the `$matches` array. (2)

We want missing components of the URI to be `null` so we had a conditionals for the aforementioned matches.

As of PHP 7.2, we can just use `PREG_UNMATCHED_AS_NULL` to get `null`s in the case (1):
https://www.php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-parameters

If we raised minimum PHP version to 7.4, we would not even need the `isset` to handle (2) because from that version onward, the flag also disables the omission of tail unmatched groups:
https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.pcre

Switch the optional outer capture groups (1, 3, 6 and 8) to anonymous ones now that we are no longer using them for anything.

This is follow up to https://github.com/simplepie/simplepie/pull/878 and should fix the type issue in https://github.com/simplepie/simplepie/pull/857