### PR TITLE
Fix typo "contrbutor" in get_contributor() docblocks

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -461,7 +461,7 @@ class Item implements RegistryAware
      * Get a contributor for the item
      *
      * @since 1.1
-     * @param int $key The contrbutor that you want to return.  Remember that arrays begin with 0, not 1
+     * @param int $key The contributor that you want to return.  Remember that arrays begin with 0, not 1
      * @return \SimplePie\Author|null
      */
     public function get_contributor(int $key = 0)

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2700,7 +2700,7 @@ class SimplePie
      * Get a contributor for the feed
      *
      * @since 1.1
-     * @param int $key The contrbutor that you want to return. Remember that arrays begin with 0, not 1
+     * @param int $key The contributor that you want to return. Remember that arrays begin with 0, not 1
      * @return Author|null
      */
     public function get_contributor(int $key = 0)


### PR DESCRIPTION
## Description

Fixes a typo — `contrbutor` → `contributor` — in the `@param` description of the `get_contributor()` method in two files:

- `src/Item.php`
- `src/SimplePie.php`

Documentation-only change; no functional impact.

Fixes #980

## Context

Originally spotted downstream in WordPress core (which bundles SimplePie). Per a WordPress core committer's suggestion, the fix is being made upstream here: https://core.trac.wordpress.org/ticket/65499