### PR TITLE
File: Various clean-ups

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -149,10 +149,13 @@ class File implements Response
                 } else {
                     // For PHPStan: `curl_exec` returns `false` only on error so the `is_string` check will always pass.
                     \assert(is_string($responseHeaders));
+                    if (curl_getinfo($fp, CURLINFO_HTTP_CONNECTCODE) !== 0) {
+                        // TODO: Replace with `CURLOPT_SUPPRESS_CONNECT_HEADERS` once PHP 7.2 support is dropped.
+                        $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders($responseHeaders);
+                    }
                     if (\PHP_VERSION_ID < 80000) {
                         curl_close($fp);
                     }
-                    $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders($responseHeaders);
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);

--- a/src/File.php
+++ b/src/File.php
@@ -147,10 +147,12 @@ class File implements Response
                     $this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp);
                     $this->success = false;
                 } else {
+                    // For PHPStan: `curl_exec` returns `false` only on error so the `is_string` check will always pass.
+                    \assert(is_string($responseHeaders));
                     if (\PHP_VERSION_ID < 80000) {
                         curl_close($fp);
                     }
-                    $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders((string) $responseHeaders);
+                    $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders($responseHeaders);
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);

--- a/src/File.php
+++ b/src/File.php
@@ -151,12 +151,10 @@ class File implements Response
                     if ($info = curl_getinfo($fp)) {
                         $this->url = $info['url'];
                     }
-                    // For PHPStan: We already checked that error did not occur.
-                    assert(is_array($info) && $info['redirect_count'] >= 0);
                     if (\PHP_VERSION_ID < 80000) {
                         curl_close($fp);
                     }
-                    $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders((string) $responseHeaders, $info['redirect_count'] + 1);
+                    $responseHeaders = \SimplePie\HTTP\Parser::prepareHeaders((string) $responseHeaders);
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);

--- a/src/File.php
+++ b/src/File.php
@@ -147,10 +147,6 @@ class File implements Response
                     $this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp);
                     $this->success = false;
                 } else {
-                    // Use the updated url provided by curl_getinfo after any redirects.
-                    if ($info = curl_getinfo($fp)) {
-                        $this->url = $info['url'];
-                    }
                     if (\PHP_VERSION_ID < 80000) {
                         curl_close($fp);
                     }

--- a/src/File.php
+++ b/src/File.php
@@ -155,7 +155,6 @@ class File implements Response
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);
                         $this->body = $parser->body;
-                        $this->status_code = $parser->status_code;
                         if ((in_array($this->status_code, [300, 301, 302, 303, 307]) || $this->status_code > 307 && $this->status_code < 400) && ($locationHeader = $this->get_header_line('location')) !== '' && $this->redirects < $redirects) {
                             $this->redirects++;
                             $location = \SimplePie\Misc::absolutize_url($locationHeader, $url);

--- a/src/File.php
+++ b/src/File.php
@@ -143,7 +143,7 @@ class File implements Response
                     $responseHeaders = curl_exec($fp);
                 }
                 $this->status_code = curl_getinfo($fp, CURLINFO_HTTP_CODE);
-                if (curl_errno($fp)) {
+                if (curl_errno($fp) !== CURLE_OK) {
                     $this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp);
                     $this->success = false;
                 } else {


### PR DESCRIPTION
- Remove redundant redirect count check: [`CURLINFO_REDIRECT_COUNT`] is only non-zero when [`CURLOPT_FOLLOWLOCATION`] is enabled but we track redirects ourselves since 692e8bc19bc4aca20b57474cca2a1d234ce89d63.

- Remove redundant url setting: Since starting to handle redirects ourselves in 692e8bc19bc4aca20b57474cca2a1d234ce89d63, `url` info item (aka `CURLINFO_EFFECTIVE_URL`) will be the same as the initial URI.

- Remove redundant status_code setting: In fact, when the server sends interim responses, this was counterproductive – it would overwrite the final response code returned by `CURLINFO_HTTP_CODE` with the interim one (e.g. 100). Though, the parser will still include the headers of all but the first response in the body.

- Avoid truthiness conversion of `curl_errno`: Explicit comparison is clearer than relying on `CURLE_OK` being falsey (`0`).

- Replace redundant string cast with assertion: This is only needed for PHPStan. Making the type assertion explicit and moving it earlier will allow us to make the `prepareHeaders` call conditional without having to add more casts.

- Make “header preparation” conditional: The method call was introduced in 4b1fc33c2a87e14f785d592cfe83f05434ccbdd8 to support tunneling through HTTP proxy using CONNECT method, whose response curl includes in the `curl_exec` result. Ideally, we would prevent that with [`CURLOPT_SUPPRESS_CONNECT_HEADERS`] but that is only available in PHP 7.3.

[`CURLOPT_FOLLOWLOCATION`]: https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html
[`CURLINFO_REDIRECT_COUNT`]: https://curl.se/libcurl/c/CURLINFO_REDIRECT_COUNT.html
[`CURLOPT_SUPPRESS_CONNECT_HEADERS`]: https://www.php.net/manual/en/curl.constants.php#constant.curlopt-suppress-connect-headers
