### PR TITLE
SimplePie: Fix encode argument of strip_htmltags

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1483,7 +1483,7 @@ class SimplePie
         }
         $this->sanitize->strip_htmltags($tags);
         if ($encode !== null) {
-            $this->sanitize->encode_instead_of_strip($tags);
+            $this->sanitize->encode_instead_of_strip($encode);
         }
     }
 


### PR DESCRIPTION
Looks like this has been incorrect since 5bf1814b6943be7708cf7689f01c1c6aeb901afe

Revealed by [PHPStan level 8](https://github.com/simplepie/simplepie/pull/857).
