### PR TITLE
Rename HttpException to ClientException

### DIFF
--- a/src/HTTP/Client.php
+++ b/src/HTTP/Client.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace SimplePie\HTTP;
 
-use SimplePie\Exception\HttpException;
-
 /**
  * HTTP Client interface
  *
@@ -24,7 +22,7 @@ interface Client
      * @param Client::METHOD_* $method
      * @param array<string, string> $headers
      *
-     * @throws HttpException if anything goes wrong requesting the data
+     * @throws ClientException if anything goes wrong requesting the data
      */
     public function request(string $method, string $url, array $headers = []): Response;
 }

--- a/src/HTTP/ClientException.php
+++ b/src/HTTP/ClientException.php
@@ -11,6 +11,8 @@ use SimplePie\Exception as SimplePieException;
 
 /**
  * Client exception class
+ *
+ * @internal
  */
 final class ClientException extends SimplePieException
 {

--- a/src/HTTP/ClientException.php
+++ b/src/HTTP/ClientException.php
@@ -5,13 +5,13 @@
 
 declare(strict_types=1);
 
-namespace SimplePie\Exception;
+namespace SimplePie\HTTP;
 
 use SimplePie\Exception as SimplePieException;
 
 /**
- * HTTP exception class
+ * Client exception class
  */
-final class HttpException extends SimplePieException
+final class ClientException extends SimplePieException
 {
 }

--- a/src/HTTP/FileClient.php
+++ b/src/HTTP/FileClient.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace SimplePie\HTTP;
 
 use InvalidArgumentException;
-use SimplePie\Exception\HttpException;
 use SimplePie\File;
 use SimplePie\Misc;
 use SimplePie\Registry;
@@ -42,7 +41,7 @@ final class FileClient implements Client
      * @param Client::METHOD_* $method
      * @param array<string, string> $headers
      *
-     * @throws HttpException if anything goes wrong requesting the data
+     * @throws ClientException if anything goes wrong requesting the data
      */
     public function request(string $method, string $url, array $headers = []): Response
     {
@@ -66,11 +65,11 @@ final class FileClient implements Client
                 $this->options['curl_options'] ?? []
             ]);
         } catch (Throwable $th) {
-            throw new HttpException($th->getMessage(), $th->getCode(), $th);
+            throw new ClientException($th->getMessage(), $th->getCode(), $th);
         }
 
         if (!$file->success) {
-            throw new HttpException($file->error);
+            throw new ClientException($file->error);
         }
 
         return $file;

--- a/src/HTTP/Psr18Client.php
+++ b/src/HTTP/Psr18Client.php
@@ -12,7 +12,6 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
-use SimplePie\Exception\HttpException;
 use Throwable;
 
 /**
@@ -71,7 +70,7 @@ final class Psr18Client implements Client
      * @param string $url
      * @param array<string,string|string[]> $headers
      *
-     * @throws HttpException if anything goes wrong requesting the data
+     * @throws ClientException if anything goes wrong requesting the data
      */
     public function request(string $method, string $url, array $headers = []): Response
     {
@@ -114,7 +113,7 @@ final class Psr18Client implements Client
             try {
                 $response = $this->httpClient->sendRequest($request);
             } catch (ClientExceptionInterface $th) {
-                throw new HttpException($th->getMessage(), $th->getCode(), $th);
+                throw new ClientException($th->getMessage(), $th->getCode(), $th);
             }
 
             $statusCode = $response->getStatusCode();
@@ -145,17 +144,17 @@ final class Psr18Client implements Client
     private function requestLocalFile(string $path): Response
     {
         if (!is_readable($path)) {
-            throw new HttpException(sprintf('file "%s" is not readable', $path));
+            throw new ClientException(sprintf('file "%s" is not readable', $path));
         }
 
         try {
             $raw = file_get_contents($path);
         } catch (Throwable $th) {
-            throw new HttpException($th->getMessage(), $th->getCode(), $th);
+            throw new ClientException($th->getMessage(), $th->getCode(), $th);
         }
 
         if ($raw === false) {
-            throw new HttpException('file_get_contents() could not read the file', 1);
+            throw new ClientException('file_get_contents() could not read the file', 1);
         }
 
         return new RawTextResponse($raw, $path);

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -11,8 +11,8 @@ use DomDocument;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
-use SimplePie\Exception\HttpException;
 use SimplePie\HTTP\Client;
+use SimplePie\HTTP\ClientException;
 use SimplePie\HTTP\FileClient;
 use SimplePie\HTTP\Psr18Client;
 use SimplePie\HTTP\Response;
@@ -263,7 +263,7 @@ class Locator implements RegistryAware
                         if ((!Misc::is_remote_uri($feed->get_final_requested_uri()) || ($feed->get_status_code() === 200 || $feed->get_status_code() > 206 && $feed->get_status_code() < 300)) && $this->is_feed($feed, true)) {
                             $feeds[$href] = $feed;
                         }
-                    } catch (HttpException $th) {
+                    } catch (ClientException $th) {
                         // Just mark it as done and continue.
                     }
                 }
@@ -388,7 +388,7 @@ class Locator implements RegistryAware
                     if ((!Misc::is_remote_uri($feed->get_final_requested_uri()) || ($feed->get_status_code() === 200 || $feed->get_status_code() > 206 && $feed->get_status_code() < 300)) && $this->is_feed($feed)) {
                         return [$feed];
                     }
-                } catch (HttpException $th) {
+                } catch (ClientException $th) {
                     // Just unset and continue.
                 }
 
@@ -420,7 +420,7 @@ class Locator implements RegistryAware
                     if ((!Misc::is_remote_uri($feed->get_final_requested_uri()) || ($feed->get_status_code() === 200 || $feed->get_status_code() > 206 && $feed->get_status_code() < 300)) && $this->is_feed($feed)) {
                         return [$feed];
                     }
-                } catch (HttpException $th) {
+                } catch (ClientException $th) {
                     // Just unset and continue.
                 }
 

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -18,8 +18,8 @@ use SimplePie\Cache\BaseDataCache;
 use SimplePie\Cache\CallableNameFilter;
 use SimplePie\Cache\DataCache;
 use SimplePie\Cache\NameFilter;
-use SimplePie\Exception\HttpException;
 use SimplePie\HTTP\Client;
+use SimplePie\HTTP\ClientException;
 use SimplePie\HTTP\FileClient;
 use SimplePie\HTTP\Psr18Client;
 
@@ -504,7 +504,7 @@ class Sanitize implements RegistryAware
                                         $img->getAttribute('src'),
                                         ['X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']]
                                     );
-                                } catch (HttpException $th) {
+                                } catch (ClientException $th) {
                                     continue;
                                 }
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -20,8 +20,8 @@ use SimplePie\Cache\NameFilter;
 use SimplePie\Cache\Psr16;
 use SimplePie\Content\Type\Sniffer;
 use SimplePie\Exception as SimplePieException;
-use SimplePie\Exception\HttpException;
 use SimplePie\HTTP\Client;
+use SimplePie\HTTP\ClientException;
 use SimplePie\HTTP\FileClient;
 use SimplePie\HTTP\Psr18Client;
 use SimplePie\HTTP\Response;
@@ -1919,7 +1919,7 @@ class SimplePie
                         try {
                             $file = $this->get_http_client()->request(Client::METHOD_GET, $this->feed_url, $headers);
                             $this->status_code = $file->get_status_code();
-                        } catch (HttpException $th) {
+                        } catch (ClientException $th) {
                             $this->check_modified = false;
                             $this->status_code = 0;
 
@@ -1972,7 +1972,7 @@ class SimplePie
                 ];
                 try {
                     $file = $this->get_http_client()->request(Client::METHOD_GET, $this->feed_url, $headers);
-                } catch (HttpException $th) {
+                } catch (ClientException $th) {
                     // If the file connection has an error, set SimplePie::error to that and quit
                     $this->error = $th->getMessage();
 

--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -11,8 +11,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
-use SimplePie\Exception\HttpException;
 use SimplePie\HTTP\Client;
+use SimplePie\HTTP\ClientException;
 use SimplePie\HTTP\FileClient;
 use SimplePie\HTTP\Psr18Client;
 use SimplePie\HTTP\Response;
@@ -52,16 +52,16 @@ class ClientsTest extends TestCase
         $this->assertStringStartsWith('<rss version="2.0">', $response->get_body_content());
     }
 
-    public function testFileClientThrowsHttpException(): void
+    public function testFileClientThrowsClientException(): void
     {
-        $this->runTestWithClientThrowsHttpException(
+        $this->runTestWithClientThrowsClientException(
             new FileClient(new Registry())
         );
     }
 
-    public function testPsr18ClientThrowsHttpException(): void
+    public function testPsr18ClientThrowsClientException(): void
     {
-        $this->runTestWithClientThrowsHttpException(
+        $this->runTestWithClientThrowsClientException(
             new Psr18Client(
                 $this->createMock(ClientInterface::class),
                 $this->createMock(RequestFactoryInterface::class),
@@ -70,11 +70,11 @@ class ClientsTest extends TestCase
         );
     }
 
-    private function runTestWithClientThrowsHttpException(Client $client): void
+    private function runTestWithClientThrowsClientException(Client $client): void
     {
         $filepath = dirname(__FILE__, 3) . '/data/this-file-does-not-exist';
 
-        $this->expectException(HttpException::class);
+        $this->expectException(ClientException::class);
         $this->expectExceptionCode(0);
 
         $this->expectExceptionMessage(sprintf('file "%s" is not readable', $filepath));

--- a/tests/Unit/HTTP/FileClientTest.php
+++ b/tests/Unit/HTTP/FileClientTest.php
@@ -75,4 +75,32 @@ final class FileClientTest extends TestCase
             ['Accept' => 'application/atom+xml']
         );
     }
+
+    public function testFileClientReturnsResponseWithStatusCode500(): void
+    {
+        $response = $this->createStub(File::class);
+        $response->method('get_status_code')->willReturn(500);
+
+        $registry = $this->createStub(Registry::class);
+        $registry->method('create')->willReturn($response);
+
+        $client = new FileClient($registry, [
+            'timeout' => 30,
+            'useragent' => 'dummy-useragent',
+            'redirects' => 10,
+            'force_fsockopen' => true,
+            'curl_options' => [
+                \CURLOPT_FAILONERROR => true,
+            ],
+        ]);
+
+        $response = $client->request(
+            FileClient::METHOD_GET,
+            'http://example.com/500-error',
+            ['Accept' => 'application/atom+xml']
+        );
+
+        // Make sure no ClientException is thrown on status code 500
+        $this->assertSame(500, $response->get_status_code());
+    }
 }

--- a/tests/Unit/HTTP/Psr18ClientTest.php
+++ b/tests/Unit/HTTP/Psr18ClientTest.php
@@ -30,6 +30,27 @@ class Psr18ClientTest extends TestCase
         $this->assertInstanceOf(Response::class, $client->request(Client::METHOD_GET, 'https://example.com/feed.xml'));
     }
 
+    public function testRequestReturnsResponseWithStatusCode500(): void
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(500);
+
+        $psr18 = $this->createStub(ClientInterface::class);
+        $psr18->method('request')->willReturn($response);
+
+        $client = new Psr18Client(
+            $psr18,
+            $this->createStub(RequestFactoryInterface::class),
+            $this->createStub(UriFactoryInterface::class)
+        );
+
+        // Make sure no ClientException is thrown on status code 500
+        $this->assertSame(
+            500,
+            $client->request(Client::METHOD_GET, 'https://example.com/feed.xml')->get_status_code()
+        );
+    }
+
     public function testRequestWithRedirectReturnsResponseWithCorrectUrls(): void
     {
         $request = $this->createMock(RequestInterface::class);


### PR DESCRIPTION
This PR renames the `SimplePie\Exception\HttpException` to `SimplePie\HTTP\ClientException` to avoid confusion that this exception is thrown on an 4xx or 5xx response from the server. Because the `ClientException` is always catched internally I marked the class as `@internal`.

This PR also adds tests to show that the responses (`File` or `Psr7Response` class) always contains the status code, even if it is 500. 