### PR TITLE
PHPUnit assert functions are static

### DIFF
--- a/tests/BCTest.php
+++ b/tests/BCTest.php
@@ -17,7 +17,7 @@ class BCTest extends TestCase
      */
     public function test_class_SimplePie_Core_exists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Core'));
+        self::assertTrue(class_exists('SimplePie_Core'));
     }
 
     /**
@@ -25,7 +25,7 @@ class BCTest extends TestCase
      */
     public function test_class_SimplePie_Misc_exists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Misc'));
+        self::assertTrue(class_exists('SimplePie_Misc'));
     }
 
     /**
@@ -33,6 +33,6 @@ class BCTest extends TestCase
      */
     public function test_class_SimplePie_Decode_HTML_Entities_exists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Decode_HTML_Entities'));
+        self::assertTrue(class_exists('SimplePie_Decode_HTML_Entities'));
     }
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -60,7 +60,7 @@ class CacheTest extends TestCase
         // PHPUnit 10 compatible way to test trigger_error().
         set_error_handler(
             function ($errno, $errstr): bool {
-                $this->assertSame(
+                self::assertSame(
                     '"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.',
                     $errstr
                 );

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -79,7 +79,7 @@ class EncodingTest extends TestCase
     public function test_convert_UTF8(string $input, string $expected, string $encoding): void
     {
         $encoding = SimplePie_Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
+        self::assertSameBin2Hex($expected, (string) SimplePie_Misc::change_encoding($input, $encoding, 'UTF-8'));
     }
 
     /**
@@ -92,7 +92,7 @@ class EncodingTest extends TestCase
     {
         $encoding = SimplePie_Misc::encoding($encoding);
         if (extension_loaded('mbstring')) {
-            $this->assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+            self::assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_mbstring($input, $encoding, 'UTF-8'));
         }
     }
 
@@ -106,7 +106,7 @@ class EncodingTest extends TestCase
     {
         $encoding = SimplePie_Misc::encoding($encoding);
         if (extension_loaded('iconv')) {
-            $this->assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
+            self::assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_iconv($input, $encoding, 'UTF-8'));
         }
     }
 
@@ -120,7 +120,7 @@ class EncodingTest extends TestCase
     {
         $encoding = SimplePie_Misc::encoding($encoding);
         if (extension_loaded('intl')) {
-            $this->assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
+            self::assertSameBin2Hex($expected, (string) Mock_Misc::change_encoding_uconverter($input, $encoding, 'UTF-8'));
         }
     }
 
@@ -144,12 +144,12 @@ class EncodingTest extends TestCase
     public function test_convert_UTF16(string $input, string $expected, string $encoding): void
     {
         $encoding = SimplePie_Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
+        self::assertSameBin2Hex($expected, (string) SimplePie_Misc::change_encoding($input, $encoding, 'UTF-16'));
     }
 
     public function test_nonexistent(): void
     {
-        $this->assertFalse(SimplePie_Misc::change_encoding('', 'TESTENC', 'UTF-8'));
+        self::assertFalse(SimplePie_Misc::change_encoding('', 'TESTENC', 'UTF-8'));
     }
 
     public static function assertSameBin2Hex(string $expected, string $actual, string $message = ''): void

--- a/tests/HTTPParserTest.php
+++ b/tests/HTTPParserTest.php
@@ -41,12 +41,12 @@ class HTTPParserTest extends TestCase
         $data = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = SimplePie_HTTP_Parser::prepareHeaders($data);
         $parser = new SimplePie_HTTP_Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -57,12 +57,12 @@ class HTTPParserTest extends TestCase
         $data = "HTTP/1.0 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = SimplePie_HTTP_Parser::prepareHeaders($data);
         $parser = new SimplePie_HTTP_Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -73,11 +73,11 @@ class HTTPParserTest extends TestCase
         $data = "HTTP/1.1 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = SimplePie_HTTP_Parser::prepareHeaders($data);
         $parser = new SimplePie_HTTP_Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 }

--- a/tests/IRITest.php
+++ b/tests/IRITest.php
@@ -72,8 +72,8 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI('http://a/b/c/d;p?q');
         $absolutized = SimplePie_IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -83,7 +83,7 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI('http://a/b/c/d;p?q');
         $expected = new SimplePie_IRI($expected);
-        $this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
+        self::assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
     }
 
     /**
@@ -93,9 +93,9 @@ class IRITest extends TestCase
     {
         $base = 'http://a/b/c/d;p?q';
         $absolutized = SimplePie_IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
-        $this->assertSame($expected, (string) SimplePie_IRI::absolutize($base, $relative));
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
+        self::assertSame($expected, (string) SimplePie_IRI::absolutize($base, $relative));
     }
 
     /**
@@ -130,8 +130,8 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI($base);
         $absolutized = SimplePie_IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -141,7 +141,7 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI($base);
         $expected = new SimplePie_IRI($expected);
-        $this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
+        self::assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
     }
 
     /**
@@ -164,7 +164,7 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI('http://example.com/');
         $base->set_query($query);
-        $this->assertSame($expected, $base->get_iri());
+        self::assertSame($expected, $base->get_iri());
     }
 
     /**
@@ -175,7 +175,7 @@ class IRITest extends TestCase
         $base = new SimplePie_IRI('http://example.com/');
         $base->set_query($query);
         $expected = new SimplePie_IRI($expected);
-        $this->assertEquals($expected, $base);
+        self::assertEquals($expected, $base);
     }
 
     /**
@@ -196,8 +196,8 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI($base);
         $absolutized = SimplePie_IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -207,7 +207,7 @@ class IRITest extends TestCase
     {
         $base = new SimplePie_IRI($base);
         $expected = new SimplePie_IRI($expected);
-        $this->assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
+        self::assertEquals($expected, SimplePie_IRI::absolutize($base, $relative));
     }
 
     /**
@@ -302,7 +302,7 @@ class IRITest extends TestCase
     public function testStringNormalization(string $input, string $output): void
     {
         $input = new SimplePie_IRI($input);
-        $this->assertSame($output, $input->get_iri());
+        self::assertSame($output, $input->get_iri());
     }
 
     /**
@@ -312,7 +312,7 @@ class IRITest extends TestCase
     {
         $input = new SimplePie_IRI($input);
         $output = new SimplePie_IRI($output);
-        $this->assertEquals($output, $input);
+        self::assertEquals($output, $input);
     }
 
     /**
@@ -333,7 +333,7 @@ class IRITest extends TestCase
     public function testURIConversion(string $input, string $output): void
     {
         $input = new SimplePie_IRI($input);
-        $this->assertSame($output, $input->get_uri());
+        self::assertSame($output, $input->get_uri());
     }
 
     /**
@@ -353,7 +353,7 @@ class IRITest extends TestCase
     {
         $input = new SimplePie_IRI($input);
         $output = new SimplePie_IRI($output);
-        $this->assertEquals($output, $input);
+        self::assertEquals($output, $input);
     }
 
     /**
@@ -373,12 +373,12 @@ class IRITest extends TestCase
     {
         $input = new SimplePie_IRI($input);
         $output = new SimplePie_IRI($output);
-        $this->assertNotEquals($output, $input);
+        self::assertNotEquals($output, $input);
     }
 
     public function testInvalidAbsolutizeBase(): void
     {
-        $this->assertFalse(SimplePie_IRI::absolutize('://not a URL', '../'));
+        self::assertFalse(SimplePie_IRI::absolutize('://not a URL', '../'));
     }
 
     public function testInvalidPathNoHost(): void
@@ -386,21 +386,21 @@ class IRITest extends TestCase
         $iri = new SimplePie_IRI();
         $iri->scheme = 'http';
         $iri->path = '//test';
-        $this->assertFalse($iri->is_valid());
+        self::assertFalse($iri->is_valid());
     }
 
     public function testInvalidRelativePathContainsColon(): void
     {
         $iri = new SimplePie_IRI();
         $iri->path = '/test:/';
-        $this->assertFalse($iri->is_valid());
+        self::assertFalse($iri->is_valid());
     }
 
     public function testValidRelativePathContainsColon(): void
     {
         $iri = new SimplePie_IRI();
         $iri->path = '/test/:';
-        $this->assertTrue($iri->is_valid());
+        self::assertTrue($iri->is_valid());
     }
 
     public function testFullGamut(): void
@@ -412,12 +412,12 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testReadAliased(): void
@@ -429,12 +429,12 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testWriteAliased(): void
@@ -446,23 +446,23 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testNonexistentProperty(): void
     {
         $iri = new SimplePie_IRI();
-        $this->assertFalse(isset($iri->nonexistent_prop));
+        self::assertFalse(isset($iri->nonexistent_prop));
 
         // PHPUnit 10 compatible way to test trigger_error().
         set_error_handler(
             function ($errno, $errstr): bool {
-                $this->assertSame(
+                self::assertSame(
                     'Undefined property: SimplePie\IRI::nonexistent_prop',
                     $errstr
                 );
@@ -481,8 +481,8 @@ class IRITest extends TestCase
         $iri = new SimplePie_IRI('http://example.com/a/?b=c#d');
         $iri->host = null;
 
-        $this->assertSame(null, $iri->host);
-        $this->assertSame('http:/a/?b=c#d', (string) $iri);
+        self::assertSame(null, $iri->host);
+        self::assertSame('http:/a/?b=c#d', (string) $iri);
     }
 
     public function testBadPort(): void
@@ -490,6 +490,6 @@ class IRITest extends TestCase
         $iri = new SimplePie_IRI();
         $iri->port = 'example';
 
-        $this->assertSame(null, $iri->port);
+        self::assertSame(null, $iri->port);
     }
 }

--- a/tests/Integration/CachingTest.php
+++ b/tests/Integration/CachingTest.php
@@ -112,7 +112,7 @@ class CachingTest extends TestCase
             $expectedDataWritten['cache_expiration_time'] = $writtenData['cache_expiration_time'];
         }
 
-        $this->assertSame($expectedDataWritten, $writtenData);
+        self::assertSame($expectedDataWritten, $writtenData);
     }
 
     /**

--- a/tests/Integration/HTTP/ClientsTest.php
+++ b/tests/Integration/HTTP/ClientsTest.php
@@ -47,12 +47,12 @@ class ClientsTest extends TestCase
 
         $response = $client->request(Client::METHOD_GET, $filepath);
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame($filepath, $response->get_permanent_uri());
-        $this->assertSame($filepath, $response->get_final_requested_uri());
-        $this->assertSame(200, $response->get_status_code());
-        $this->assertSame([], $response->get_headers());
-        $this->assertStringStartsWith('<rss version="2.0">', $response->get_body_content());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame($filepath, $response->get_permanent_uri());
+        self::assertSame($filepath, $response->get_final_requested_uri());
+        self::assertSame(200, $response->get_status_code());
+        self::assertSame([], $response->get_headers());
+        self::assertStringStartsWith('<rss version="2.0">', $response->get_body_content());
     }
 
     public function testFileClientThrowsClientException(): void
@@ -103,7 +103,7 @@ class ClientsTest extends TestCase
 
         $server->stop();
 
-        $this->assertSame(429, $response->get_status_code());
+        self::assertSame(429, $response->get_status_code());
     }
 
     public function testFileClientReturnsResponseOn500StatusCode(): void
@@ -122,7 +122,7 @@ class ClientsTest extends TestCase
 
         $server->stop();
 
-        $this->assertSame(500, $response->get_status_code());
+        self::assertSame(500, $response->get_status_code());
     }
 
     public function testFileClientThrowsClientExceptionIfServerIsUnreachable(): void
@@ -215,10 +215,10 @@ class ClientsTest extends TestCase
 
         $server->stop();
 
-        $this->assertSame(200, $response->get_status_code());
-        $this->assertSame('OK', $response->get_body_content());
-        $this->assertSame($permanentLocation, $response->get_permanent_uri());
-        $this->assertSame($finalLocation, $response->get_final_requested_uri());
+        self::assertSame(200, $response->get_status_code());
+        self::assertSame('OK', $response->get_body_content());
+        self::assertSame($permanentLocation, $response->get_permanent_uri());
+        self::assertSame($finalLocation, $response->get_final_requested_uri());
     }
 
     /**
@@ -279,12 +279,12 @@ class ClientsTest extends TestCase
         $start = $endianness === 'be' ? "\x00<\x00r\x00s\x00s\x00 " : "<\x00r\x00s\x00s\x00 \x00";
         $end = $endianness === 'be' ? "\x00<\x00/\x00r\x00s\x00s\x00>\x00\n" : "<\x00/\x00r\x00s\x00s\x00>\x00\n\x00";
 
-        $this->assertSame(
+        self::assertSame(
             $start,
             substr($response->get_body_content(), 0, strlen($start)),
             'Body does not start as expected: ' . $response->get_body_content()
         );
-        $this->assertSame(
+        self::assertSame(
             $end,
             substr($response->get_body_content(), -strlen($end)),
             'Body does not end as expected: ' . $response->get_body_content()

--- a/tests/Integration/SimplePieTest.php
+++ b/tests/Integration/SimplePieTest.php
@@ -37,8 +37,8 @@ class SimplePieTest extends TestCase
         $simplepie->enable_cache(false);
         $simplepie->set_feed_url($filepath);
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
     }
 
     /**
@@ -53,8 +53,8 @@ class SimplePieTest extends TestCase
         $file = new File($filepath);
         $simplepie->set_file($file);
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
     }
 
     /**
@@ -73,8 +73,8 @@ class SimplePieTest extends TestCase
         );
         $simplepie->set_feed_url($filepath);
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
     }
 
     /**
@@ -122,8 +122,8 @@ class SimplePieTest extends TestCase
         );
         $simplepie->set_feed_url('https://example.org/feed.xml');
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
     }
 
     public function testSimplePieReturnsCorrectStatusCodeFromServerResponse(): void
@@ -145,9 +145,9 @@ class SimplePieTest extends TestCase
 
         $server->stop();
 
-        $this->assertFalse($return);
-        $this->assertSame(429, $simplepie->status_code());
-        $this->assertSame('Retrieved unsupported status code "429"', $simplepie->error());
+        self::assertFalse($return);
+        self::assertSame(429, $simplepie->status_code());
+        self::assertSame('Retrieved unsupported status code "429"', $simplepie->error());
     }
 
     public function testSimplePieReturnsCorrectStatusCodeOnServerConnectionError(): void
@@ -161,9 +161,9 @@ class SimplePieTest extends TestCase
 
         $return = $simplepie->init();
 
-        $this->assertFalse($return);
-        $this->assertSame(0, $simplepie->status_code());
-        $this->assertSame('cURL error 6: Could not resolve host: example.invalid', $simplepie->error());
+        self::assertFalse($return);
+        self::assertSame(0, $simplepie->status_code());
+        self::assertSame('cURL error 6: Could not resolve host: example.invalid', $simplepie->error());
 
     }
 
@@ -216,8 +216,8 @@ class SimplePieTest extends TestCase
 
         $simplepie->set_feed_url('https://example.com/feed.xml');
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
 
         BaseCacheWithCallbacksMock::resetAllCallbacks();
     }
@@ -258,8 +258,8 @@ class SimplePieTest extends TestCase
         $simplepie->set_cache($cache);
         $simplepie->set_feed_url('https://example.com/feed.xml');
 
-        $this->assertTrue($simplepie->init());
-        $this->assertSame(100, $simplepie->get_item_quantity());
+        self::assertTrue($simplepie->init());
+        self::assertSame(100, $simplepie->get_item_quantity());
     }
 
 
@@ -277,7 +277,7 @@ class SimplePieTest extends TestCase
         $simplepie->enable_cache(false);
         $simplepie->set_feed_url($filepath);
 
-        $this->assertTrue($simplepie->init());
+        self::assertTrue($simplepie->init());
     }
 
     /**
@@ -326,14 +326,14 @@ class SimplePieTest extends TestCase
         $feed->enable_cache(false);
 
         $error = implode("\n", (array) ($feed->error() ?? '')); // For PHPStan
-        $this->assertTrue($feed->init(), 'Failed fetching feed: ' . $error);
+        self::assertTrue($feed->init(), 'Failed fetching feed: ' . $error);
 
-        $this->assertSame($feedTitle, $feed->get_title());
+        self::assertSame($feedTitle, $feed->get_title());
         $items = $feed->get_items();
-        $this->assertSame(count($titles), count($items), 'Number of items does not match');
+        self::assertSame(count($titles), count($items), 'Number of items does not match');
         foreach (array_map(null, $titles, $items) as $i => [$expectedTitle, $item]) {
             assert($item !== null); // For PHPStan
-            $this->assertSame($expectedTitle, $item->get_title(), "Title of item #$i does not match");
+            self::assertSame($expectedTitle, $item->get_title(), "Title of item #$i does not match");
         }
     }
 
@@ -544,13 +544,13 @@ HTML
         $feed->enable_cache(false);
 
         $error = implode("\n", (array) ($feed->error() ?? '')); // For PHPStan
-        $this->assertTrue($feed->init(), 'Failed fetching feed: ' . $error);
+        self::assertTrue($feed->init(), 'Failed fetching feed: ' . $error);
 
         $server->stop();
 
-        $this->assertSame($hubUrl, $feed->get_link(0, 'hub'), 'Link rel=hub does not match');
-        $this->assertSame($selfUrl, $feed->get_link(0, 'self'), 'Link rel=self does not match');
-        $this->assertLessThanOrEqual(1, count($feed->get_links('self') ?? []), 'Link rel=self should not be promoted from HTML when it is already present in headers');
-        $this->assertSame($bogoUrl, $feed->get_link(0, 'bogo'), 'Link rel=bogo does not match');
+        self::assertSame($hubUrl, $feed->get_link(0, 'hub'), 'Link rel=hub does not match');
+        self::assertSame($selfUrl, $feed->get_link(0, 'self'), 'Link rel=self does not match');
+        self::assertLessThanOrEqual(1, count($feed->get_links('self') ?? []), 'Link rel=self should not be promoted from HTML when it is already present in headers');
+        self::assertSame($bogoUrl, $feed->get_link(0, 'bogo'), 'Link rel=bogo does not match');
     }
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -69,7 +69,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -84,7 +84,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -99,7 +99,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -114,7 +114,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -129,7 +129,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -149,7 +149,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -169,7 +169,7 @@ class ItemTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->checkFromTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     public function testItemWithEmptyContent(): void
@@ -186,7 +186,7 @@ class ItemTest extends TestCase
         $content = 'item description';
         $feed = $this->checkFromTemplate($data, $content);
         $item = $feed->get_item();
-        $this->assertInstanceOf(Item::class, $item);
-        $this->assertSame($content, $item->get_content());
+        self::assertInstanceOf(Item::class, $item);
+        self::assertSame($content, $item->get_content());
     }
 }

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -44,7 +44,7 @@ class LocatorTest extends TestCase
         $locator->set_registry($registry);
 
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-        $this->assertSame($data, $feed);
+        self::assertSame($data, $feed);
     }
 
     public function testInvalidMIMEType(): void
@@ -59,7 +59,7 @@ class LocatorTest extends TestCase
         $locator->set_registry($registry);
 
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-        $this->assertSame(null, $feed);
+        self::assertSame(null, $feed);
     }
 
     public function testDirectNoDOM(): void
@@ -71,8 +71,8 @@ class LocatorTest extends TestCase
         $locator->dom = null;
         $locator->set_registry($registry);
 
-        $this->assertTrue($locator->is_feed($data));
-        $this->assertSame($data, $locator->find(SIMPLEPIE_LOCATOR_ALL, $found));
+        self::assertTrue($locator->is_feed($data));
+        self::assertSame($data, $locator->find(SIMPLEPIE_LOCATOR_ALL, $found));
     }
 
     public function testFailDiscoveryNoDOM(): void
@@ -88,8 +88,8 @@ class LocatorTest extends TestCase
         $locator->dom = null;
         $locator->set_registry($registry);
 
-        $this->assertFalse($locator->is_feed($data));
-        $this->assertFalse($locator->find(SIMPLEPIE_LOCATOR_ALL, $found));
+        self::assertFalse($locator->is_feed($data));
+        self::assertFalse($locator->find(SIMPLEPIE_LOCATOR_ALL, $found));
     }
 
     /**
@@ -136,12 +136,12 @@ class LocatorTest extends TestCase
         //$expected = SimplePie_Misc::get_element('link', $data->body);
 
         $feed = $locator->find(SIMPLEPIE_LOCATOR_ALL, $all);
-        $this->assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
-        $this->assertInstanceOf(FileMock::class, $feed);
+        self::assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
+        self::assertInstanceOf(FileMock::class, $feed);
         $success = array_filter($expected, [get_class($this), 'filter_success']);
 
         $found = array_map([get_class($this), 'map_url_file'], $all);
-        $this->assertSame($success, $found);
+        self::assertSame($success, $found);
     }
 
     protected static function filter_success(string $url): bool

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -14,7 +14,7 @@ class SanitizeTest extends TestCase
     {
         $sanitize = new SimplePie_Sanitize();
 
-        $this->assertSame(
+        self::assertSame(
             <<<HTML
 &lt;head&gt; &amp; &lt;body&gt; /\ ' === ' &amp; " === ". Sbohem bez šátečku! Тут был Лёха.
 HTML
@@ -87,6 +87,6 @@ HTML
 
         $base = 'http://example.com/';
 
-        $this->assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
+        self::assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
     }
 }

--- a/tests/SubscribeUrlTest.php
+++ b/tests/SubscribeUrlTest.php
@@ -20,7 +20,7 @@ class SubscribeUrlTest extends TestCase
 
         $feed->init();
 
-        $this->assertSame('https://example.com/feed/2019-10-07', $feed->subscribe_url());
-        $this->assertSame('https://example.com/feed/', $feed->subscribe_url(true));
+        self::assertSame('https://example.com/feed/2019-10-07', $feed->subscribe_url());
+        self::assertSame('https://example.com/feed/', $feed->subscribe_url(true));
     }
 }

--- a/tests/Unit/AuthorTest.php
+++ b/tests/Unit/AuthorTest.php
@@ -16,12 +16,12 @@ class AuthorTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Author'));
+        self::assertTrue(class_exists('SimplePie\Author'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Author'));
+        self::assertTrue(class_exists('SimplePie_Author'));
     }
 
     /**
@@ -494,12 +494,12 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
         $author = $item->get_author();
-        $this->assertInstanceOf(Author::class, $author);
+        self::assertInstanceOf(Author::class, $author);
 
-        $this->assertSame($expected, $author->get_name());
+        self::assertSame($expected, $author->get_name());
     }
 
     /**
@@ -722,11 +722,11 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
         $author = $item->get_contributor();
-        $this->assertInstanceOf(Author::class, $author);
+        self::assertInstanceOf(Author::class, $author);
 
-        $this->assertSame($expected, $author->get_name());
+        self::assertSame($expected, $author->get_name());
     }
 }

--- a/tests/Unit/Cache/BaseDataCacheTest.php
+++ b/tests/Unit/Cache/BaseDataCacheTest.php
@@ -25,7 +25,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertTrue($cache->set_data($key, $value, $ttl));
+        self::assertTrue($cache->set_data($key, $value, $ttl));
     }
 
     public function testSetDataReturnsFalseIfDataCouldNotBeWritten(): void
@@ -39,7 +39,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertFalse($cache->set_data($key, $value, $ttl));
+        self::assertFalse($cache->set_data($key, $value, $ttl));
     }
 
     public function testGetDataReturnsCorrectData(): void
@@ -53,7 +53,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertSame($value, $cache->get_data($key));
+        self::assertSame($value, $cache->get_data($key));
     }
 
     public function testGetDataWithCacheMissReturnsDefault(): void
@@ -66,7 +66,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertSame($default, $cache->get_data($key, $default));
+        self::assertSame($default, $cache->get_data($key, $default));
     }
 
     public function testGetDataWithCacheExpiredReturnsDefault(): void
@@ -80,7 +80,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertSame($default, $cache->get_data($key, $default));
+        self::assertSame($default, $cache->get_data($key, $default));
     }
 
     public function testGetDataWithCacheCorruptionReturnsDefault(): void
@@ -93,7 +93,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertSame($default, $cache->get_data($key, $default));
+        self::assertSame($default, $cache->get_data($key, $default));
     }
 
     public function testDeleteDataReturnsTrueIfDataCouldBeDeleted(): void
@@ -105,7 +105,7 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertTrue($cache->delete_data($key));
+        self::assertTrue($cache->delete_data($key));
     }
 
     public function testDeleteDataReturnsFalseIfDataCouldNotBeDeleted(): void
@@ -117,6 +117,6 @@ class BaseDataCacheTest extends TestCase
 
         $cache = new BaseDataCache($baseCache);
 
-        $this->assertFalse($cache->delete_data($key));
+        self::assertFalse($cache->delete_data($key));
     }
 }

--- a/tests/Unit/Cache/BaseTest.php
+++ b/tests/Unit/Cache/BaseTest.php
@@ -13,11 +13,11 @@ class BaseTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(interface_exists('SimplePie\Cache\Base'));
+        self::assertTrue(interface_exists('SimplePie\Cache\Base'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(interface_exists('SimplePie_Cache_Base'));
+        self::assertTrue(interface_exists('SimplePie_Cache_Base'));
     }
 }

--- a/tests/Unit/Cache/DBTest.php
+++ b/tests/Unit/Cache/DBTest.php
@@ -13,11 +13,11 @@ class DBTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\DB'));
+        self::assertTrue(class_exists('SimplePie\Cache\DB'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_DB'));
+        self::assertTrue(class_exists('SimplePie_Cache_DB'));
     }
 }

--- a/tests/Unit/Cache/FileTest.php
+++ b/tests/Unit/Cache/FileTest.php
@@ -13,11 +13,11 @@ class FileTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\File'));
+        self::assertTrue(class_exists('SimplePie\Cache\File'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_File'));
+        self::assertTrue(class_exists('SimplePie_Cache_File'));
     }
 }

--- a/tests/Unit/Cache/MemcacheTest.php
+++ b/tests/Unit/Cache/MemcacheTest.php
@@ -13,11 +13,11 @@ class MemcacheTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\Memcache'));
+        self::assertTrue(class_exists('SimplePie\Cache\Memcache'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_Memcache'));
+        self::assertTrue(class_exists('SimplePie_Cache_Memcache'));
     }
 }

--- a/tests/Unit/Cache/MemcachedTest.php
+++ b/tests/Unit/Cache/MemcachedTest.php
@@ -13,11 +13,11 @@ class MemcachedTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\Memcached'));
+        self::assertTrue(class_exists('SimplePie\Cache\Memcached'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_Memcached'));
+        self::assertTrue(class_exists('SimplePie_Cache_Memcached'));
     }
 }

--- a/tests/Unit/Cache/MySQLTest.php
+++ b/tests/Unit/Cache/MySQLTest.php
@@ -13,11 +13,11 @@ class MySQLTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\MySQL'));
+        self::assertTrue(class_exists('SimplePie\Cache\MySQL'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_MySQL'));
+        self::assertTrue(class_exists('SimplePie_Cache_MySQL'));
     }
 }

--- a/tests/Unit/Cache/Psr16Test.php
+++ b/tests/Unit/Cache/Psr16Test.php
@@ -28,7 +28,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertTrue($cache->set_data($key, $value, $ttl));
+        self::assertTrue($cache->set_data($key, $value, $ttl));
     }
 
     public function testSetDataReturnsFalseIfDataCouldNotBeWritten(): void
@@ -42,7 +42,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertFalse($cache->set_data($key, $value, $ttl));
+        self::assertFalse($cache->set_data($key, $value, $ttl));
     }
 
     public function testSetDataWithInvalidKeyThrowsInvalidArgumentException(): void
@@ -78,7 +78,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertSame($value, $cache->get_data($key));
+        self::assertSame($value, $cache->get_data($key));
     }
 
     public function testGetDataWithCacheMissReturnsDefault(): void
@@ -91,7 +91,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertSame($default, $cache->get_data($key, $default));
+        self::assertSame($default, $cache->get_data($key, $default));
     }
 
     public function testGetDataWithCacheCorruptionReturnsDefault(): void
@@ -104,7 +104,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertSame($default, $cache->get_data($key, $default));
+        self::assertSame($default, $cache->get_data($key, $default));
     }
 
     public function testGetDataWithInvalidKeyThrowsInvalidArgumentException(): void
@@ -137,7 +137,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertTrue($cache->delete_data($key));
+        self::assertTrue($cache->delete_data($key));
     }
 
     public function testDeleteDataReturnsFalseIfDataCouldNotBeDeleted(): void
@@ -149,7 +149,7 @@ class Psr16Test extends TestCase
 
         $cache = new Psr16($psr16);
 
-        $this->assertFalse($cache->delete_data($key));
+        self::assertFalse($cache->delete_data($key));
     }
 
     public function testDeleteDataWithInvalidKeyThrowsInvalidArgumentException(): void

--- a/tests/Unit/Cache/RedisTest.php
+++ b/tests/Unit/Cache/RedisTest.php
@@ -13,11 +13,11 @@ class RedisTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache\Redis'));
+        self::assertTrue(class_exists('SimplePie\Cache\Redis'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache_Redis'));
+        self::assertTrue(class_exists('SimplePie_Cache_Redis'));
     }
 }

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -13,11 +13,11 @@ class CacheTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Cache'));
+        self::assertTrue(class_exists('SimplePie\Cache'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Cache'));
+        self::assertTrue(class_exists('SimplePie_Cache'));
     }
 }

--- a/tests/Unit/CaptionTest.php
+++ b/tests/Unit/CaptionTest.php
@@ -13,11 +13,11 @@ class CaptionTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Caption'));
+        self::assertTrue(class_exists('SimplePie\Caption'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Caption'));
+        self::assertTrue(class_exists('SimplePie_Caption'));
     }
 }

--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -16,12 +16,12 @@ class CategoryTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Category'));
+        self::assertTrue(class_exists('SimplePie\Category'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Category'));
+        self::assertTrue(class_exists('SimplePie_Category'));
     }
 
     /**
@@ -387,9 +387,9 @@ XML
         $feed->init();
 
         $category = $feed->get_category();
-        $this->assertInstanceOf(Category::class, $category);
+        self::assertInstanceOf(Category::class, $category);
 
-        $this->assertSame($expected, $category->get_label());
+        self::assertSame($expected, $category->get_label());
     }
 
     /**
@@ -815,11 +815,11 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
         $category = $item->get_category();
-        $this->assertInstanceOf(Category::class, $category);
+        self::assertInstanceOf(Category::class, $category);
 
-        $this->assertSame($expected, $category->get_label());
+        self::assertSame($expected, $category->get_label());
     }
 }

--- a/tests/Unit/Content/Type/SnifferTest.php
+++ b/tests/Unit/Content/Type/SnifferTest.php
@@ -13,11 +13,11 @@ class SnifferTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Content\Type\Sniffer'));
+        self::assertTrue(class_exists('SimplePie\Content\Type\Sniffer'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Content_Type_Sniffer'));
+        self::assertTrue(class_exists('SimplePie_Content_Type_Sniffer'));
     }
 }

--- a/tests/Unit/CopyrightTest.php
+++ b/tests/Unit/CopyrightTest.php
@@ -13,11 +13,11 @@ class CopyrightTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Copyright'));
+        self::assertTrue(class_exists('SimplePie\Copyright'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Copyright'));
+        self::assertTrue(class_exists('SimplePie_Copyright'));
     }
 }

--- a/tests/Unit/CreditTest.php
+++ b/tests/Unit/CreditTest.php
@@ -13,11 +13,11 @@ class CreditTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Credit'));
+        self::assertTrue(class_exists('SimplePie\Credit'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Credit'));
+        self::assertTrue(class_exists('SimplePie_Credit'));
     }
 }

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -16,12 +16,12 @@ class EnclosureTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Enclosure'));
+        self::assertTrue(class_exists('SimplePie\Enclosure'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Enclosure'));
+        self::assertTrue(class_exists('SimplePie_Enclosure'));
     }
 
     /**
@@ -35,11 +35,11 @@ class EnclosureTest extends TestCase
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
         $enclosure = $item->get_enclosure(0);
-        $this->assertInstanceOf(Enclosure::class, $enclosure);
-        $this->assertSame($expected, $enclosure->get_link());
+        self::assertInstanceOf(Enclosure::class, $enclosure);
+        self::assertSame($expected, $enclosure->get_link());
     }
 
     /**
@@ -135,8 +135,8 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
-        $this->assertCount($expectedEnclosureCount, (array) $item->get_enclosures());
+        self::assertInstanceOf(Item::class, $item);
+        self::assertCount($expectedEnclosureCount, (array) $item->get_enclosures());
     }
 
     /**

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -13,11 +13,11 @@ class ExceptionTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Exception'));
+        self::assertTrue(class_exists('SimplePie\Exception'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Exception'));
+        self::assertTrue(class_exists('SimplePie_Exception'));
     }
 }

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -16,17 +16,17 @@ class FileTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\File'));
+        self::assertTrue(class_exists('SimplePie\File'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_File'));
+        self::assertTrue(class_exists('SimplePie_File'));
     }
 
     public function testFileExtendsResponse(): void
     {
-        $this->assertInstanceOf(Response::class, new FileMock(''));
+        self::assertInstanceOf(Response::class, new FileMock(''));
     }
 
     /**
@@ -42,7 +42,7 @@ class FileTest extends TestCase
      */
     public function testGetRequestedUriReturnsString(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             'http://example.com/feed',
             $response->get_final_requested_uri()
         );
@@ -53,7 +53,7 @@ class FileTest extends TestCase
      */
     public function testGetStatusCodeReturnsInt(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             200,
             $response->get_status_code()
         );
@@ -64,7 +64,7 @@ class FileTest extends TestCase
      */
     public function testGetHeadersReturnsArray(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             ['content-type' => ['application/atom+xml']],
             $response->get_headers()
         );
@@ -75,7 +75,7 @@ class FileTest extends TestCase
      */
     public function testHasHeadersReturnsTrue(File $response): void
     {
-        $this->assertTrue($response->has_header('Content-Type'));
+        self::assertTrue($response->has_header('Content-Type'));
     }
 
     /**
@@ -83,7 +83,7 @@ class FileTest extends TestCase
      */
     public function testHasHeadersReturnsFalse(File $response): void
     {
-        $this->assertFalse($response->has_header('X-Custom-Header'));
+        self::assertFalse($response->has_header('X-Custom-Header'));
     }
 
     /**
@@ -91,7 +91,7 @@ class FileTest extends TestCase
      */
     public function testGetHeaderReturnsArray(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             ['application/atom+xml'],
             $response->get_header('CONTENT-TYPE')
         );
@@ -102,7 +102,7 @@ class FileTest extends TestCase
      */
     public function testGetHeaderReturnsEmptyArray(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             [],
             $response->get_header('X-Custom-Header')
         );
@@ -113,7 +113,7 @@ class FileTest extends TestCase
      */
     public function testGetHeaderLineReturnsString(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             'application/atom+xml',
             $response->get_header_line('content-Type')
         );
@@ -124,7 +124,7 @@ class FileTest extends TestCase
      */
     public function testGetHeaderLineReturnsEmptyString(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $response->get_header_line('X-Custom-Header')
         );
@@ -135,7 +135,7 @@ class FileTest extends TestCase
      */
     public function testGetBodyContentReturnsString(File $response): void
     {
-        $this->assertSame(
+        self::assertSame(
             '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />',
             $response->get_body_content()
         );

--- a/tests/Unit/GzdecodeTest.php
+++ b/tests/Unit/GzdecodeTest.php
@@ -13,11 +13,11 @@ class GzdecodeTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Gzdecode'));
+        self::assertTrue(class_exists('SimplePie\Gzdecode'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_gzdecode'));
+        self::assertTrue(class_exists('SimplePie_gzdecode'));
     }
 }

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -14,12 +14,12 @@ class ParserTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\HTTP\Parser'));
+        self::assertTrue(class_exists('SimplePie\HTTP\Parser'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_HTTP_Parser'));
+        self::assertTrue(class_exists('SimplePie_HTTP_Parser'));
     }
 
     /**
@@ -51,12 +51,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -67,12 +67,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.0 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -83,12 +83,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => 'text/plain'], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => 'text/plain'], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     public function testDuplicateHeaders(): void
@@ -96,8 +96,8 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Security-Policy: default-src 'self' http://example.com\r\nContent-Type: text/plain\r\nContent-Security-Policy: script-src http://example.com/\r\n\r\n";
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data);
-        $this->assertTrue($parser->parse());
-        $this->assertSame([
+        self::assertTrue($parser->parse());
+        self::assertSame([
             // Later Content-Type takes precedence.
             'content-type' => 'text/plain',
             // This is invalid but we are going to remove the parser eventually.
@@ -113,12 +113,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data, true);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => ['text/plain']], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -129,12 +129,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.0 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data, true);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => ['text/plain']], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     /**
@@ -145,12 +145,12 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 Connection established\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" . $data;
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data, true);
-        $this->assertTrue($parser->parse());
-        $this->assertSame(1.1, $parser->http_version);
-        $this->assertSame(200, $parser->status_code);
-        $this->assertSame('OK', $parser->reason);
-        $this->assertSame(['content-type' => ['text/plain']], $parser->headers);
-        $this->assertSame($expected, $parser->body);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 
     public function testDuplicateHeadersPsr7(): void
@@ -158,8 +158,8 @@ class ParserTest extends TestCase
         $data = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Security-Policy: default-src 'self' http://example.com\r\nContent-Type: text/plain\r\nContent-Security-Policy: script-src http://example.com/\r\n\r\n";
         $data = Parser::prepareHeaders($data);
         $parser = new Parser($data, true);
-        $this->assertTrue($parser->parse());
-        $this->assertSame([
+        self::assertTrue($parser->parse());
+        self::assertSame([
             // Later Content-Type takes precedence.
             'content-type' => ['text/plain'],
             'content-security-policy' => ["default-src 'self' http://example.com", 'script-src http://example.com/'],

--- a/tests/Unit/HTTP/Psr18ClientTest.php
+++ b/tests/Unit/HTTP/Psr18ClientTest.php
@@ -27,7 +27,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(UriFactoryInterface::class)
         );
 
-        $this->assertInstanceOf(Response::class, $client->request(Client::METHOD_GET, 'https://example.com/feed.xml'));
+        self::assertInstanceOf(Response::class, $client->request(Client::METHOD_GET, 'https://example.com/feed.xml'));
     }
 
     public function testRequestReturnsResponseWithStatusCode429(): void
@@ -45,7 +45,7 @@ class Psr18ClientTest extends TestCase
         );
 
         // Make sure no ClientException is thrown on status code 429
-        $this->assertSame(
+        self::assertSame(
             429,
             $client->request(Client::METHOD_GET, 'https://example.com/429-error')->get_status_code()
         );
@@ -78,7 +78,7 @@ class Psr18ClientTest extends TestCase
 
         $response = $client->request(Client::METHOD_GET, 'https://example.com/redirect');
 
-        $this->assertSame('https://example.com/redirect', $response->get_permanent_uri());
-        $this->assertSame('https://example.com/feed.xml', $response->get_final_requested_uri());
+        self::assertSame('https://example.com/redirect', $response->get_permanent_uri());
+        self::assertSame('https://example.com/feed.xml', $response->get_final_requested_uri());
     }
 }

--- a/tests/Unit/HTTP/Psr7ResponseTest.php
+++ b/tests/Unit/HTTP/Psr7ResponseTest.php
@@ -17,7 +17,7 @@ class Psr7ResponseTest extends TestCase
 {
     public function testPsr7ResponseExtendsResponse(): void
     {
-        $this->assertInstanceOf(Response::class, new Psr7Response($this->createMock(ResponseInterface::class), '', ''));
+        self::assertInstanceOf(Response::class, new Psr7Response($this->createMock(ResponseInterface::class), '', ''));
     }
 
     public function createPsr7Response(): Psr7Response
@@ -53,7 +53,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             'https://example.com',
             $response->get_permanent_uri()
         );
@@ -63,7 +63,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             'https://example.com/feed.xml',
             $response->get_final_requested_uri()
         );
@@ -73,7 +73,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             200,
             $response->get_status_code()
         );
@@ -83,7 +83,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             ['content-type' => ['application/atom+xml']],
             $response->get_headers()
         );
@@ -93,21 +93,21 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertTrue($response->has_header('Content-Type'));
+        self::assertTrue($response->has_header('Content-Type'));
     }
 
     public function testHasHeadersReturnsFalse(): void
     {
         $response = $this->createPsr7Response();
 
-        $this->assertFalse($response->has_header('X-Custom-Header'));
+        self::assertFalse($response->has_header('X-Custom-Header'));
     }
 
     public function testGetHeaderReturnsArray(): void
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             ['application/atom+xml'],
             $response->get_header('CONTENT-TYPE')
         );
@@ -117,7 +117,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             [],
             $response->get_header('X-Custom-Header')
         );
@@ -127,7 +127,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             'application/atom+xml',
             $response->get_header_line('content-Type')
         );
@@ -137,7 +137,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             '',
             $response->get_header_line('X-Custom-Header')
         );
@@ -147,7 +147,7 @@ class Psr7ResponseTest extends TestCase
     {
         $response = $this->createPsr7Response();
 
-        $this->assertSame(
+        self::assertSame(
             '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom" />',
             $response->get_body_content()
         );

--- a/tests/Unit/IRITest.php
+++ b/tests/Unit/IRITest.php
@@ -14,12 +14,12 @@ class IRITest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\IRI'));
+        self::assertTrue(class_exists('SimplePie\IRI'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_IRI'));
+        self::assertTrue(class_exists('SimplePie_IRI'));
     }
 
     /**
@@ -82,8 +82,8 @@ class IRITest extends TestCase
     {
         $base = new IRI('http://a/b/c/d;p?q');
         $absolutized = IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -93,7 +93,7 @@ class IRITest extends TestCase
     {
         $base = new IRI('http://a/b/c/d;p?q');
         $expected = new IRI($expected);
-        $this->assertEquals($expected, IRI::absolutize($base, $relative));
+        self::assertEquals($expected, IRI::absolutize($base, $relative));
     }
 
     /**
@@ -103,9 +103,9 @@ class IRITest extends TestCase
     {
         $base = 'http://a/b/c/d;p?q';
         $absolutized = IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
-        $this->assertSame($expected, (string) IRI::absolutize($base, $relative));
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
+        self::assertSame($expected, (string) IRI::absolutize($base, $relative));
     }
 
     /**
@@ -140,8 +140,8 @@ class IRITest extends TestCase
     {
         $base = new IRI($base);
         $absolutized = IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -151,7 +151,7 @@ class IRITest extends TestCase
     {
         $base = new IRI($base);
         $expected = new IRI($expected);
-        $this->assertEquals($expected, IRI::absolutize($base, $relative));
+        self::assertEquals($expected, IRI::absolutize($base, $relative));
     }
 
     /**
@@ -174,7 +174,7 @@ class IRITest extends TestCase
     {
         $base = new IRI('http://example.com/');
         $base->set_query($query);
-        $this->assertSame($expected, $base->get_iri());
+        self::assertSame($expected, $base->get_iri());
     }
 
     /**
@@ -185,7 +185,7 @@ class IRITest extends TestCase
         $base = new IRI('http://example.com/');
         $base->set_query($query);
         $expected = new IRI($expected);
-        $this->assertEquals($expected, $base);
+        self::assertEquals($expected, $base);
     }
 
     /**
@@ -206,8 +206,8 @@ class IRITest extends TestCase
     {
         $base = new IRI($base);
         $absolutized = IRI::absolutize($base, $relative);
-        $this->assertNotFalse($absolutized);
-        $this->assertSame($expected, $absolutized->get_iri());
+        self::assertNotFalse($absolutized);
+        self::assertSame($expected, $absolutized->get_iri());
     }
 
     /**
@@ -217,7 +217,7 @@ class IRITest extends TestCase
     {
         $base = new IRI($base);
         $expected = new IRI($expected);
-        $this->assertEquals($expected, IRI::absolutize($base, $relative));
+        self::assertEquals($expected, IRI::absolutize($base, $relative));
     }
 
     /**
@@ -312,7 +312,7 @@ class IRITest extends TestCase
     public function testStringNormalization(string $input, string $output): void
     {
         $input = new IRI($input);
-        $this->assertSame($output, $input->get_iri());
+        self::assertSame($output, $input->get_iri());
     }
 
     /**
@@ -322,7 +322,7 @@ class IRITest extends TestCase
     {
         $input = new IRI($input);
         $output = new IRI($output);
-        $this->assertEquals($output, $input);
+        self::assertEquals($output, $input);
     }
 
     /**
@@ -343,7 +343,7 @@ class IRITest extends TestCase
     public function testURIConversion(string $input, string $output): void
     {
         $input = new IRI($input);
-        $this->assertSame($output, $input->get_uri());
+        self::assertSame($output, $input->get_uri());
     }
 
     /**
@@ -363,7 +363,7 @@ class IRITest extends TestCase
     {
         $input = new IRI($input);
         $output = new IRI($output);
-        $this->assertEquals($output, $input);
+        self::assertEquals($output, $input);
     }
 
     /**
@@ -383,12 +383,12 @@ class IRITest extends TestCase
     {
         $input = new IRI($input);
         $output = new IRI($output);
-        $this->assertNotEquals($output, $input);
+        self::assertNotEquals($output, $input);
     }
 
     public function testInvalidAbsolutizeBase(): void
     {
-        $this->assertFalse(IRI::absolutize('://not a URL', '../'));
+        self::assertFalse(IRI::absolutize('://not a URL', '../'));
     }
 
     public function testInvalidPathNoHost(): void
@@ -396,21 +396,21 @@ class IRITest extends TestCase
         $iri = new IRI();
         $iri->scheme = 'http';
         $iri->path = '//test';
-        $this->assertFalse($iri->is_valid());
+        self::assertFalse($iri->is_valid());
     }
 
     public function testInvalidRelativePathContainsColon(): void
     {
         $iri = new IRI();
         $iri->path = '/test:/';
-        $this->assertFalse($iri->is_valid());
+        self::assertFalse($iri->is_valid());
     }
 
     public function testValidRelativePathContainsColon(): void
     {
         $iri = new IRI();
         $iri->path = '/test/:';
-        $this->assertTrue($iri->is_valid());
+        self::assertTrue($iri->is_valid());
     }
 
     public function testFullGamut(): void
@@ -422,12 +422,12 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testReadAliased(): void
@@ -439,12 +439,12 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testWriteAliased(): void
@@ -456,23 +456,23 @@ class IRITest extends TestCase
         $iri->path = '/test/';
         $iri->fragment = 'test';
 
-        $this->assertSame('http', $iri->scheme);
-        $this->assertSame('user:password', $iri->userinfo);
-        $this->assertSame('example.com', $iri->host);
-        $this->assertSame(80, $iri->port);
-        $this->assertSame('/test/', $iri->path);
-        $this->assertSame('test', $iri->fragment);
+        self::assertSame('http', $iri->scheme);
+        self::assertSame('user:password', $iri->userinfo);
+        self::assertSame('example.com', $iri->host);
+        self::assertSame(80, $iri->port);
+        self::assertSame('/test/', $iri->path);
+        self::assertSame('test', $iri->fragment);
     }
 
     public function testNonexistentProperty(): void
     {
         $iri = new IRI();
-        $this->assertFalse(isset($iri->nonexistent_prop));
+        self::assertFalse(isset($iri->nonexistent_prop));
 
         // PHPUnit 10 compatible way to test trigger_error().
         set_error_handler(
             function ($errno, $errstr): bool {
-                $this->assertSame(
+                self::assertSame(
                     'Undefined property: SimplePie\IRI::nonexistent_prop',
                     $errstr
                 );
@@ -491,8 +491,8 @@ class IRITest extends TestCase
         $iri = new IRI('http://example.com/a/?b=c#d');
         $iri->host = null;
 
-        $this->assertSame(null, $iri->host);
-        $this->assertSame('http:/a/?b=c#d', (string) $iri);
+        self::assertSame(null, $iri->host);
+        self::assertSame('http:/a/?b=c#d', (string) $iri);
     }
 
     public function testBadPort(): void
@@ -500,6 +500,6 @@ class IRITest extends TestCase
         $iri = new IRI();
         $iri->port = 'example';
 
-        $this->assertSame(null, $iri->port);
+        self::assertSame(null, $iri->port);
     }
 }

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -15,12 +15,12 @@ class ItemTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Item'));
+        self::assertTrue(class_exists('SimplePie\Item'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Item'));
+        self::assertTrue(class_exists('SimplePie_Item'));
     }
 
     /**
@@ -657,9 +657,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_content());
+        self::assertSame($expected, $item->get_content());
     }
 
     /**
@@ -1332,9 +1332,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_date('U'));
+        self::assertSame($expected, $item->get_date('U'));
     }
 
     /**
@@ -1970,9 +1970,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_description());
+        self::assertSame($expected, $item->get_description());
     }
 
     /**
@@ -2374,9 +2374,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_id());
+        self::assertSame($expected, $item->get_id());
     }
 
     /**
@@ -2601,9 +2601,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_latitude());
+        self::assertSame($expected, $item->get_latitude());
     }
 
     /**
@@ -2828,9 +2828,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_longitude());
+        self::assertSame($expected, $item->get_longitude());
     }
 
     /**
@@ -3353,9 +3353,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_content());
+        self::assertSame($expected, $item->get_content());
     }
 
     /**
@@ -3431,9 +3431,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_permalink());
+        self::assertSame($expected, $item->get_permalink());
     }
 
     /**
@@ -4944,9 +4944,9 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
-        $this->assertSame($expected, $item->get_title());
+        self::assertSame($expected, $item->get_title());
     }
 
     /**
@@ -4960,10 +4960,10 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
         $thumbnail = $item->get_thumbnail();
-        $this->assertNotNull($thumbnail);
-        $this->assertSame($expected, $thumbnail['url']);
+        self::assertNotNull($thumbnail);
+        self::assertSame($expected, $thumbnail['url']);
     }
 
     /**

--- a/tests/Unit/LocatorTest.php
+++ b/tests/Unit/LocatorTest.php
@@ -20,12 +20,12 @@ class LocatorTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Locator'));
+        self::assertTrue(class_exists('SimplePie\Locator'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Locator'));
+        self::assertTrue(class_exists('SimplePie_Locator'));
     }
 
     /**
@@ -57,7 +57,7 @@ class LocatorTest extends TestCase
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
-        $this->assertSame($data, $feed);
+        self::assertSame($data, $feed);
     }
 
     public function testInvalidMIMEType(): void
@@ -72,7 +72,7 @@ class LocatorTest extends TestCase
         $locator->set_registry($registry);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
-        $this->assertSame(null, $feed);
+        self::assertSame(null, $feed);
     }
 
     public function testDirectNoDOM(): void
@@ -84,8 +84,8 @@ class LocatorTest extends TestCase
         $locator->dom = null;
         $locator->set_registry($registry);
 
-        $this->assertTrue($locator->is_feed($data));
-        $this->assertSame($data, $locator->find(SimplePie::LOCATOR_ALL, $found));
+        self::assertTrue($locator->is_feed($data));
+        self::assertSame($data, $locator->find(SimplePie::LOCATOR_ALL, $found));
     }
 
     public function testFailDiscoveryNoDOM(): void
@@ -101,8 +101,8 @@ class LocatorTest extends TestCase
         $locator->dom = null;
         $locator->set_registry($registry);
 
-        $this->assertFalse($locator->is_feed($data));
-        $this->assertFalse($locator->find(SimplePie::LOCATOR_ALL, $found));
+        self::assertFalse($locator->is_feed($data));
+        self::assertFalse($locator->find(SimplePie::LOCATOR_ALL, $found));
     }
 
     /**
@@ -149,12 +149,12 @@ class LocatorTest extends TestCase
         //$expected = SimplePie_Misc::get_element('link', $data->body);
 
         $feed = $locator->find(SimplePie::LOCATOR_ALL, $all);
-        $this->assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
-        $this->assertInstanceOf(FileMock::class, $feed);
+        self::assertFalse($locator->is_feed($data), 'HTML document not be a feed itself');
+        self::assertInstanceOf(FileMock::class, $feed);
         $success = array_filter($expected, [get_class($this), 'filter_success']);
 
         $found = array_map([get_class($this), 'map_url_file'], $all);
-        $this->assertSame($success, $found);
+        self::assertSame($success, $found);
     }
 
     protected function filter_success(string $url): bool

--- a/tests/Unit/MiscTest.php
+++ b/tests/Unit/MiscTest.php
@@ -16,24 +16,24 @@ class MiscTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists(Misc::class));
+        self::assertTrue(class_exists(Misc::class));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists(SimplePie_Misc::class));
+        self::assertTrue(class_exists(SimplePie_Misc::class));
     }
 
     public function test_existence_of_get_element(): void
     {
         // BC: make sure that get_element() exists
-        $this->assertSame([], Misc::get_element('', ''));
+        self::assertSame([], Misc::get_element('', ''));
     }
 
     public function test_existence_of_entities_decode(): void
     {
         // BC: make sure that entities_decode() exists
-        $this->assertSame('', Misc::entities_decode(''));
+        self::assertSame('', Misc::entities_decode(''));
     }
 
     /* ## UTF-8 methods */
@@ -67,7 +67,7 @@ class MiscTest extends TestCase
     public function test_convert_UTF8(string $input, string $expected, string $encoding): void
     {
         $encoding = Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) Misc::change_encoding($input, $encoding, 'UTF-8'));
+        self::assertSameBin2Hex($expected, (string) Misc::change_encoding($input, $encoding, 'UTF-8'));
     }
 
     /**
@@ -95,7 +95,7 @@ class MiscTest extends TestCase
         }
 
         $encoding = Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_mbstring($input, $encoding, 'UTF-8'));
+        self::assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_mbstring($input, $encoding, 'UTF-8'));
     }
 
     /**
@@ -123,7 +123,7 @@ class MiscTest extends TestCase
         }
 
         $encoding = Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_iconv($input, $encoding, 'UTF-8'));
+        self::assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_iconv($input, $encoding, 'UTF-8'));
     }
 
     /**
@@ -151,7 +151,7 @@ class MiscTest extends TestCase
         }
 
         $encoding = Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_uconverter($input, $encoding, 'UTF-8'));
+        self::assertSameBin2Hex($expected, (string) MiscWithPublicStaticMethodsMock::change_encoding_uconverter($input, $encoding, 'UTF-8'));
     }
 
     /* ## UTF-16 methods */
@@ -174,12 +174,12 @@ class MiscTest extends TestCase
     public function test_convert_UTF16(string $input, string $expected, string $encoding): void
     {
         $encoding = Misc::encoding($encoding);
-        $this->assertSameBin2Hex($expected, (string) Misc::change_encoding($input, $encoding, 'UTF-16'));
+        self::assertSameBin2Hex($expected, (string) Misc::change_encoding($input, $encoding, 'UTF-16'));
     }
 
     public function test_nonexistent(): void
     {
-        $this->assertFalse(Misc::change_encoding('', 'TESTENC', 'UTF-8'));
+        self::assertFalse(Misc::change_encoding('', 'TESTENC', 'UTF-8'));
     }
 
     public function assertSameBin2Hex(string $expected, string $actual, string $message = ''): void
@@ -187,7 +187,7 @@ class MiscTest extends TestCase
         $expected = bin2hex($expected);
         $actual = bin2hex($actual);
 
-        $this->assertSame($expected, $actual, $message);
+        self::assertSame($expected, $actual, $message);
     }
 
     /**
@@ -378,7 +378,7 @@ class MiscTest extends TestCase
     {
         $base = 'http://a/b/c/d;p?q';
 
-        $this->assertSame(
+        self::assertSame(
             $expected,
             Misc::absolutize_url($relative, $base)
         );
@@ -483,7 +483,7 @@ class MiscTest extends TestCase
      */
     public function test_absolutize_url_bugs(string $base, string $relative, string $expected): void
     {
-        $this->assertSame(
+        self::assertSame(
             $expected,
             Misc::absolutize_url($relative, $base)
         );
@@ -734,7 +734,7 @@ class MiscTest extends TestCase
      */
     public function test_parse_date(string $data, $expected): void
     {
-        $this->assertSame(
+        self::assertSame(
             $expected,
             Misc::parse_date($data)
         );

--- a/tests/Unit/Net/IPv6Test.php
+++ b/tests/Unit/Net/IPv6Test.php
@@ -13,11 +13,11 @@ class IPv6Test extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Net\IPv6'));
+        self::assertTrue(class_exists('SimplePie\Net\IPv6'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Net_IPv6'));
+        self::assertTrue(class_exists('SimplePie_Net_IPv6'));
     }
 }

--- a/tests/Unit/Parse/DateTest.php
+++ b/tests/Unit/Parse/DateTest.php
@@ -14,12 +14,12 @@ class DateTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Parse\Date'));
+        self::assertTrue(class_exists('SimplePie\Parse\Date'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Parse_Date'));
+        self::assertTrue(class_exists('SimplePie_Parse_Date'));
     }
 
     /**
@@ -75,7 +75,7 @@ class DateTest extends TestCase
     public function testW3cDtf(string $data, int $expected): void
     {
         $date = new Date();
-        $this->assertSame(
+        self::assertSame(
             $expected,
             $date->date_w3cdtf($data)
         );

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -15,12 +15,12 @@ class ParserTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Parser'));
+        self::assertTrue(class_exists('SimplePie\Parser'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Parser'));
+        self::assertTrue(class_exists('SimplePie_Parser'));
     }
 
     /**
@@ -305,9 +305,9 @@ class ParserTest extends TestCase
 
         $result = $parser->parse($feed, 'UTF-8', $base);
 
-        $this->assertTrue($result);
-        $this->assertSame($parser->get_error_code(), null);
-        $this->assertSame($parser->get_error_string(), null);
-        $this->assertSame($parser->get_data(), $parsedData);
+        self::assertTrue($result);
+        self::assertSame($parser->get_error_code(), null);
+        self::assertSame($parser->get_error_string(), null);
+        self::assertSame($parser->get_data(), $parsedData);
     }
 }

--- a/tests/Unit/RatingTest.php
+++ b/tests/Unit/RatingTest.php
@@ -13,11 +13,11 @@ class RatingTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Rating'));
+        self::assertTrue(class_exists('SimplePie\Rating'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Rating'));
+        self::assertTrue(class_exists('SimplePie_Rating'));
     }
 }

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -18,12 +18,12 @@ class RegistryTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists(Registry::class));
+        self::assertTrue(class_exists(Registry::class));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Registry'));
+        self::assertTrue(class_exists('SimplePie_Registry'));
     }
 
     /**
@@ -37,7 +37,7 @@ class RegistryTest extends TestCase
     {
         $registry = new Registry();
 
-        $this->assertSame($expected, $registry->get_class($type));
+        self::assertSame($expected, $registry->get_class($type));
     }
 
     /**
@@ -104,7 +104,7 @@ class RegistryTest extends TestCase
 
         $registry->register($registeredType, $classname);
 
-        $this->assertSame($classname, $registry->get_class($requestedType));
+        self::assertSame($classname, $registry->get_class($requestedType));
     }
 
     /**

--- a/tests/Unit/RestrictionTest.php
+++ b/tests/Unit/RestrictionTest.php
@@ -17,12 +17,12 @@ class RestrictionTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Restriction'));
+        self::assertTrue(class_exists('SimplePie\Restriction'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Restriction'));
+        self::assertTrue(class_exists('SimplePie_Restriction'));
     }
 
     /**
@@ -86,14 +86,14 @@ XML
         $feed->init();
 
         $item = $feed->get_item(0);
-        $this->assertInstanceOf(Item::class, $item);
+        self::assertInstanceOf(Item::class, $item);
 
         $enclosure = $item->get_enclosure();
-        $this->assertInstanceOf(Enclosure::class, $enclosure);
+        self::assertInstanceOf(Enclosure::class, $enclosure);
 
         $restriction = $enclosure->get_restriction();
-        $this->assertInstanceOf(Restriction::class, $restriction);
+        self::assertInstanceOf(Restriction::class, $restriction);
 
-        $this->assertSame($expected, $restriction->get_relationship());
+        self::assertSame($expected, $restriction->get_relationship());
     }
 }

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -16,19 +16,19 @@ class SanitizeTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Sanitize'));
+        self::assertTrue(class_exists('SimplePie\Sanitize'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Sanitize'));
+        self::assertTrue(class_exists('SimplePie_Sanitize'));
     }
 
     public function testSanitize(): void
     {
         $sanitize = new Sanitize();
 
-        $this->assertSame(
+        self::assertSame(
             <<<HTML
 &lt;head&gt; &amp; &lt;body&gt; /\ ' === ' &amp; " === ". Sbohem bez šátečku! Тут был Лёха.
 HTML
@@ -101,6 +101,6 @@ HTML
 
         $base = 'http://example.com/';
 
-        $this->assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
+        self::assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
     }
 }

--- a/tests/Unit/SimplePieTest.php
+++ b/tests/Unit/SimplePieTest.php
@@ -24,12 +24,12 @@ class SimplePieTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\SimplePie'));
+        self::assertTrue(class_exists('SimplePie\SimplePie'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists(SimplePie::class));
+        self::assertTrue(class_exists(SimplePie::class));
     }
 
     /**
@@ -90,7 +90,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -105,7 +105,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -120,7 +120,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -135,7 +135,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -150,7 +150,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -170,7 +170,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     /**
@@ -190,7 +190,7 @@ class SimplePieTest extends TestCase
 	</channel>
 </rss>';
         $feed = $this->createFeedWithTemplate($data, $title);
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 
     public function testItemWithEmptyContent(): void
@@ -207,8 +207,8 @@ class SimplePieTest extends TestCase
         $content = 'item description';
         $feed = $this->createFeedWithTemplate($data, $content);
         $item = $feed->get_item();
-        $this->assertInstanceOf(Item::class, $item);
-        $this->assertSame($content, $item->get_content());
+        self::assertInstanceOf(Item::class, $item);
+        self::assertSame($content, $item->get_content());
     }
 
     public function testSetPsr16Cache(): void
@@ -232,7 +232,7 @@ class SimplePieTest extends TestCase
         // PHPUnit 10 compatible way to test trigger_error().
         set_error_handler(
             function ($errno, $errstr): bool {
-                $this->assertSame(
+                self::assertSame(
                     '"SimplePie\SimplePie::set_cache_class()" is deprecated since SimplePie 1.3, please use "SimplePie\SimplePie::set_cache()" instead.',
                     $errstr
                 );
@@ -281,8 +281,8 @@ class SimplePieTest extends TestCase
 
         $feed->init();
 
-        $this->assertSame('https://example.com/feed/2019-10-07', $feed->subscribe_url());
-        $this->assertSame('https://example.com/feed/', $feed->subscribe_url(true));
+        self::assertSame('https://example.com/feed/2019-10-07', $feed->subscribe_url());
+        self::assertSame('https://example.com/feed/', $feed->subscribe_url(true));
     }
 
     /**
@@ -595,7 +595,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_copyright());
+        self::assertSame($expected, $feed->get_copyright());
     }
 
     /**
@@ -1006,7 +1006,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_description());
+        self::assertSame($expected, $feed->get_description());
     }
 
     /**
@@ -1303,7 +1303,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_image_height());
+        self::assertSame($expected, $feed->get_image_height());
     }
 
     /**
@@ -1400,7 +1400,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_image_link());
+        self::assertSame($expected, $feed->get_image_link());
     }
 
     /**
@@ -1647,7 +1647,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_image_title());
+        self::assertSame($expected, $feed->get_image_title());
     }
 
     /**
@@ -1896,7 +1896,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_image_url());
+        self::assertSame($expected, $feed->get_image_url());
     }
 
     /**
@@ -2198,7 +2198,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_image_width());
+        self::assertSame($expected, $feed->get_image_width());
     }
 
     /**
@@ -2453,7 +2453,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_language());
+        self::assertSame($expected, $feed->get_language());
     }
 
     /**
@@ -2721,7 +2721,7 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_link());
+        self::assertSame($expected, $feed->get_link());
     }
 
     /**
@@ -3145,6 +3145,6 @@ XML
         $feed->enable_cache(false);
         $feed->init();
 
-        $this->assertSame($expected, $feed->get_title());
+        self::assertSame($expected, $feed->get_title());
     }
 }

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -13,11 +13,11 @@ class SourceTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\Source'));
+        self::assertTrue(class_exists('SimplePie\Source'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_Source'));
+        self::assertTrue(class_exists('SimplePie_Source'));
     }
 }

--- a/tests/Unit/XML/Declaration/ParserTest.php
+++ b/tests/Unit/XML/Declaration/ParserTest.php
@@ -13,11 +13,11 @@ class ParserTest extends TestCase
 {
     public function testNamespacedClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie\XML\Declaration\Parser'));
+        self::assertTrue(class_exists('SimplePie\XML\Declaration\Parser'));
     }
 
     public function testClassExists(): void
     {
-        $this->assertTrue(class_exists('SimplePie_XML_Declaration_Parser'));
+        self::assertTrue(class_exists('SimplePie_XML_Declaration_Parser'));
     }
 }


### PR DESCRIPTION
Flagged by PHPStan (strict mode). Found during https://github.com/simplepie/simplepie/pull/939

I am actually surprised that the [PHPUnit documentation](https://docs.phpunit.de/en/12.3/assertions.html) proposes to use either `$this->assertTrue()` or `self::assertTrue()`. A static method should be called statically (I could not even find in the official PHP documentation anything that suggests that it should be allowed otherwise, but it does still work so far):
* https://phpstan.org/error-identifiers/staticMethod.dynamicCall
* https://github.com/phpstan/phpstan/issues/514
