### PR TITLE
Parser: Support HTTP Early Hints response

### DIFF
--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -63,6 +63,8 @@ class Parser
 
     private const STATE_BODY = 'body';
 
+    private const STATE_BODY_OR_STATUS = 'body_or_status';
+
     private const STATE_NAME = 'name';
 
     private const STATE_VALUE = 'value';
@@ -148,7 +150,7 @@ class Parser
             $this->$state();
         }
         $this->data = '';
-        if ($this->state === self::STATE_EMIT || $this->state === self::STATE_BODY) {
+        if (($this->status_code !== 0) && ($this->state === self::STATE_EMIT || $this->state === self::STATE_BODY_OR_STATUS)) {
             return true;
         }
 
@@ -264,6 +266,26 @@ class Parser
         }
     }
 
+   /**
+     * Skip over HTTP Status 103 (Early Hint), and retrieve
+     * the next status code.  103 may appear multiple times.
+     */
+    protected function body_or_status()
+    {
+        if ($this->status_code === 103)
+        {
+	    $this->http_version = 0.0;
+            $this->status_code = 0;
+            $this->reason = '';
+            $this->headers = [];
+            $this->state = self::STATE_HTTP_VERSION;
+        }
+        else
+        {
+            $this->state = self::STATE_BODY;
+        }
+    }
+
     /**
      * Deal with a new line, shifting data around as needed
      * @return void
@@ -284,10 +306,10 @@ class Parser
         $this->value = '';
         if (substr($this->data[$this->position], 0, 2) === "\x0D\x0A") {
             $this->position += 2;
-            $this->state = self::STATE_BODY;
+            $this->state = self::STATE_BODY_OR_STATUS;
         } elseif ($this->data[$this->position] === "\x0A") {
             $this->position++;
-            $this->state = self::STATE_BODY;
+            $this->state = self::STATE_BODY_OR_STATUS;
         } else {
             $this->state = self::STATE_NAME;
         }

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -43,6 +43,19 @@ class ParserTest extends TestCase
         ];
     }
 
+    public static function simpleDataProvider(): array
+    {
+        return [
+            [
+                "abra\ncadabra\nall we got\n",
+                "abra\ncadabra\nall we got\n"
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider chunkedDataProvider
+
     /**
      * @dataProvider chunkedDataProvider
      */
@@ -164,5 +177,37 @@ class ParserTest extends TestCase
             'content-type' => ['text/plain'],
             'content-security-policy' => ["default-src 'self' http://example.com", 'script-src http://example.com/'],
         ], $parser->headers);
+    }
+
+    /**
+     * @dataProvider simpleDataProvider
+     */
+    public function testEarlyHintHeaders(string $data, string $expected): void
+    {
+        $data = "HTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n" . $data;
+        $data = Parser::prepareHeaders($data);
+        $parser = new Parser($data, true);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame($expected, $parser->body);
+    }
+
+    /**
+     * @dataProvider simpleDataProvider
+     */
+    public function testMultipleEarlyHintHeaders(string $data, string $expected): void
+    {
+        $data = "HTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n" . $data;
+        $data = Parser::prepareHeaders($data);
+        $parser = new Parser($data, true);
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame($expected, $parser->body);
     }
 }


### PR DESCRIPTION
Webserver may provide HTTP 103 Early Hints before they supply HTTP success or failure codes.  Curl includes Early Hints in the response.

Skip over these headers to the actual success or failure code, and supply that to the consumer.