### PR TITLE
Parser: Use typed XML\Element for Microformats

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -40,8 +40,13 @@ class Parser implements RegistryAware
     public $xml_base_explicit = [false];
     /** @var string[] */
     public $xml_lang = [''];
-    /** @var array<string, mixed> */
+    /**
+     * @var array<string, mixed>
+     * @deprecated since 1.10.0, use `Parser::getRootElement()`.
+     */
     public $data = [];
+    /** @var array<string, mixed> */
+    private XML\Element $root;
     /** @var array<array<string, mixed>> */
     public $datas = [[]];
     /** @var int */
@@ -65,7 +70,7 @@ class Parser implements RegistryAware
     public function parse(string &$data, string $encoding, string $url = '')
     {
         if (self::contains_microformats($data) && ($mf = self::parse_microformats($data, $url)) !== null) {
-            $this->data = $mf;
+            $this->set_root($mf);
             return true;
         }
 
@@ -262,6 +267,13 @@ class Parser implements RegistryAware
         return $this->data;
     }
 
+    private function set_root(XML\Element $root): void
+    {
+        $this->root = $root;
+        // Unfortunately, the data property is public so we need this hack.
+        $this->data = $root->get_legacy_representation();
+    }
+
     /**
      * @param XMLParser|resource|null $parser
      * @param array<string, string> $attributes
@@ -444,9 +456,9 @@ class Parser implements RegistryAware
     /**
      * Requires `mf2/mf2` library.
      *
-     * @return ?array<mixed> RSS document constructed from microformats, or `null` if the `mf2` library is not installed.
+     * @return ?XML\Root RSS document constructed from microformats, or `null` if the `mf2` library is not installed.
      */
-    private static function parse_microformats(string &$data, string $url): ?array
+    private static function parse_microformats(string &$data, string $url): ?XML\Root
     {
         if (!function_exists('Mf2\parse') || !function_exists('Mf2\fetch')) {
             return null;
@@ -645,8 +657,8 @@ class Parser implements RegistryAware
             }
         }
         // Mimic RSS data format when storing microformats.
-        $link = [['data' => $url]];
-        $image = '';
+        $link = new XML\Element()->withText($url); // TODO: not escaped
+        $image = ''; // TODO: invalid?
         if (!is_string($feed_author) &&
                 isset($feed_author['properties']['photo'][0])) {
             $image = [['child' => ['' => ['url' =>
@@ -663,12 +675,12 @@ class Parser implements RegistryAware
                 $feed_title = [['data' => htmlspecialchars($matches[1])]];
             }
         }
-        $channel = ['channel' => [['child' => ['' =>
-            ['link' => $link, 'image' => $image, 'title' => $feed_title,
-                  'item' => $items]]]]];
-        $rss = [['attribs' => ['' => ['version' => '2.0']],
-                           'child' => ['' => $channel]]];
-        return ['child' => ['' => ['rss' => $rss]]];
+        $channel = new XML\Element()->withChild('link', $link)->withChild('image', $image)->withChild('title', $feed_title)->withChild(
+            'item',
+            $items
+        );
+        $rss = new XML\Element()->withAttr('version', '2.0')->withChild('channel', $channel);
+        return new XML\Root('rss', $rss);
     }
 
     private static function set_doctype(string $data): string

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -64,19 +64,8 @@ class Parser implements RegistryAware
      */
     public function parse(string &$data, string $encoding, string $url = '')
     {
-        if (class_exists('DOMXpath') && function_exists('Mf2\parse')) {
-            $doc = new \DOMDocument();
-            @$doc->loadHTML($data);
-            $xpath = new \DOMXpath($doc);
-            // Check for both h-feed and h-entry, as both a feed with no entries
-            // and a list of entries without an h-feed wrapper are both valid.
-            $query = '//*[contains(concat(" ", @class, " "), " h-feed ") or '.
-                'contains(concat(" ", @class, " "), " h-entry ")]';
-            /** @var \DOMNodeList<\DOMElement> $result */
-            $result = $xpath->query($query);
-            if ($result->length !== 0) {
-                return $this->parse_microformats($data, $url);
-            }
+        if (self::contains_microformats($data) && function_exists('Mf2\parse')) {
+            return $this->parse_microformats($data, $url);
         }
 
         // Use UTF-8 if we get passed US-ASCII, as every US-ASCII character is a UTF-8 character
@@ -425,6 +414,30 @@ class Parser implements RegistryAware
             }
         }
         return $data['value'] ?? '';
+    }
+
+    /**
+     * Checks if the document contains `h-feed` or `h-entry` elements.
+     *
+     * Requires `dom` extension.
+     */
+    private static function contains_microformats(string $data): bool
+    {
+        if (!class_exists('DOMXpath')) {
+            return false;
+        }
+
+        $doc = new \DOMDocument();
+        @$doc->loadHTML($data);
+        $xpath = new \DOMXpath($doc);
+        // Check for both h-feed and h-entry, as both a feed with no entries
+        // and a list of entries without an h-feed wrapper are both valid.
+        $query = '//*[contains(concat(" ", @class, " "), " h-feed ") or '.
+            'contains(concat(" ", @class, " "), " h-entry ")]';
+        /** @var \DOMNodeList<\DOMElement> $result */
+        $result = $xpath->query($query);
+
+        return $result->length !== 0;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -64,8 +64,9 @@ class Parser implements RegistryAware
      */
     public function parse(string &$data, string $encoding, string $url = '')
     {
-        if (self::contains_microformats($data) && function_exists('Mf2\parse')) {
-            return $this->parse_microformats($data, $url);
+        if (self::contains_microformats($data) && ($mf = self::parse_microformats($data, $url)) !== null) {
+            $this->data = $mf;
+            return true;
         }
 
         // Use UTF-8 if we get passed US-ASCII, as every US-ASCII character is a UTF-8 character
@@ -441,13 +442,16 @@ class Parser implements RegistryAware
     }
 
     /**
-     * @return true
+     * Requires `mf2/mf2` library.
+     *
+     * @return ?array<mixed> RSS document constructed from microformats, or `null` if the `mf2` library is not installed.
      */
-    private function parse_microformats(string &$data, string $url): bool
+    private static function parse_microformats(string &$data, string $url): ?array
     {
-        // For PHPStan, we already check that in call site.
-        \assert(function_exists('Mf2\parse'));
-        \assert(function_exists('Mf2\fetch'));
+        if (!function_exists('Mf2\parse') || !function_exists('Mf2\fetch')) {
+            return null;
+        }
+
         $feed_title = '';
         $feed_author = null;
         $author_cache = [];
@@ -664,8 +668,7 @@ class Parser implements RegistryAware
                   'item' => $items]]]]];
         $rss = [['attribs' => ['' => ['version' => '2.0']],
                            'child' => ['' => $channel]]];
-        $this->data = ['child' => ['' => ['rss' => $rss]]];
-        return true;
+        return ['child' => ['' => ['rss' => $rss]]];
     }
 
     private static function set_doctype(string $data): string

--- a/src/XML/Element.php
+++ b/src/XML/Element.php
@@ -1,0 +1,65 @@
+<?php
+
+// SPDX-FileCopyrightText: 2004-2023 Ryan Parman, Sam Sneddon, Ryan McCue
+// SPDX-License-Identifier: BSD-3-Clause
+
+declare(strict_types=1);
+
+namespace SimplePie\XML;
+
+/**
+ * Models XML element data in a form ready for lookups.
+ * @internal
+ */
+final class Element
+{
+    /** @var array<string, array<string, string>> attributes grouped by namespace */
+    private array $attrs = ['' => []];
+
+    /** @var array<string, array<string, Element>> children grouped by namespace */
+    private array $children = [];
+
+    private ?string $xml_base = null;
+
+    private bool $xml_base_explicit = false;
+
+    private ?string $xml_lang = null;
+
+    private string $text = '';
+
+    /**
+     * @return array<mixed>
+     */
+    public function get_legacy_representation(): array
+    {
+        return [
+            'child' => array_map($this->children, fn ($children) => array_map($children, fn ($child) => $child->get_legacy_representation())),
+            'attrs' => $this->attrs,
+            'data' => htmlspecialchars($this->text),
+        ];
+    }
+
+    // TODO: docs
+    public function withText(string $text): static {
+        $element = (clone) $this;
+        $element->text = $text;
+
+        return $element;
+    }
+
+    public function withAttr(string $name, string $value, string $ns = ''): static {
+        $element = (clone) $this;
+        $element->attrs[$ns][$name][] = $value;
+
+        return $element;
+    }
+
+    public function withChild(string $name, Element $child, string $ns = ''): static {
+        $element = (clone) $this;
+        $element->children[$ns][$name][] = $child;
+
+        return $element;
+    }
+
+    // TODO: getters
+}

--- a/src/XML/Root.php
+++ b/src/XML/Root.php
@@ -1,0 +1,44 @@
+<?php
+
+// SPDX-FileCopyrightText: 2004-2023 Ryan Parman, Sam Sneddon, Ryan McCue
+// SPDX-License-Identifier: BSD-3-Clause
+
+declare(strict_types=1);
+
+namespace SimplePie\XML;
+
+/**
+ * Models XML root.
+ * @internal
+ */
+final class Root
+{
+    private string $name;
+    private string $ns;
+    private Element $element;
+
+    // private ?string $xml_base = null;
+
+    // private bool $xml_base_explicit = false;
+
+    // private ?string $xml_lang = null;
+
+    // private string $text = '';
+
+    public function __construct(string $name, Element $element, string $ns = '')
+    {
+        $this->name = $name;
+        $this->ns = $ns;
+        $this->element = $element;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function get_legacy_representation(): array
+    {
+        return [
+            'child' => [$this->ns => [$this->name => $this->element->get_legacy_representation(),],],
+        ];
+    }
+}


### PR DESCRIPTION
The recursively nested `data` arrays are confusing to reason about both for me and for static analyzers.
Let’s introduce classes with well typed fields.

For starter’s we will just apply it to microformats.

Since data is often public, we will unfortunately need to keep the legacy representation for the next while.

Unlike the arrays, we will always have all commonly used fields initialized to eliminate “Undefined array key” warnings like #970.