### PR TITLE
[1.8] Fix locator with website missing Content-Type header

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1831,7 +1831,7 @@ class SimplePie
 
             if (!$locate->is_feed($file)) {
                 $copyStatusCode = $file->status_code;
-                $copyContentType = $file->headers['content-type'];
+                $copyContentType = $file->headers['content-type'] ?? '';
                 try {
                     $microformats = false;
                     if (class_exists('DOMXpath') && function_exists('Mf2\parse')) {


### PR DESCRIPTION
On master, this has been fixed by 8fc95caf3c0f944191ca77fa57c70db034f88b8f – `File::get_header_line()` returns an empty string for a non-existent header.

Given that the value is only used for error message, let’s do the same.

Fixes: https://github.com/simplepie/simplepie/issues/885
