### PR TITLE
PHP 8.5: Conditionally call deprecated functions

### DIFF
--- a/compatibility_test/sp_compatibility_test.php
+++ b/compatibility_test/sp_compatibility_test.php
@@ -29,7 +29,9 @@ elseif (extension_loaded('xml'))
 {
 	$parser_check = xml_parser_create();
 	xml_parse_into_struct($parser_check, '<foo>&amp;</foo>', $values);
-	xml_parser_free($parser_check);
+    if (\PHP_VERSION_ID < 80000) {
+	    xml_parser_free($parser_check);
+    }
 	$xml_ok = isset($values[0]['value']);
 }
 else

--- a/src/File.php
+++ b/src/File.php
@@ -153,7 +153,9 @@ class File implements Response
                     }
                     // For PHPStan: We already checked that error did not occur.
                     assert(is_array($info) && $info['redirect_count'] >= 0);
-                    curl_close($fp);
+                    if (\PHP_VERSION_ID < 80000) {
+                        curl_close($fp);
+                    }
                     $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders((string) $responseHeaders, $info['redirect_count'] + 1);
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -128,7 +128,9 @@ class Parser implements RegistryAware
         if ($xml_is_sane === null) {
             $parser_check = xml_parser_create();
             xml_parse_into_struct($parser_check, '<foo>&amp;</foo>', $values);
-            xml_parser_free($parser_check);
+            if (\PHP_VERSION_ID < 80000) {
+                xml_parser_free($parser_check);
+            }
             $xml_is_sane = isset($values[0]['value']);
         }
 
@@ -164,7 +166,9 @@ class Parser implements RegistryAware
             $this->current_line = xml_get_current_line_number($xml);
             $this->current_column = xml_get_current_column_number($xml);
             $this->current_byte = xml_get_current_byte_index($xml);
-            xml_parser_free($xml);
+            if (\PHP_VERSION_ID < 80000) {
+                xml_parser_free($xml);
+            }
             return $return;
         }
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1655,7 +1655,9 @@ class SimplePie
             if ($xml_is_sane === null) {
                 $parser_check = xml_parser_create();
                 xml_parse_into_struct($parser_check, '<foo>&amp;</foo>', $values);
-                xml_parser_free($parser_check);
+                if (\PHP_VERSION_ID < 80000) {
+                    xml_parser_free($parser_check);
+                }
                 $xml_is_sane = isset($values[0]['value']);
             }
             if (!$xml_is_sane) {


### PR DESCRIPTION
Several PHP functions that have not been doing anything since PHP 8.0/8.1 will be deprecated in PHP 8.5 and will thus be throwing warnings: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion

To solve this while supporting multiple versions of PHP, they can be called conditionally based on a PHP version check.

This PR adds this for affected functions throughout the SimplePie  codebase.