### PR TITLE
Normalize encoding uppercase

### DIFF
--- a/src/XML/Declaration/Parser.php
+++ b/src/XML/Declaration/Parser.php
@@ -242,7 +242,7 @@ class Parser
     public function encoding_value(): void
     {
         if ($encoding = $this->get_value()) {
-            $this->encoding = $encoding;
+            $this->encoding = strtoupper($encoding);
             $this->skip_whitespace();
             if ($this->has_data()) {
                 $this->state = self::STATE_STANDALONE_NAME;


### PR DESCRIPTION
SimplePie uses uppercase for encoding everywhere, except in the parser, which makes `array_unique()` to fail to do its job when the document declares `utf-8` and we already have `UTF-8` in the list:
https://github.com/simplepie/simplepie/blob/1838b28db27ee206e0c2cf183f7b2af75abed143/src/SimplePie.php#L1780-L1785
