### PR TITLE
Fix typo in docblock description

### DIFF
--- a/src/Net/IPv6.php
+++ b/src/Net/IPv6.php
@@ -23,7 +23,7 @@ class IPv6
     /**
      * Uncompresses an IPv6 address
      *
-     * RFC 4291 allows you to compress concecutive zero pieces in an address to
+     * RFC 4291 allows you to compress consecutive zero pieces in an address to
      * '::'. This method expects a valid IPv6 address and expands the '::' to
      * the required number of zero pieces.
      *
@@ -83,7 +83,7 @@ class IPv6
     /**
      * Compresses an IPv6 address
      *
-     * RFC 4291 allows you to compress concecutive zero pieces in an address to
+     * RFC 4291 allows you to compress consecutive zero pieces in an address to
      * '::'. This method expects a valid IPv6 address and compresses consecutive
      * zero pieces to '::'.
      *


### PR DESCRIPTION
Changes 'concecutive' to 'consecutive'