### PR TITLE
Update Date.php

### DIFF
--- a/src/Parse/Date.php
+++ b/src/Parse/Date.php
@@ -556,8 +556,8 @@ class Date
      */
     public function __construct()
     {
-        $this->day_pcre = '(' . implode('|', array_keys($this->day)) . ')';
-        $this->month_pcre = '(' . implode('|', array_keys($this->month)) . ')';
+        $this->day_pcre = '(' . implode(array_keys($this->day), '|') . ')';
+        $this->month_pcre = '(' . implode(array_keys($this->month), '|') . ')';
 
         static $cache;
         if (!isset($cache[get_class($this)])) {


### PR DESCRIPTION
Method call for implode used the legacy signaturr which is no longer supported with PHP 8.0+x.