### PR TITLE
Use CURLOPT_ACCEPT_ENCODING instead of CURLOPT_ENCODING when avialable

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -121,7 +121,9 @@ class File implements Response
                     }
                     unset($curl_options[CURLOPT_HTTPHEADER]);
                 }
-                if (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
+                if (version_compare(\SimplePie\Misc::get_curl_version(), '7.21.6', '>=')) {
+                    curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
+                } elseif (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
                     curl_setopt($fp, CURLOPT_ENCODING, '');
                 }
                 curl_setopt($fp, CURLOPT_URL, $url);
@@ -139,7 +141,11 @@ class File implements Response
 
                 $responseHeaders = curl_exec($fp);
                 if (curl_errno($fp) === CURLE_WRITE_ERROR || curl_errno($fp) === CURLE_BAD_CONTENT_ENCODING) {
-                    curl_setopt($fp, CURLOPT_ENCODING, 'none');
+                    if (version_compare(\SimplePie\Misc::get_curl_version(), '7.21.6', '>=')) {
+                        curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, 'none');
+                    } else {
+                        curl_setopt($fp, CURLOPT_ENCODING, 'none');
+                    }
                     $responseHeaders = curl_exec($fp);
                 }
                 $this->status_code = curl_getinfo($fp, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This PR fixes #959.

It replaces the `CURLOPT_ENCODING` setting with `CURLOPT_ACCEPT_ENCODING`, but only when a cURL version newer than 7.21.6 is available.

See note on renaming in the [CURLOPT_ACCEPT_ENCODING man page](https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html).