### PR TITLE
Implement whitelist for sanitizer: `allowed_html_elements_with_attributes()`

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -641,6 +641,35 @@ class SimplePie
     public $rename_attributes = [];
 
     /**
+     * @var array<string,string[]> Stores allowed tags and attributes.
+     * Preferred over $strip_htmltags and $strip_attributes.
+     * Note that `<html>`, `<head>`, `<body>`, `<div>` are always allowed.
+     * @see SimplePie::allowed_html_elements_with_attributes()
+     * @access private
+     */
+    public $allowed_html_elements_with_attributes = [];
+
+    /**
+     * @var string[] Stores array of default allowed attributes.
+     * @see SimplePie::allowed_html_attributes()
+     * @access private
+     */
+    public $allowed_html_attributes = [];
+
+    /**
+     * @var bool Whether `data-*` attributes should be allowed or not
+     * @see SimplePie::allow_data_attr()
+     * @access private
+     */
+    public $allow_data_attr = true;
+    /**
+     * @var bool Whether `aria-*` attributes should be allowed or not
+     * @see SimplePie::allow_aria_attr()
+     * @access private
+     */
+    public $allow_aria_attr = true;
+
+    /**
      * @var bool Should we throw exceptions, or use the old-style error property?
      * @access private
      */
@@ -1485,6 +1514,42 @@ class SimplePie
         if ($encode !== null) {
             $this->sanitize->encode_instead_of_strip($encode);
         }
+    }
+
+    /**
+     * @param array<string,string[]> $tags Set array of allowed tags and attributes.
+     * Note that `<html>`, `<head>`, `<body>`, `<div>` are always allowed.
+     * Preferred over {@see SimplePie::allowed_html_attributes()} and {@see SimplePie::strip_attributes()}.
+     *
+     * Example: `['a' => ['href', 'title'], 'img' => ['src', 'alt']]`
+     */
+    public function allowed_html_elements_with_attributes(array $tags = []): void
+    {
+        $this->sanitize->allowed_html_elements_with_attributes($tags);
+    }
+
+    /**
+     * @param string[] $attrs Set default array of allowed attributes.
+     */
+    public function allowed_html_attributes(array $attrs = []): void
+    {
+        $this->sanitize->allowed_html_attributes($attrs);
+    }
+
+    /**
+     * @param bool $allow Whether `data-*` attributes should be allowed or not
+     */
+    public function allow_data_attr(bool $allow = true): void
+    {
+        $this->sanitize->allow_data_attr($allow);
+    }
+
+    /**
+     * @param bool $allow Whether `aria-*` attributes should be allowed or not
+     */
+    public function allow_aria_attr(bool $allow = true): void
+    {
+        $this->sanitize->allow_aria_attr($allow);
     }
 
     /**

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -28,6 +28,36 @@ HTML
             ),
             'XML input (with corresponding xml entities) should be cleaned and converted to utf-8 escaped HTML'
         );
+
+        $sanitize_whitelist = new SimplePie_Sanitize();
+        $sanitize_whitelist->allowed_html_attributes([
+            'title', 'role',
+        ]);
+        $sanitize_whitelist->allowed_html_elements_with_attributes([
+            'details' => ['open'],
+            'summary' => [],
+            'p' => [],
+        ]);
+        self::assertSame(
+            <<<HTML
+<details open title="Click to expand"><summary data-xyz="123" aria-hidden="false">Details</summary><p>...</p></details>
+HTML
+            ,
+            trim(preg_replace('/\R\s+/', '', $sanitize_whitelist->sanitize(
+                <<<HTML
+<details open title="Click to expand" onmouseover="alert(1)" xyz="1">
+    <summary data-xyz="123" aria-hidden="false">Details</summary>
+    <x-custom>
+        <p>...</p>
+    </x-custom>
+</details>
+<iframe src="https://example.net"></iframe>
+HTML
+                ,
+                SIMPLEPIE_CONSTRUCT_HTML
+            )) ?? ''),
+            'Non-whitelisted tags and attributes should be cleaned'
+        );
     }
 
     /**


### PR DESCRIPTION
Downstream PR: https://github.com/FreshRSS/FreshRSS/pull/7924 https://github.com/FreshRSS/simplepie/pull/53

Fixes https://github.com/simplepie/simplepie/issues/872, no default whitelist yet though - see the [PR from FreshRSS](https://github.com/FreshRSS/FreshRSS/pull/7924/files#diff-6ebff7743ede829cf5a7f0e4566b42023a2d4779cc8d7e96fefec116f2292174R341-R492) for an example whitelist