### PR TITLE
PHP 8.5: Fix null warning in IRI

### DIFF
--- a/src/IRI.php
+++ b/src/IRI.php
@@ -1023,7 +1023,7 @@ class IRI
         }
         if ($this->ipath !== '') {
             $iri .= $this->ipath;
-        } elseif (!empty($this->normalization[$this->scheme]['ipath']) && $iauthority !== null && $iauthority !== '') {
+        } elseif ($this->scheme !== null && !empty($this->normalization[$this->scheme]['ipath']) && $iauthority !== null && $iauthority !== '') {
             $iri .= $this->normalization[$this->scheme]['ipath'];
         }
         if ($this->iquery !== null) {


### PR DESCRIPTION
In PHP 8.5, `empty($my_array[null])` generates a warning:
> PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead
