### PR TITLE
File: Drop curl 7.10.5 conditional

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -123,7 +123,7 @@ class File implements Response
                 }
                 if (version_compare(\SimplePie\Misc::get_curl_version(), '7.21.6', '>=')) {
                     curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
-                } elseif (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
+                } else {
                     curl_setopt($fp, CURLOPT_ENCODING, '');
                 }
                 curl_setopt($fp, CURLOPT_URL, $url);


### PR DESCRIPTION
PHP 7.2 requires at least libcurl 7.10.5 so the check is always true on all supported PHP versions:
https://github.com/php/php-src/blob/php-7.2.0/ext/curl/config.m4#L34

PHP 7.3 bumps the minimum to 7.15.5 but, even when we drop support for PHP < 7.4, that won’t help us with cleanups:
https://github.com/php/php-src/blob/php-7.3.0/ext/curl/config.m4#L32

PHP 8.0 further bumps this to 7.29.0, which would allow us to remove the remaining conditionals, but we still support 7.2.0 for now and will support 7.4.0 for a while.
https://github.com/php/php-src/blob/php-8.0.0/ext/curl/config.m4#L7
