### PR TITLE
[1.8 backport] Clarify error type

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -417,10 +417,10 @@ class SimplePie
     public $data = [];
 
     /**
-     * @var mixed Error string
+     * @var string|string[]|null Error string (or array when multiple feeds are initialized)
      * @access private
      */
-    public $error;
+    public $error = null;
 
     /**
      * @var int HTTP status code
@@ -1911,7 +1911,7 @@ class SimplePie
     /**
      * Get the error message for the occurred error
      *
-     * @return string|array Error message, or array of messages for multifeeds
+     * @return string|string[]|null Error message, or array of messages for multifeeds
      */
     public function error()
     {


### PR DESCRIPTION
(cherry picked from commit aa3436ab6e99419ebb2996ced64f4b88638b6737 (https://github.com/simplepie/simplepie/pull/786))

This is an issue for consumers checking error not being `null` with PHPStan 2.0.

