### PR TITLE
SimplePie: Restrict `cache_name_function` type

### DIFF
--- a/src/Cache/CallableNameFilter.php
+++ b/src/Cache/CallableNameFilter.php
@@ -13,10 +13,13 @@ namespace SimplePie\Cache;
 final class CallableNameFilter implements NameFilter
 {
     /**
-     * @var callable
+     * @var callable(string): string
      */
     private $callable;
 
+    /**
+     * @param callable(string): string $callable
+     */
     public function __construct(callable $callable)
     {
         $this->callable = $callable;

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -168,7 +168,7 @@ class Sanitize implements RegistryAware
         // BC: $cache_name_function could be a callable as string
         if (is_string($cache_name_function)) {
             // trigger_error(sprintf('Providing $cache_name_function as string in "%s()" is deprecated since SimplePie 1.8.0, provide as "%s" instead.', __METHOD__, NameFilter::class), \E_USER_DEPRECATED);
-            $this->cache_name_function = (string) $cache_name_function;
+            $this->cache_name_function = $cache_name_function;
 
             $cache_name_function = new CallableNameFilter($cache_name_function);
         }

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -60,7 +60,7 @@ class Sanitize implements RegistryAware
     public $enable_cache = true;
     /** @var string */
     public $cache_location = './cache';
-    /** @var string */
+    /** @var string&(callable(string): string) */
     public $cache_name_function = 'md5';
 
     /**
@@ -144,7 +144,7 @@ class Sanitize implements RegistryAware
     }
 
     /**
-     * @param string|NameFilter $cache_name_function
+     * @param (string&(callable(string): string))|NameFilter $cache_name_function
      * @param class-string<Cache> $cache_class
      * @return void
      */

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -523,7 +523,7 @@ class SimplePie
     public $cache_location = './cache';
 
     /**
-     * @var string Function that creates the cache filename
+     * @var string&(callable(string): string) Function that creates the cache filename
      * @see SimplePie::set_cache_name_function()
      * @access private
      */
@@ -1414,10 +1414,10 @@ class SimplePie
      *
      * @deprecated since SimplePie 1.8.0, use {@see set_cache_namefilter()} instead
      *
-     * @param ?callable(string): string $function Callback function
+     * @param (string&(callable(string): string))|null $function Callback function
      * @return void
      */
-    public function set_cache_name_function(?callable $function = null)
+    public function set_cache_name_function(?string $function = null)
     {
         // trigger_error(sprintf('"%s()" is deprecated since SimplePie 1.8.0, please use "SimplePie\SimplePie::set_cache_namefilter()" instead.', __METHOD__), \E_USER_DEPRECATED);
 


### PR DESCRIPTION
Even though the intention in 399a46ce44cb89f4bf7f5ad59fd8f7814ecf65c8 was to allow any `callable`, in practice, `Sanitize` forced it to be a `string` by casting it to `string` anyway d374d214c2f8ef3bf72077f982582218224e73bf.

We added a `?callable` type annotation to `set_cache_name_function` in a2ee1d711a370a43fb292198d4eba403144d34ea (not yet released). Let’s change it to a narrower type to avoid growing the API surface of deprecated functions.
