### PR TITLE
PHPStan: Add extension for typing Registry::call()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "SimplePieUtils\\": "utils/",
             "SimplePie\\Tests\\Fixtures\\": "tests/Fixtures",
             "SimplePie\\Tests\\Unit\\": "tests/Unit"
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -65,3 +65,6 @@ parameters:
             message: '(^Access to an undefined property XMLReader::\$\w+\.$)'
             # Only occurs on PHP ≥ 8.2
             reportUnmatched: false
+
+includes:
+    - utils/PHPStan/extension.neon

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1858,7 +1858,7 @@ class Misc
 
     /**
      * @param array<string, array<string, string>> $attribs
-     * @return int
+     * @return int-mask-of<SimplePie::CONSTRUCT_*>
      */
     public static function atom_10_construct_type(array $attribs)
     {
@@ -1882,7 +1882,7 @@ class Misc
 
     /**
      * @param array<string, array<string, string>> $attribs
-     * @return int
+     * @return int-mask-of<SimplePie::CONSTRUCT_*>
      */
     public static function atom_10_content_construct_type(array $attribs)
     {

--- a/utils/PHPStan/README.md
+++ b/utils/PHPStan/README.md
@@ -1,0 +1,7 @@
+# SimplePie PHPStan extension
+
+**This extension is considered unstable, use at your own risk.**
+
+It provides:
+
+- Correct return type for `Registry::call()`

--- a/utils/PHPStan/RegistryCallMethodReturnTypeExtension.php
+++ b/utils/PHPStan/RegistryCallMethodReturnTypeExtension.php
@@ -1,0 +1,101 @@
+<?php
+
+// SPDX-FileCopyrightText: 2024 Jan Tojnar
+// SPDX-License-Identifier: BSD-3-Clause
+
+declare(strict_types=1);
+
+namespace SimplePieUtils\PHPStan;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Reflection\ReflectionProvider;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+
+/**
+ * Fixes return type for `Registry::call()` to match the called method.
+ */
+class RegistryCallMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /** @var ReflectionProvider */
+    private $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function getClass(): string
+    {
+        return 'SimplePie\Registry';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'call';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        // The method will be called as `$registry->call($className, $methodName, $arguments)`.
+        $args = $methodCall->getArgs();
+
+        if (count($args) < 2) {
+            // Not enough arguments to determine the return type.
+            return new MixedType();
+        }
+
+        $classNameArg = $args[0]->value;
+        $methodNameArg = $args[1]->value;
+        $argumentsArg = $args[2]->value ?? null;
+
+        $classType = $scope->getType($classNameArg);
+        $methodType = $scope->getType($methodNameArg);
+
+        if (!$classType  instanceof ConstantStringType || !$methodType instanceof ConstantStringType) {
+            return new MixedType();
+        }
+
+        $className = $classType->getValue();
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return new MixedType();
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $methodName = $methodType->getValue();
+        if (!$classReflection->hasMethod($methodName)) {
+            return new MixedType();
+        }
+
+        $methodReflection = $classReflection->getMethod($methodName, $scope);
+
+        $argumentTypes = [];
+        if ($argumentsArg !== null) {
+            $argumentsType = $scope->getType($argumentsArg);
+
+            if ($argumentsType instanceof ConstantArrayType) {
+                $argumentTypes = $argumentsType->getValueTypes();
+            } elseif ($argumentsType instanceof ArrayType) {
+                $argumentTypes = [$argumentsType->getItemType()];
+            } else {
+                return new MixedType();
+            }
+        }
+
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromTypes(
+            $argumentTypes,
+            $methodReflection->getVariants(),
+            false
+        );
+
+        return $parametersAcceptor->getReturnType();
+    }
+}

--- a/utils/PHPStan/extension.neon
+++ b/utils/PHPStan/extension.neon
@@ -1,0 +1,6 @@
+
+services:
+    -
+        class: SimplePieUtils\PHPStan\RegistryCallMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension


### PR DESCRIPTION
`Registry::call()` is widely used in SimplePie to allow extensibility. Unfortunately, the pattern hides the actual method from PHPStan so it cannot determine the return value type, and there is no annotation we can add to make it work. , This results in an inadequate analysis.

Thankfully, most cases allow us to determine the method statically so we can create a PHPStan extension doing just that.

The extension might be useful for SimplePie consumers so let’s expose it in `composer.json`.

We may want to add more type checking extensions in the future.