### PR TITLE
tests: Improve ClientsTest::testRedirectsChain

### DIFF
--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -216,6 +216,7 @@ class ClientsTest extends TestCase
         $server->stop();
 
         $this->assertSame(200, $response->get_status_code());
+        $this->assertSame('OK', $response->get_body_content());
         $this->assertSame($permanentLocation, $response->get_permanent_uri());
         $this->assertSame($finalLocation, $response->get_final_requested_uri());
     }

--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -142,7 +142,7 @@ class ClientsTest extends TestCase
     /**
      * @return iterable<array{client: Client}>
      */
-    public function clientsProvider(): iterable
+    public static function clientsProvider(): iterable
     {
         yield 'curl' => [
             'client' => new FileClient(new Registry(), [


### PR DESCRIPTION
The built-in PHP server used by `donatj/mock-webserver` will happily include warnings in the response body.
If that happens before `Location` header is sent, such as with the implicit nullable types deprecation warning on PHP 8.4 from `Mf2\Parser` being pulled in by static autoloader, the redirect will never happen and later assertions will fail without any hint as to why.

Also fix PHPunit deprecation warning.

Follow up to #918 