### PR TITLE
Parser: fix inconsistency between different PHP version when parsing …

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -139,6 +139,9 @@ class Parser implements RegistryAware
             $xml = xml_parser_create_ns($this->encoding, $this->separator);
             xml_parser_set_option($xml, XML_OPTION_SKIP_WHITE, 1);
             xml_parser_set_option($xml, XML_OPTION_CASE_FOLDING, 0);
+            if (defined('XML_OPTION_PARSE_HUGE')) {
+                xml_parser_set_option($xml, XML_OPTION_PARSE_HUGE, 1);
+            }
             xml_set_character_data_handler($xml, [$this, 'cdata']);
             xml_set_element_handler($xml, [$this, 'tag_open'], [$this, 'tag_close']);
 


### PR DESCRIPTION
PHP 8.4.0 introduced a new option[1], which makes it behave differently.

>  XML_OPTION_PARSE_HUGE (int)
>     Available as of PHP 8.4.0. When libxml2 < 2.7.0 is used (e.g. on PHP 7.x), this option is enabled by default and cannot be disabled.

The default value of this new option is `0`[2]. And this option is only effective when `libxml2` is used. `libexpat` totally ignores it[3].

This patch sets this option to `1`, the old default value, when this option is defined. So everything is consistent.

Yes, this brings more risks of potential DoS attack, but it should be defended somewhere else. Because the whole XML string is already downloaded into the memory when parsing, bars could be placed during downloading, no matter which PHP version and XML lib is used.

Downstream issue:
FreshRSS/FreshRSS#8516
FreshRSS/FreshRSS#8710
@Alkarex 

1. https://www.php.net/manual/en/xml.constants.php#constant.xml-option-parse-huge
2. https://github.com/php/php-src/blob/90744ec52a50e0eacab47d5a51d82c1b26607b76/ext/xml/xml.c#L1116
3. https://wiki.php.net/rfc/xml_option_parse_huge