### PR TITLE
Disable cURL encoding/compression handling when a bad Content-Encoding header is received

### DIFF
--- a/utils/PHPStan/extension.neon
+++ b/utils/PHPStan/extension.neon
@@ -1,3 +1,5 @@
+includes:
+    - version_dependent.php
 
 services:
     -

--- a/utils/PHPStan/version_dependent.php
+++ b/utils/PHPStan/version_dependent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SimplePieUtils\PHPStan;
+
+$typeAliases = [];
+
+if (PHP_VERSION_ID < 80000) {
+    $typeAliases['\CurlHandle'] = 'resource';
+}
+
+return [
+    'parameters' => [
+        'typeAliases' => $typeAliases,
+    ],
+];


### PR DESCRIPTION
This PR relates to #961 and FreshRSS/FreshRSS#8374.

When cURL has already returned a bad encoding error, this is a good indication that the server ignores `Accept-Encoding` headers, as the `CURLOPT_ENCODING` option is already set to `''` for the first request. This results in cURL sending an `Accept-Encoding` header with all supported encodings (compression algorithms, in practice) already in the first request. And the fact that this request results in a `CURLE_BAD_CONTENT_ENCODING` error indicates that the server ignored that header already. So trying again, but this time with `CURLOPT_ENCODING = 'none'` seems unlikely to result in success?

Instead, my proposal here is to set `CURLOPT_ENCODING` to `null`, which tells cURL to disable compression handling altogether and to ignore the bad `Content-Encoding` header send by the server.

I was able to confirm that this works in tests with FreshRSS against a test setup where the server sends a valid `index.xml` with an RSS feed, but with the `Content-Encoding` header set to `aws-chunked`. With `CURLOPT_ENCODING = 'none'`, the fetch fails and the body is empty, leading to FreshRSS not being able to add the feed. But with `CURLOPT_ENCODING = null` set, the fetch succeeds and the feed can be added. 