### PR TITLE
[1.8 backport] Add docs about PSR-16 caching support in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,22 @@ Requirements
 * PCRE support
 
 
+PSR-16: Caching support
+--------------
+
+Since SimplePie 1.8.0 you can use the [PSR-16](https://www.php-fig.org/psr/psr-16/) cache from
+[Symfony](https://symfony.com/doc/current/components/cache.html)
+or [every other implementation](https://packagist.org/providers/psr/simple-cache-implementation).
+
+```php
+$simplepie = new \SimplePie\SimplePie();
+$simplepie->set_cache(
+    new \Symfony\Component\Cache\Psr16Cache(
+        new \Symfony\Component\Cache\Adapter\FilesystemAdapter()
+    ),
+);
+```
+
 What comes in the package?
 --------------------------
 1. `src/` - SimplePie classes for use with the autoloader


### PR DESCRIPTION
Support for PSR-16 cache via `$simplepie->set_cache($psr16)` was added in SimplePie 1.8.0, but the docs was updated in https://github.com/simplepie/simplepie/commit/b36e93456331fccae52fe26b9a15a04f4df37d8a only on the master branch.

This PR adds the docs about the PSR-18 cache in the 1.8 branch.