### PR TITLE
Fix wrong player_parent logic leading to invalid type

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -1224,13 +1224,14 @@ class Item implements RegistryAware
             }
 
             // PLAYER
-            if ($player_parent = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
-                if (isset($player_parent[0]['attribs']['']['url'])) {
-                    $player_parent = $this->sanitize($player_parent[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_parent[0]));
+            $player_parent = null;
+            if ($player_tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
+                if (isset($player_tags[0]['attribs']['']['url'])) {
+                    $player_parent = $this->sanitize($player_tags[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_tags[0]));
                 }
-            } elseif ($player_parent = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
-                if (isset($player_parent[0]['attribs']['']['url'])) {
-                    $player_parent = $this->sanitize($player_parent[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_parent[0]));
+            } elseif ($player_tags = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
+                if (isset($player_tags[0]['attribs']['']['url'])) {
+                    $player_parent = $this->sanitize($player_tags[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_tags[0]));
                 }
             }
 

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -296,4 +296,85 @@ XML
             11223344,
         ];
     }
+
+    /**
+     * @dataProvider getEnclosurePlayerProvider
+     */
+    public function test_enclosure_player(string $data, ?string $expectedPlayer): void
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data($data);
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        self::assertInstanceOf(Item::class, $item);
+
+        $enclosure = $item->get_enclosure(0);
+        self::assertInstanceOf(Enclosure::class, $enclosure);
+        self::assertSame($expectedPlayer, $enclosure->get_player());
+    }
+
+    /**
+     * @return iterable<array{string,?string}>
+     */
+    public static function getEnclosurePlayerProvider(): iterable
+    {
+        yield 'Test media:player with url attribute' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test</title>
+                    <link>http://example.net/</link>
+                    <item>
+                        <title>Test item</title>
+                        <link>http://example.net/1</link>
+                        <enclosure url="http://example.net/a.mp4" type="video/mp4" />
+                        <media:player url="http://example.net/player" />
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            'http://example.net/player',
+        ];
+
+        yield 'Test media:player without url attribute' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test</title>
+                    <link>http://example.net/</link>
+                    <item>
+                        <title>Test item</title>
+                        <link>http://example.net/2</link>
+                        <enclosure url="http://example.net/a.mp4" type="video/mp4" />
+                        <media:player />
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            null,
+        ];
+
+        yield 'Test channel-level media:player without url attribute' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test</title>
+                    <link>http://example.net/</link>
+                    <media:player />
+                    <item>
+                        <title>Test item</title>
+                        <link>http://example.net/3</link>
+                        <enclosure url="http://example.net/a.mp4" type="video/mp4" />
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            null,
+        ];
+    }
 }


### PR DESCRIPTION
```
PHP Fatal error: Uncaught TypeError:
SimplePie\Enclosure::__construct(): Argument #20 ($player) must be of type ?string, array given
in /opt/freshrss/lib/simplepie/simplepie/src/Enclosure.php:199
```

This happens when there is no`url` parameter.

Example of feed:
* https://feeds.feedburner.com/crunchyroll/rss/anime?lang=deDE

Downstream issue:
* https://github.com/FreshRSS/FreshRSS/issues/8892
