### PR TITLE
Fix parse_date() return type

### DIFF
--- a/src/Misc.php
+++ b/src/Misc.php
@@ -1737,7 +1737,7 @@ class Misc
     }
 
     /**
-     * @return int|bool
+     * @return int|false
      */
     public static function parse_date(string $dt)
     {


### PR DESCRIPTION
Corrected to `@return int|false`