### PR TITLE
Minor PHPStan type hint compatibility

### DIFF
--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -42,7 +42,7 @@ class Parser
     /**
      * Key/value pairs of the headers
      *
-     * @var (Psr7Compatible is true ? array<string, non-empty-array<string>> : array<string, string>)
+     * @phpstan-var (Psr7Compatible is true ? array<string, non-empty-array<string>> : array<string, string>)
      */
     public $headers = [];
 


### PR DESCRIPTION
This type hint is a syntax only supported by PHPStan, so it generates errors in other systems such as Intellephense
