### PR TITLE
Trim body for all paths

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -156,7 +156,7 @@ class File implements Response
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);
-                        $this->body = trim($parser->body, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
+                        $this->body = $parser->body;
                         $this->status_code = $parser->status_code;
                         if ((in_array($this->status_code, [300, 301, 302, 303, 307]) || $this->status_code > 307 && $this->status_code < 400) && ($locationHeader = $this->get_header_line('location')) !== '' && $this->redirects < $redirects) {
                             $this->redirects++;
@@ -238,7 +238,7 @@ class File implements Response
                                             $this->error = 'Unable to decode HTTP "gzip" stream';
                                             $this->success = false;
                                         } else {
-                                            $this->body = trim($decompressed, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
+                                            $this->body = $decompressed;
                                         }
                                         break;
 
@@ -275,9 +275,12 @@ class File implements Response
                 $this->error = sprintf('file "%s" is not readable', $url);
                 $this->success = false;
             } else {
-                $this->body = trim($filebody, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
+                $this->body = $filebody;
                 $this->status_code = 200;
             }
+        }
+        if ($this->success) {
+            $this->body = trim($this->body, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
         }
     }
 

--- a/src/File.php
+++ b/src/File.php
@@ -280,7 +280,9 @@ class File implements Response
             }
         }
         if ($this->success) {
-            $this->body = trim($this->body, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
+            // (Leading) whitespace may cause XML parsing errors so we trim it,
+            // but we must not trim \x00 to avoid breaking BOM or multibyte characters
+            $this->body = trim($this->body, " \n\r\t\v");
         }
     }
 


### PR DESCRIPTION
Slight refactor of https://github.com/simplepie/simplepie/pull/916 to cover all paths.
Missing paths included the fsock method without gzip (e.g. deflate or plain).
