### PR TITLE
Fix CI/CD for Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: composer cs
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: composer cs
 
   test:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -87,6 +87,13 @@ HTML
 
         $base = 'http://example.com/';
 
-        self::assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
+        $actual = $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base);
+
+        // Normalize whitespace between tags for PHP 7.2 compatibility
+        $normalize = static function (string $html): string {
+            return preg_replace('/>\s+</', '><', $html) ?: '';
+        };
+
+        self::assertSame($normalize($expected), $normalize($actual));
     }
 }

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -89,11 +89,10 @@ HTML
 
         $actual = $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base);
 
-        // Normalize whitespace between tags for PHP 7.2 compatibility
-        $normalize = static function (string $html): string {
-            return preg_replace('/>\s+</', '><', $html) ?: '';
-        };
+        // Remove newlines for PHP 7.2 compatibility
+        $expected = str_replace(["\n", "\r"], '', $expected);
+        $actual = str_replace(["\n", "\r"], '', $actual);
 
-        self::assertSame($normalize($expected), $normalize($actual));
+        self::assertSame($expected, $actual);
     }
 }

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -103,11 +103,10 @@ HTML
 
         $actual = $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base);
 
-        // Normalize whitespace between tags for PHP 7.2 compatibility
-        $normalize = static function (string $html): string {
-            return preg_replace('/>\s+</', '><', $html) ?: '';
-        };
+        // Remove newlines for PHP 7.2 compatibility
+        $expected = str_replace(["\n", "\r"], '', $expected);
+        $actual = str_replace(["\n", "\r"], '', $actual);
 
-        self::assertSame($normalize($expected), $normalize($actual));
+        self::assertSame($expected, $actual);
     }
 }

--- a/tests/Unit/SanitizeTest.php
+++ b/tests/Unit/SanitizeTest.php
@@ -101,6 +101,13 @@ HTML
 
         $base = 'http://example.com/';
 
-        self::assertSame($expected, $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base));
+        $actual = $sanitize->sanitize($given, SIMPLEPIE_CONSTRUCT_HTML, $base);
+
+        // Normalize whitespace between tags for PHP 7.2 compatibility
+        $normalize = static function (string $html): string {
+            return preg_replace('/>\s+</', '><', $html) ?: '';
+        };
+
+        self::assertSame($normalize($expected), $normalize($actual));
     }
 }


### PR DESCRIPTION
testSanitizeURLResolution test fails for PHP 7.2 under Ubuntu 26.04:

```
There were 4 failures:

1) SanitizeTest::testSanitizeURLResolution with data set "audio with alternative source src absolute paths, resolved, fixed" ('<audio><source src="a/b.wav" ...audio>', '<audio preload="none"><source...audio>')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<audio preload="none"><source src="http://example.com/a/b.wav"><source src="http://example.com/c/d.mp3"></audio>'
+'<audio preload="none"><source src="http://example.com/a/b.wav">
+<source src="http://example.com/c/d.mp3"></audio>'

/home/runner/work/simplepie/simplepie/tests/SanitizeTest.php:90
phpvfscomposer:///home/runner/work/simplepie/simplepie/vendor/phpunit/phpunit/phpunit:97

2) SanitizeTest::testSanitizeURLResolution with data set "video with alternative source src, resolved, fixed" ('<video><source src="a/b.mpeg"...video>', '<video preload="none"><source...video>')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<video preload="none"><source src="http://example.com/a/b.mpeg"><source src="http://example.com/d.mov"></video>'
+'<video preload="none"><source src="http://example.com/a/b.mpeg">
+<source src="http://example.com/d.mov"></video>'

/home/runner/work/simplepie/simplepie/tests/SanitizeTest.php:90
phpvfscomposer:///home/runner/work/simplepie/simplepie/vendor/phpunit/phpunit/phpunit:97

3) SimplePie\Tests\Unit\SanitizeTest::testSanitizeURLResolution with data set "audio with alternative source src absolute paths, resolved, fixed" ('<audio><source src="a/b.wav" ...audio>', '<audio preload="none"><source...audio>')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<audio preload="none"><source src="http://example.com/a/b.wav"><source src="http://example.com/c/d.mp3"></audio>'
+'<audio preload="none"><source src="http://example.com/a/b.wav">
+<source src="http://example.com/c/d.mp3"></audio>'

/home/runner/work/simplepie/simplepie/tests/Unit/SanitizeTest.php:104
phpvfscomposer:///home/runner/work/simplepie/simplepie/vendor/phpunit/phpunit/phpunit:97

4) SimplePie\Tests\Unit\SanitizeTest::testSanitizeURLResolution with data set "video with alternative source src, resolved, fixed" ('<video><source src="a/b.mpeg"...video>', '<video preload="none"><source...video>')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<video preload="none"><source src="http://example.com/a/b.mpeg"><source src="http://example.com/d.mov"></video>'
+'<video preload="none"><source src="http://example.com/a/b.mpeg">
+<source src="http://example.com/d.mov"></video>'

/home/runner/work/simplepie/simplepie/tests/Unit/SanitizeTest.php:104
phpvfscomposer:///home/runner/work/simplepie/simplepie/vendor/phpunit/phpunit/phpunit:97

FAILURES!
Tests: 2097, Assertions: 3308, Failures: 4.
```

Need to apply some whitespace normalisation.