### PR TITLE
Misc: Deprecate unused functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SimplePie\Misc::element_implode()`
   - `SimplePie\Misc::percent_encoding_normalization()`
   - `SimplePie\Misc::strip_comments()`
+  - `SimplePie\Misc::uncomment_rfc822()`
 
   If you need any of them, consider copying the function to your codebase. (by @jtojnar in [#899](https://github.com/simplepie/simplepie/pull/899))
 - The method `SimplePie\SimplePie::set_file()` is deprecated, use `SimplePie\SimplePie::set_http_client()` or `SimplePie\SimplePie::set_raw_data()` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- The method `SimplePie\Misc::percent_encoding_normalization()` is deprecated. If you need it, consider copying the function to your codebase. (by @jtojnar in [#895](https://github.com/simplepie/simplepie/pull/895))
+- The following `SimplePie\Misc` methods are deprecated without replacement:
+  - `SimplePie\Misc::element_implode()`
+  - `SimplePie\Misc::percent_encoding_normalization()`
+
+  If you need any of them, consider copying the function to your codebase. (by @jtojnar in [#899](https://github.com/simplepie/simplepie/pull/899))
 - The method `SimplePie\SimplePie::set_file()` is deprecated, use `SimplePie\SimplePie::set_http_client()` or `SimplePie\SimplePie::set_raw_data()` instead
 - The method `SimplePie\Sanitize::pass_file_data()` is deprecated, use `SimplePie\Sanitize::set_http_client()` instead
 - Passing multiple URLs to `SimplePie\SimplePie::set_feed_url()` is deprecated. You can create separate `SimplePie` instance per feed and then use `SimplePie::merge_items()` to get a single list of items. ([#795](https://github.com/simplepie/simplepie/pull/795))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The following `SimplePie\Misc` methods are deprecated without replacement:
   - `SimplePie\Misc::element_implode()`
+  - `SimplePie\Misc::parse_str()`
   - `SimplePie\Misc::percent_encoding_normalization()`
   - `SimplePie\Misc::strip_comments()`
   - `SimplePie\Misc::uncomment_rfc822()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- The method `SimplePie\Misc::percent_encoding_normalization()` is deprecated. If you need it, consider copying the function to your codebase. (by @jtojnar in [#895](https://github.com/simplepie/simplepie/pull/895))
 - The method `SimplePie\SimplePie::set_file()` is deprecated, use `SimplePie\SimplePie::set_http_client()` or `SimplePie\SimplePie::set_raw_data()` instead
 - The method `SimplePie\Sanitize::pass_file_data()` is deprecated, use `SimplePie\Sanitize::set_http_client()` instead
 - Passing multiple URLs to `SimplePie\SimplePie::set_feed_url()` is deprecated. You can create separate `SimplePie` instance per feed and then use `SimplePie::merge_items()` to get a single list of items. ([#795](https://github.com/simplepie/simplepie/pull/795))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following `SimplePie\Misc` methods are deprecated without replacement:
   - `SimplePie\Misc::element_implode()`
   - `SimplePie\Misc::percent_encoding_normalization()`
+  - `SimplePie\Misc::strip_comments()`
 
   If you need any of them, consider copying the function to your codebase. (by @jtojnar in [#899](https://github.com/simplepie/simplepie/pull/899))
 - The method `SimplePie\SimplePie::set_file()` is deprecated, use `SimplePie\SimplePie::set_http_client()` or `SimplePie\SimplePie::set_raw_data()` instead

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1716,11 +1716,14 @@ class Misc
     /**
      * Strip HTML comments
      *
+     * @deprecated since SimplePie 1.9.0. If you need it, you can copy the function to your codebase. But you should consider using `DOMDocument` for any DOM wrangling.
      * @param string $data Data to strip comments from
      * @return string Comment stripped string
      */
     public static function strip_comments(string $data)
     {
+        // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.9.'), \E_USER_DEPRECATED);
+
         $output = '';
         while (($start = strpos($data, '<!--')) !== false) {
             $output .= substr($data, 0, $start);

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -105,11 +105,14 @@ class Misc
     }
 
     /**
+     * @deprecated since SimplePie 1.9.0. If you need it, you can copy the function to your codebase. But you should consider using `DOMDocument` for any DOM wrangling.
      * @param array{tag: string, self_closing: bool, attribs: array<string, array{data: string}>, content: string} $element
      * @return string
      */
     public static function element_implode(array $element)
     {
+        // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.9.'), \E_USER_DEPRECATED);
+
         $full = "<{$element['tag']}";
         foreach ($element['attribs'] as $key => $value) {
             $key = strtolower($key);

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1763,11 +1763,14 @@ class Misc
     /**
      * Remove RFC822 comments
      *
+     * @deprecated since SimplePie 1.9.0. If you need it, consider copying the function to your codebase.
      * @param string $string Data to strip comments from
      * @return string Comment stripped string
      */
     public static function uncomment_rfc822(string $string)
     {
+        // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.9.'), \E_USER_DEPRECATED);
+
         $position = 0;
         $length = strlen($string);
         $depth = 0;

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1968,12 +1968,15 @@ class Misc
      * Returns an associative array of name/value pairs, where the value is an
      * array of values that have used the same name
      *
+     * @deprecated since SimplePie 1.9.0. If you need it, consider copying the function to your codebase.
      * @static
      * @param string $str The input string.
      * @return array<string, array<string|null>>
      */
     public static function parse_str(string $str)
     {
+        // trigger_error(sprintf('Using method "' . __METHOD__ . '" is deprecated since SimplePie 1.9.'), \E_USER_DEPRECATED);
+
         $return = [];
         $str = explode('&', $str);
 

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -250,6 +250,7 @@ class Misc
     }
 
     /**
+     * @deprecated since SimplePie 1.9.0. This functionality is part of `IRI` – if you need it standalone, consider copying the function to your codebase.
      * @param array<int, string> $match
      * @return string
      */


### PR DESCRIPTION
- The following `SimplePie\Misc` methods are deprecated without replacement:

  - `element_implode`
  - `parse_str`
  - `percent_encoding_normalization`
  - `strip_comments`
  - `uncomment_rfc822`

See the individual commits for details.
