### PR TITLE
[1.8 backport] Composer: prevent a lock file from being created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     },
     "config": {
         "bin-dir": "bin",
+        "lock": false,
         "sort-packages": true
     },
     "scripts": {


### PR DESCRIPTION
Backport of #887 into 1.8 branch.

refs #886 