### PR TITLE
Update date parsing to use DateTimeImmutable

### DIFF
--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -942,7 +942,7 @@ PCRE;
     }
 
     /**
-     * Parse dates using strtotime()
+     * Parse dates using DateTimeImmutable()
      *
      * @access protected
      * @param string $date
@@ -950,7 +950,7 @@ PCRE;
      */
     public function date_strtotime(string $date)
     {
-        $strtotime = strtotime($date);
+        $strtotime = ( new \DateTimeImmutable( $date ) )->getTimestamp();
         if ($strtotime === -1 || $strtotime === false) {
             return false;
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -603,7 +603,7 @@ class Parser implements RegistryAware
                     $item['category'] = [['data' => $category_csv]];
                 }
                 if (isset($entry['properties']['published'][0])) {
-                    $timestamp = strtotime($entry['properties']['published'][0]);
+                    $timestamp = ( new \DateTimeImmutable( $entry['properties']['published'][0] ) )->getTimestamp();
                     $pub_date = date('F j Y g:ia', $timestamp).' GMT';
                     $item['pubDate'] = [['data' => $pub_date]];
                 }


### PR DESCRIPTION
Replaced `strtotime` with `DateTimeImmutable` for more accurate and reliable date conversion. This change affects both `Parser.php` and `Parse/Date.php` and enhances the handling of date strings.