### PR TITLE
[1.8 backport] SimplePie: Fix encode argument of strip_htmltags

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1373,7 +1373,7 @@ class SimplePie
         }
         $this->sanitize->strip_htmltags($tags);
         if ($encode !== null) {
-            $this->sanitize->encode_instead_of_strip($tags);
+            $this->sanitize->encode_instead_of_strip($encode);
         }
     }
 


### PR DESCRIPTION
Backport of #894 into 1.8 branch.

refs #886
