### PR TITLE
[1.8] GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
           - '8.4'
 
     name: "PHP: ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code
@@ -41,15 +40,8 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 8.4)"
-        if: ${{ matrix.php < '8.4' }}
+      - name: "Install Composer dependencies"
         uses: "ramsey/composer-install@v2"
-
-      - name: "Install Composer dependencies (PHP 8.4)"
-        if: ${{ matrix.php >= '8.4' }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-reqs
 
       - name: Run unit tests
         run: composer test


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.

Ref: https://www.php.net/releases/8.4/en.php
(cherry picked from commit 72b42935cb828ef691d17ca1e39fc0c9f480028b)

Backport of https://github.com/simplepie/simplepie/pull/901.